### PR TITLE
append '_' to names of properties available only after fitting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,14 +125,14 @@ fit_transform on our preprocessing pipeline.
 Tracing features from post-transform to original 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The sklearndf pipeline has a features_original attribute which returns a series mapping
+The sklearndf pipeline has a `features_original_` attribute which returns a series mapping
 the output columns (the series' index) to the input columns (the series' values).
 We can therefore easily select all output features generated from a given input feature,
 such as in this case for embarked.
 
 .. code-block:: Python
 
-    embarked_type_derivatives = preprocessing_df.features_original == "embarked"
+    embarked_type_derivatives = preprocessing_df.features_original_ == "embarked"
     transformed_df.loc[:, embarked_type_derivatives].head()
 
 

--- a/sphinx/source/tutorial/sklearndf_tutorial.ipynb
+++ b/sphinx/source/tutorial/sklearndf_tutorial.ipynb
@@ -639,7 +639,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "The `~sklearndf.transformation.ColumnTransformerDF.features_original` attribute returns a series mapping the output columns (the series' index) to the input columns (the series' values):"
+    "The `~sklearndf.transformation.ColumnTransformerDF.features_original_` attribute returns a series mapping the output columns (the series' index) to the input columns (the series' values):"
    ]
   },
   {
@@ -749,7 +749,7 @@
     }
    ],
    "source": [
-    "preprocessing_df.features_original.to_frame().head(10)"
+    "preprocessing_df.features_original_.to_frame().head(10)"
    ]
   },
   {
@@ -886,7 +886,7 @@
     }
    ],
    "source": [
-    "garage_type_derivatives = preprocessing_df.features_original == \"GarageType\"\n",
+    "garage_type_derivatives = preprocessing_df.features_original_ == \"GarageType\"\n",
     "\n",
     "transformed_df.loc[:, garage_type_derivatives].head()"
    ]
@@ -1183,7 +1183,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "Property `is_fitted` tells if the regressor is fitted, and -- for fitted estimators -- property `features_in` returns the names of the ingoing features as a pandas index."
+    "Property `is_fitted` tells if the regressor is fitted, and -- for fitted estimators -- property `features_in_` returns the names of the ingoing features as a pandas index."
    ]
   },
   {
@@ -1246,7 +1246,7 @@
     }
    ],
    "source": [
-    "random_forest_regressor_df.features_in"
+    "random_forest_regressor_df.features_in_"
    ]
   },
   {
@@ -1987,7 +1987,7 @@
     }
    ],
    "source": [
-    "boruta_pipeline.features_out.to_list()"
+    "boruta_pipeline.features_out_.to_list()"
    ]
   },
   {
@@ -1996,7 +1996,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "`sklearndf` allows us to trace outgoing features back to the original features from which they were derived, using the `~sklearndf.TransformerDF.features_original` property. This is useful here as we want to know which features to eliminate before putting them into the pipeline.\n",
+    "`sklearndf` allows us to trace outgoing features back to the original features from which they were derived, using the `~sklearndf.TransformerDF.features_original_` property. This is useful here as we want to know which features to eliminate before putting them into the pipeline.\n",
     "\n",
     "In our example, feature `BsmtQual_Ex` is a derivative of feature `BsmtQual`, obtained through one-hot encoding: "
    ]
@@ -2130,7 +2130,7 @@
     }
    ],
    "source": [
-    "boruta_pipeline.features_original.to_frame()"
+    "boruta_pipeline.features_original_.to_frame()"
    ]
   },
   {
@@ -2160,7 +2160,7 @@
     }
    ],
    "source": [
-    "boruta_pipeline.features_original.unique()"
+    "boruta_pipeline.features_original_.unique()"
    ]
   }
  ],

--- a/src/sklearndf/__init__.py
+++ b/src/sklearndf/__init__.py
@@ -17,11 +17,11 @@ This includes methods such as :meth:`~EstimatorDF.fit`,
 :meth:`~TransformerDF.transform`, :meth:`~LearnerDF.predict`, and so on.
 
 All estimators enhanced by `sklearndf` also implement an additional attribute
