### PR TITLE
remove breaks in API overview bullet list for proper rendering in docs

### DIFF
--- a/src/sklearndf/__init__.py
+++ b/src/sklearndf/__init__.py
@@ -45,25 +45,21 @@ scikit-learn classes (but is only partially reflected
 via class inheritance in the
 original implementation):
 
-- all `sklearndf` transformers are subclasses of
-:class:`.TransformerDF`, which \
-  in turn provides the API for all common transformer
-  methods, e.g., \
+- all `sklearndf` transformers are subclasses of :class:`.TransformerDF`, which in turn
+  provides the API for all common transformer methods, e.g.,
   :meth:`~TransformerDF.transform`
-- all `sklearndf` regressors are subclasses
-of :class:`.RegressorDF`, which \
-  in turn provides the API for all common regressor
-  methods, e.g., \
+
+- all `sklearndf` regressors are subclasses of :class:`.RegressorDF`, which
+  in turn provides the API for all common regressor methods, e.g.,
   :meth:`~LearnerDF.predict`
-- all `sklearndf` classifiers are subclasses of :class:
-`.ClassifierDF`, which \
-  in turn provides the API for all common classifier
-  methods, e.g., \
+
+- all `sklearndf` classifiers are subclasses of :class:`.ClassifierDF`, which
+  in turn provides the API for all common classifier methods, e.g.,
   :meth:`~ClassifierDF.predict_proba`
-- all `sklearndf` regressors and classifiers are
-subclasses of :class:`.LearnerDF`
-- all `sklearndf` estimators are subclasses of
-:class:`.EstimatorDF`
+
+- all `sklearndf` regressors and classifiers are subclasses of :class:`.LearnerDF`
+
+- all `sklearndf` estimators are subclasses of :class:`.EstimatorDF`
 
 `sklearndf` introduces two additional pipeline classes,
 :class:`.RegressorPipelineDF` and


### PR DESCRIPTION
This PR cleans up the bullet points used on the API landing page in docs which come from the `src/sklearndf/__init__` file. 
Please build docs by running `python make.py html` from the sphinx folder. Expected result is:
![image](https://user-images.githubusercontent.com/17013354/98233451-f7cd2f80-1f56-11eb-9242-9f33ecf7433e.png)
