### PR TITLE
Fix automatic duplication of estimator methods in DF estimator classes

### DIFF
--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -932,6 +932,7 @@ def df_estimator(
             function = update_wrapper(_make_forwarder(), delegate)
             docstring = f"see :meth:`{full_name}`"
             function.__doc__ = docstring
+            return function
         else:
             docstring = f"see :attr:`{full_name}`"
             if inspect.isdatadescriptor(delegate):


### PR DESCRIPTION
This PR adds a missing `return` statement after referencing an estimator method from a DF class.