-:attr:`~EstimatorDF.features_in`, keeping track of the column names of the data
+:attr:`~EstimatorDF.features_in_`, keeping track of the column names of the data
 frame used to fit the estimator.
 
-`sklearndf` transformers also implement :attr:`~TransformerDF.features_out` and
-:attr:`~TransformerDF.features_original`, keeping track of the feature names of the
+`sklearndf` transformers also implement :attr:`~TransformerDF.features_out_` and
+:attr:`~TransformerDF.features_original_`, keeping track of the feature names of the
 transformed outputs as well as mapping output features back to the input features.
 This  enables tracing features back to the original inputs even across complex
 pipelines (see allso :class:`.PipelineDF`)

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -89,7 +89,7 @@ class EstimatorDF(FittableMixin[pd.DataFrame], metaclass=ABCMeta):
         pass
 
     @property
-    def features_in(self) -> pd.Index:
+    def features_in_(self) -> pd.Index:
         """
         The pandas column index with the names of the features used to fit this
         estimator.
@@ -100,7 +100,7 @@ class EstimatorDF(FittableMixin[pd.DataFrame], metaclass=ABCMeta):
         return self._get_features_in().rename(self.COL_FEATURE_IN)
 
     @property
-    def n_outputs(self) -> int:
+    def n_outputs_(self) -> int:
         """
         The number of outputs used to fit this estimator.
 
@@ -226,7 +226,7 @@ class TransformerDF(EstimatorDF, TransformerMixin, metaclass=ABCMeta):
         self._features_original = None
 
     @property
-    def features_original(self) -> pd.Series:
+    def features_original_(self) -> pd.Series:
         """
         A pandas series, mapping the output features resulting from the transformation
         to the original input features.
@@ -244,7 +244,7 @@ class TransformerDF(EstimatorDF, TransformerMixin, metaclass=ABCMeta):
         return self._features_original
 
     @property
-    def features_out(self) -> pd.Index:
+    def features_out_(self) -> pd.Index:
         """
         A pandas column index with the names of the features produced by this
         transformer
@@ -307,8 +307,8 @@ class TransformerDF(EstimatorDF, TransformerMixin, metaclass=ABCMeta):
 
     def _get_features_out(self) -> pd.Index:
         # return a pandas index with this transformer's output columns
-        # default behaviour: get index returned by features_original
-        return self.features_original.index
+        # default behaviour: get index returned by features_original_
+        return self.features_original_.index
 
 
 class RegressorDF(LearnerDF, RegressorMixin, metaclass=ABCMeta):
@@ -393,13 +393,12 @@ class ClassifierDF(LearnerDF, ClassifierMixin, metaclass=ABCMeta):
         """
 
     @property
-    def classes(self) -> Sequence[Any]:
+    @abstractmethod
+    def classes_(self) -> Sequence[Any]:
         """
         Get the classes predicted by this classifier.
         By default expects classes as a list-like stored in the `classes_` attribute.
 
         :return: the classes predicted by this classifier
         """
-        self._ensure_fitted()
-        # noinspection PyUnresolvedReferences
-        return self.classes_
+        pass

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -7,8 +7,8 @@ Otherwise the wrappers are designed to precisely mirror the API and behavior of 
 native estimators they wrap.
 
 The wrappers also implement the additional column attributes introduced by `sklearndf`,
-:meth:`~EstimatorDF.features_in`, :meth:`~TransformerDF.features_out`, and
-:meth:`~TransformerDF.features_original`.
+:meth:`~EstimatorDF.features_in_`, :meth:`~TransformerDF.features_out_`, and
+:meth:`~TransformerDF.features_original_`.
 """
 
 import inspect
