### PR TITLE
Edit of sklearndf git_url so conda build works on windows

### DIFF
--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0.0
 
 source:
-  git_url: {{FACET_PATH}}/sklearndf/
+  git_url: {{FACET_PATH}}/sklearndf
 
 build:
   noarch: python


### PR DESCRIPTION
**PR**

This PR removes the forward slash at the end of the git_url in the `conda-build/meta.yml` so that the build via make.py will work as intended on a windows machine.