### PR TITLE
remove _EstimatorWrapperDF parameter _delegate_estimator

### DIFF
--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -95,13 +95,8 @@ class _EstimatorWrapperDF(
     instantiate the delegate estimator to be wrapped.
     """
 
-    def __init__(
-        self, *args, _delegate_estimator: Optional[T_DelegateEstimator] = None, **kwargs
-    ) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         """
-        :param _delegate_estimator: (optional) an estimator to use as the delegate;
-            if specified, do not create a new estimator and ignore any other arguments
-            passed to this initializer
         :param args: positional arguments to use when initializing a new new delegate
             estimator
         :param kwargs: keyword arguments to use when initializing a new new delegate
@@ -109,14 +104,9 @@ class _EstimatorWrapperDF(
         """
         super().__init__()
 
-        if _delegate_estimator is None:
-            # create a new delegate estimator with the given parameters
-            # noinspection PyProtectedMember
-            self._delegate_estimator = type(self)._make_delegate_estimator(
-                *args, **kwargs
-            )
-        else:
-            self._delegate_estimator = _delegate_estimator
+        # create a new delegate estimator with the given parameters
+        # noinspection PyProtectedMember
+        self._delegate_estimator = type(self)._make_delegate_estimator(*args, **kwargs)
 
         self._validate_delegate_estimator()
 
@@ -153,9 +143,13 @@ class _EstimatorWrapperDF(
 
         class _FittedEstimator(cls):
             def __init__(self) -> None:
-                super().__init__(_delegate_estimator=estimator)
+                super().__init__()
                 self._features_in = features_in
                 self._n_outputs = n_outputs
+
+            @classmethod
+            def _make_delegate_estimator(cls) -> T_DelegateEstimator:
+                return estimator
 
         return _FittedEstimator()
 


### PR DESCRIPTION
Class method `_EstimatorWrapperDF.from_fitter` used to rely on keyword parameter `_delegate_estimator` of `_EstimatorWrapperDF.from_fitter.__init__`.
This mechanism is somewhat error-prone as it interferes with handling estimator parameters.
This PR removes the keyword parameter and gives `_EstimatorWrapperDF.from_fitter` a better mechanism to wrap an existing, fitted estimator, by overloading method `_make_delegate_estimator`.