@@ -233,7 +233,7 @@ class _EstimatorWrapperDF(
             raise TypeError("arg X must be a DataFrame")
         if self.is_fitted:
             _EstimatorWrapperDF._verify_df(
-                df_name="X argument", df=X, expected_columns=self.features_in
+                df_name="X argument", df=X, expected_columns=self.features_in_
             )
         if y is not None and not isinstance(y, (pd.Series, pd.DataFrame)):
             raise TypeError("arg y must be None, or a pandas Series or DataFrame")
@@ -346,7 +346,7 @@ class _TransformerWrapperDF(
         transformed = self._transform(X)
 
         return self._transformed_to_df(
-            transformed=transformed, index=X.index, columns=self.features_out
+            transformed=transformed, index=X.index, columns=self.features_out_
         )
 
     # noinspection PyPep8Naming
@@ -368,7 +368,7 @@ class _TransformerWrapperDF(
             ) from cause
 
         return self._transformed_to_df(
-            transformed=transformed, index=X.index, columns=self.features_out
+            transformed=transformed, index=X.index, columns=self.features_out_
         )
 
     # noinspection PyPep8Naming
@@ -381,7 +381,7 @@ class _TransformerWrapperDF(
         transformed = self._inverse_transform(X)
 
         return self._transformed_to_df(
-            transformed=transformed, index=X.index, columns=self.features_in
+            transformed=transformed, index=X.index, columns=self.features_in_
         )
 
     def _reset_fit(self) -> None:
@@ -551,6 +551,13 @@ class _ClassifierWrapperDF(
     """
     Wrapper around sklearn classifiers that preserves data frames.
     """
+
+    @property
+    def classes_(self) -> Sequence[Any]:
+        """[see superclass]"""
+        self._ensure_fitted()
+        # noinspection PyUnresolvedReferences
+        return self._delegate_estimator.classes_
 
     # noinspection PyPep8Naming
     def predict_proba(

--- a/src/sklearndf/classification/_classification.py
+++ b/src/sklearndf/classification/_classification.py
@@ -629,7 +629,7 @@ class _ClassifierChainWrapperDF(
         classes: Optional[Sequence[Any]] = None,
     ) -> Union[pd.Series, pd.DataFrame, List[pd.DataFrame]]:
         return super()._prediction_with_class_labels(
-            X=X, y=y, classes=range(self.n_outputs)
+            X=X, y=y, classes=range(self.n_outputs_)
         )
 
 

--- a/src/sklearndf/pipeline/_learner_pipeline.py
+++ b/src/sklearndf/pipeline/_learner_pipeline.py
@@ -125,12 +125,12 @@ class _EstimatorPipelineDF(
         """
         Pandas column index of all features resulting from the preprocessing step.
 
-        Same as :attr:`.features_in` if the preprocessing step is ``None``.
+        Same as :attr:`.features_in_` if the preprocessing step is ``None``.
         """
         if self.preprocessing is not None:
-            return self.preprocessing.features_out
+            return self.preprocessing.features_out_
         else:
-            return self.features_in.rename(TransformerDF.COL_FEATURE_OUT)
+            return self.features_in_.rename(TransformerDF.COL_FEATURE_OUT)
 
     @property
     def is_fitted(self) -> bool:
@@ -141,15 +141,15 @@ class _EstimatorPipelineDF(
 
     def _get_features_in(self) -> pd.Index:
         if self.preprocessing is not None:
-            return self.preprocessing.features_in
+            return self.preprocessing.features_in_
         else:
-            return self.final_estimator.features_in
+            return self.final_estimator.features_in_
 
     def _get_n_outputs(self) -> int:
         if self.preprocessing is not None:
-            return self.preprocessing.n_outputs
+            return self.preprocessing.n_outputs_
         else:
-            return self.final_estimator.n_outputs
+            return self.final_estimator.n_outputs_
 
     # noinspection PyPep8Naming
     def _pre_transform(self, X: pd.DataFrame) -> pd.DataFrame:
@@ -281,6 +281,11 @@ class ClassifierPipelineDF(
                 f"{type(classifier).__name__}"
             )
         self.classifier = classifier
+
+    @property
+    def classes_(self) -> Sequence[Any]:
+        """[see superclass]"""
+        return self.final_estimator.classes_
 
     @property
     def final_estimator(self) -> T_FinalClassifierDF:

--- a/src/sklearndf/pipeline/_pipeline.py
+++ b/src/sklearndf/pipeline/_pipeline.py
@@ -138,12 +138,12 @@ class _PipelineWrapperDF(
 
     def _get_features_original(self) -> pd.Series:
         col_mappings = [
-            df_transformer.features_original
+            df_transformer.features_original_
             for _, df_transformer in self._transformer_steps()
         ]
 
         if len(col_mappings) == 0:
-            _features_out: pd.Index = self.features_in
+            _features_out: pd.Index = self.features_in_
             _features_original: Union[np.ndarray, ExtensionArray] = _features_out.values
         else:
             _features_out: pd.Index = col_mappings[-1].index
@@ -175,9 +175,9 @@ class _PipelineWrapperDF(
     def _get_features_out(self) -> pd.Index:
         for _, transformer in reversed(self.steps):
             if isinstance(transformer, TransformerDF):
-                return transformer.features_out
+                return transformer.features_out_
 
-        return self.features_in
+        return self.features_in_
 
 
 # noinspection PyAbstractClass
@@ -217,7 +217,7 @@ class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCM
         return pd.concat(
             objs=(
                 _prepend_features_original(
-                    features_original=transformer.features_original, name_prefix=name
+                    features_original=transformer.features_original_, name_prefix=name
                 )
                 for name, transformer, _ in self.native_estimator._iter()
             )
@@ -233,7 +233,7 @@ class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCM
         # noinspection PyProtectedMember
         indices = [
             self._prepend_features_out(
-                features_out=transformer.features_out, name_prefix=name
+                features_out=transformer.features_out_, name_prefix=name
             )
             for name, transformer, _ in self.native_estimator._iter()
         ]

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -242,7 +242,7 @@ class _ColumnTransformerWrapperDF(
         return reduce(
             lambda x, y: x.append(y),
             (
-                df_transformer.features_original
+                df_transformer.features_original_
                 for df_transformer in self._inner_transformers()
             ),
         )
@@ -374,7 +374,7 @@ class _ImputerWrapperDF(_TransformerWrapperDF[T_Imputer], metaclass=ABCMeta):
             nan_mask = np.all(delegate_estimator._mask_fit_X, axis=0)
 
         # the imputed columns are all ingoing columns, except the ones that were dropped
-        imputed_columns = self.features_in.delete(np.argwhere(nan_mask))
+        imputed_columns = self.features_in_.delete(np.argwhere(nan_mask))
         features_original = pd.Series(
             index=imputed_columns, data=imputed_columns.values
         )
@@ -383,10 +383,10 @@ class _ImputerWrapperDF(_TransformerWrapperDF[T_Imputer], metaclass=ABCMeta):
         if delegate_estimator.add_indicator:
             missing_indicator = MissingIndicatorDF.from_fitted(
                 estimator=delegate_estimator.indicator_,
-                features_in=self.features_in,
-                n_outputs=self.n_outputs,
+                features_in=self.features_in_,
+                n_outputs=self.n_outputs_,
             )
-            return features_original.append(missing_indicator.features_original)
+            return features_original.append(missing_indicator.features_original_)
         else:
             return features_original
 
@@ -406,7 +406,7 @@ class _MissingIndicatorWrapperDF(
     _TransformerWrapperDF[MissingIndicator], metaclass=ABCMeta
 ):
     def _get_features_original(self) -> pd.Series:
-        features_original: np.ndarray = self.features_in[
+        features_original: np.ndarray = self.features_in_[
             self.native_estimator.features_
         ].values
         features_out = pd.Index([f"{name}__missing" for name in features_original])
@@ -544,7 +544,7 @@ class _PolynomialFeaturesWrapperDF(
     def _get_features_out(self) -> pd.Index:
         return pd.Index(
             data=self.native_estimator.get_feature_names(
-                input_features=self.features_in.astype(str)
+                input_features=self.features_in_.astype(str)
             )
         )
 
@@ -682,11 +682,11 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
         values the corresponding input column names.
         """
         return pd.Series(
-            index=pd.Index(self.native_estimator.get_feature_names(self.features_in)),
+            index=pd.Index(self.native_estimator.get_feature_names(self.features_in_)),
             data=[
                 column_original
                 for column_original, category in zip(
-                    self.features_in, self.native_estimator.categories_
+                    self.features_in_, self.native_estimator.categories_
                 )
                 for _ in category
             ],
@@ -738,7 +738,7 @@ class _KBinsDiscretizerWrapperDF(
                 *(
                     (feature_name, f"{feature_name}_bin_{bin_index}")
                     for feature_name, n_bins in zip(
-                        self.features_in, n_bins_per_feature
+                        self.features_in_, n_bins_per_feature
                     )
                     for bin_index in range(n_bins)
                 )
@@ -748,7 +748,7 @@ class _KBinsDiscretizerWrapperDF(
 
         elif self.native_estimator.encode == "ordinal":
             return pd.Series(
-                index=self.features_in.astype(str) + "_bin", data=self.features_in
+                index=self.features_in_.astype(str) + "_bin", data=self.features_in_
             )
         else:
             raise ValueError(

--- a/src/sklearndf/transformation/_wrapper.py
+++ b/src/sklearndf/transformation/_wrapper.py
@@ -83,7 +83,7 @@ class _ColumnPreservingTransformerWrapperDF(
     """
 
     def _get_features_out(self) -> pd.Index:
-        return self.features_in
+        return self.features_in_
 
 
 class _BaseMultipleInputsPerOutputTransformerWrapperDF(
@@ -193,4 +193,4 @@ class _FeatureSelectionWrapperDF(
 
     def _get_features_out(self) -> pd.Index:
         get_support = getattr(self.native_estimator, self._ATTR_GET_SUPPORT)
-        return self.features_in[get_support()]
+        return self.features_in_[get_support()]

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -103,7 +103,7 @@ class OutlierRemoverDF(TransformerDF, BaseEstimator):
         return self._features_original
 
     def _get_features_in(self) -> pd.Index:
-        return self.features_original.index
+        return self.features_original_.index
 
     def _get_n_outputs(self) -> int:
         return 0
@@ -116,7 +116,7 @@ class _BorutaPyWrapperDF(
     metaclass=ABCMeta,
 ):
     def _get_features_out(self) -> pd.Index:
-        return self.features_in[self.native_estimator.support_]
+        return self.features_in_[self.native_estimator.support_]
 
 
 # noinspection PyAbstractClass,PyUnresolvedReferences

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -114,9 +114,9 @@ def test_wrapped_fit_predict(
 
             if is_multi_output:
                 assert isinstance(predictions, list)
-                assert classifier.n_outputs == len(predictions)
+                assert classifier.n_outputs_ == len(predictions)
             else:
-                assert classifier.n_outputs == predictions.shape[1] if is_chain else 1
+                assert classifier.n_outputs_ == predictions.shape[1] if is_chain else 1
                 predictions = [predictions]
 
             for prediction in predictions:


### PR DESCRIPTION
This PR adds an underscore (`_`) character to the names of he following properties

- `EstimatorDF.features_in_`
- `EstimatorDF.n_outputs_`
- `TransformerDF.features_out_`
- `TransformerDF.features_original_`
- `ClassifierDF.classes_`

This is to conform with the `scikit-learn` naming convention for any attributes that are valid only after fitting.

We also replace `features_out` with `features_original_` to correctly handle Boruta results in some notebooks.