### PR TITLE
flatten structure of 'pytools' module, eliminating 'common' sub-package

### DIFF
--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -15,7 +15,7 @@ from sklearn.base import (
     clone,
 )
 
-from pytools.common.fit import FittableMixin
+from pytools.fit import FittableMixin
 
 log = logging.getLogger(__name__)
 

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -28,7 +28,7 @@ from sklearn.base import (
     TransformerMixin,
 )
 
-from pytools.common import inheritdoc
+from pytools.api import inheritdoc
 from sklearndf import (
     BaseEstimatorDF,
     ClassifierDF,


### PR DESCRIPTION
The structure of `pytools` modules and submodules changes as follows:
- `pytools.common.expression` → `pytools.expression`
- `pytools.common.fit` → `pytools.fit`
- `pytools.common.parallelization` → `pytools.parallelization`
- `pytools.common` → `pytools.api`