### PR TITLE
This commit corrects a typo in a line of code in the tutorial notebook

### DIFF
--- a/sphinx/source/tutorial/sklearndf_tutorial.ipynb
+++ b/sphinx/source/tutorial/sklearndf_tutorial.ipynb
@@ -150,7 +150,7 @@
    },
    "outputs": [],
    "source": [
-    "housing_df[\"GarageType\"].unique()"
+    "housing_features_df[\"GarageType\"].unique()"
    ]
   },
   {


### PR DESCRIPTION
**PR**
This PR corrects a typo in a line of code in the tutorial notebook from `housing_df["GarageType"].unique()` to ` housing_features_df["GarageType"].unique()`.

**Run**
To run navigate to the sphinx directory and execute `python make.py html`

**Output**
Check that the expected output is now a list of garage types for the cell which now contains `housing_features_df["GarageType"].unique()`. 

![image](https://user-images.githubusercontent.com/17013354/94543142-93c19800-0241-11eb-916c-ab354166854e.png)
