### PR TITLE
rename type variables for methods' "self" arguments to T_Self

### DIFF
--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -25,7 +25,7 @@ __all__ = ["EstimatorDF", "LearnerDF", "ClassifierDF", "RegressorDF", "Transform
 # type variables
 #
 
-T = TypeVar("T")
+T_Self = TypeVar("T_Self")
 T_EstimatorDF = TypeVar("T_EstimatorDF")
 
 #
@@ -66,11 +66,11 @@ class EstimatorDF(FittableMixin[pd.DataFrame], metaclass=ABCMeta):
     # noinspection PyPep8Naming
     @abstractmethod
     def fit(
-        self: T,
+        self: T_Self,
         X: pd.DataFrame,
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params,
-    ) -> T:
+    ) -> T_Self:
         """
         Fit this estimator using the given inputs.
 
@@ -114,7 +114,7 @@ class EstimatorDF(FittableMixin[pd.DataFrame], metaclass=ABCMeta):
         # noinspection PyUnresolvedReferences
         return super().get_params(deep=deep)
 
-    def set_params(self: T, **kwargs) -> T:
+    def set_params(self: T_Self, **kwargs) -> T_Self:
         """
         Set the parameters of this estimator.
 

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -74,7 +74,7 @@ INCLUDE_FULL_SKLEARN_DOCUMENTATION = False
 #
 
 T = TypeVar("T")
-
+T_Self = TypeVar("T_Self")
 T_DelegateEstimator = TypeVar("T_DelegateEstimator", bound=BaseEstimator)
 T_DelegateTransformer = TypeVar("T_DelegateTransformer", bound=TransformerMixin)
 T_DelegateLearner = TypeVar("T_DelegateLearner", RegressorMixin, ClassifierMixin)
@@ -168,7 +168,7 @@ class _EstimatorWrapperDF(
         """[see superclass]"""
         return self._delegate_estimator.get_params(deep=deep)
 
-    def set_params(self: T, **kwargs) -> T:
+    def set_params(self: T_Self, **kwargs) -> T_Self:
         """[see superclass]"""
         self: _EstimatorWrapperDF  # support type hinting in PyCharm
         self._delegate_estimator.set_params(**kwargs)
@@ -176,11 +176,11 @@ class _EstimatorWrapperDF(
 
     # noinspection PyPep8Naming
     def fit(
-        self: T,
+        self: T_Self,
         X: pd.DataFrame,
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params,
-    ) -> T:
+    ) -> T_Self:
         """[see superclass]"""
 
         # support type hinting in PyCharm

--- a/src/sklearndf/pipeline/_learner_pipeline.py
+++ b/src/sklearndf/pipeline/_learner_pipeline.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 __all__ = ["LearnerPipelineDF", "RegressorPipelineDF", "ClassifierPipelineDF"]
 
-T = TypeVar("T")
+T_Self = TypeVar("T_Self")
 T_FinalEstimatorDF = TypeVar("T_FinalEstimatorDF", bound=EstimatorDF)
 T_FinalLearnerDF = TypeVar("T_FinalLearnerDF", bound=LearnerDF)
 T_FinalRegressorDF = TypeVar("T_FinalRegressorDF", bound=RegressorDF)
@@ -108,14 +108,14 @@ class _EstimatorPipelineDF(
 
     # noinspection PyPep8Naming
     def fit(
-        self: T,
+        self: T_Self,
         X: pd.DataFrame,
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         *,
         feature_sequence: Optional[pd.Index] = None,
         sample_weight: Optional[pd.Series] = None,
         **fit_params,
-    ) -> T:
+    ) -> T_Self:
         """
         Fit this pipeline using the given inputs.
 

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -22,7 +22,7 @@ __all__ = ["OutlierRemoverDF", "BorutaDF"]
 # type variables
 #
 
-T = TypeVar("T")
+T_Self = TypeVar("T_Self")
 
 #
 # Class definitions
@@ -45,7 +45,7 @@ class OutlierRemoverDF(TransformerDF, BaseEstimator):
     def get_params(self, deep=True) -> Mapping[str, Any]:
         return super().get_params(deep)
 
-    def set_params(self: T, **kwargs) -> T:
+    def set_params(self: T_Self, **kwargs) -> T_Self:
         return super(**kwargs)
 
     def __init__(self, iqr_multiple: float = 3.0):
@@ -59,11 +59,11 @@ class OutlierRemoverDF(TransformerDF, BaseEstimator):
 
     # noinspection PyPep8Naming
     def fit(
-        self: T,
+        self: T_Self,
         X: pd.DataFrame,
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params,
-    ) -> T:
+    ) -> T_Self:
         """
         Fit the transformer.
 


### PR DESCRIPTION
Use type variable `T_Self` in constructs of the form

``` python
def a_method(self: T_Self, …) -> T_Self:
    …
```

This leads to a more self-explanatory return type in the Sphinx docstring.