### PR TITLE
Introduce factory functions to simplify the creation of ...DF estimators

### DIFF
--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -943,7 +943,6 @@ class _EstimatorDFClassFactory(metaclass=SingletonMeta):
         # noinspection PyMissingOrEmptyDocstring
         class WrapperDF(base_wrapper):
             def __init__(self, *args, **kwargs) -> None:
-                print(args, kwargs)
                 super().__init__(*args, **kwargs)
 
             def __reduce__(

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -348,9 +348,14 @@ class _EstimatorWrapperDF(
     def __getattr__(self, name: str) -> Any:
         # get a non-private attribute of the delegate estimator
         if name.startswith("_"):
-            raise AttributeError(f"{type(self).__name__}.{name}")
+            # raise attribute error
+            self.__getattribute__(name)
         else:
-            return getattr(self._delegate_estimator, name)
+            try:
+                return getattr(self._delegate_estimator, name)
+            except AttributeError:
+                # raise attribute error
+                self.__getattribute__(name)
 
     def __setattr__(self, name: str, value: Any) -> None:
         # set a public attribute of the delegate estimator

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -83,6 +83,11 @@ T_DelegateClassifier = TypeVar("T_DelegateClassifier", bound=ClassifierMixin)
 
 # noinspection PyTypeChecker
 T_EstimatorWrapperDF = TypeVar("T_EstimatorWrapperDF", bound="_EstimatorWrapperDF")
+T_TransformerWrapperDF = TypeVar(
+    "T_TransformerWrapperDF", bound="_TransformerWrapperDF"
+)
+T_RegressorWrapperDF = TypeVar("T_RegressorWrapperDF", bound="_RegressorWrapperDF")
+T_ClassifierWrapperDF = TypeVar("T_ClassifierWrapperDF", bound="_ClassifierWrapperDF")
 
 
 #
@@ -1100,13 +1105,13 @@ class _DFDecorator(metaclass=SingletonMeta):
 
 class _DFClassifierDecorator(_DFDecorator):
     @property
-    def _df_wrapper_base_type(self) -> Type[_EstimatorWrapperDF]:
+    def _df_wrapper_base_type(self) -> Type[_ClassifierWrapperDF]:
         return _ClassifierWrapperDF
 
 
 class _DFRegressorDecorator(_DFDecorator):
     @property
-    def _df_wrapper_base_type(self) -> Type[_EstimatorWrapperDF]:
+    def _df_wrapper_base_type(self) -> Type[_RegressorWrapperDF]:
         return _RegressorWrapperDF
 
 
@@ -1120,8 +1125,8 @@ _DFRegressorDecorator()
 def make_df_classifier(
     classifier: Type[T_DelegateClassifier],
     *,
-    df_wrapper_type: Optional[Type[_ClassifierWrapperDF[T_DelegateClassifier]]] = None,
-) -> Union[Type[ClassifierDF], Type[T_DelegateClassifier]]:
+    df_wrapper_type: Optional[T_ClassifierWrapperDF] = None,
+) -> Union[Type[T_ClassifierWrapperDF], Type[T_DelegateClassifier]]:
     return df_classifier(
         delegate_estimator=cast(
             Type[T_DelegateClassifier],
@@ -1134,8 +1139,8 @@ def make_df_classifier(
 def make_df_regressor(
     regressor: Type[T_DelegateRegressor],
     *,
-    df_wrapper_type: Optional[Type[_RegressorWrapperDF[T_DelegateRegressor]]] = None,
-) -> Union[Type[T_DelegateRegressor], Type[RegressorDF]]:
+    df_wrapper_type: Optional[T_RegressorWrapperDF] = None,
+) -> Union[Type[T_RegressorWrapperDF], Type[T_DelegateRegressor]]:
     return df_regressor(
         delegate_estimator=cast(
             Type[T_DelegateRegressor],

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -109,9 +109,7 @@ class _EstimatorWrapperDF(
     EstimatorDF,
     BaseEstimator,
     Generic[T_DelegateEstimator],
-    metaclass=compose_meta(
-        type(EstimatorDF), type(BaseEstimator), _EstimatorWrapperDFMeta
-    ),
+    metaclass=compose_meta(type(EstimatorDF), _EstimatorWrapperDFMeta),
 ):
     """
     Base class for wrappers around a delegate :class:`sklearn.base.BaseEstimator`.

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -101,6 +101,9 @@ class _EstimatorWrapperDFMeta(type):
 
     @property
     def native_estimator_type(cls) -> Type[BaseEstimator]:
+        """
+        The type of native estimator that instances of this wrapper class delegate to.
+        """
         return cls.__wrapped__
 
 
@@ -156,12 +159,15 @@ class _EstimatorWrapperDF(
     @property
     def native_estimator(self) -> T_DelegateEstimator:
         """
-        The native estimator which this wrapper delegates to.
+        The native estimator that this wrapper delegates to.
         """
         return self._delegate_estimator
 
     @property
     def native_estimator_type(self) -> Type[T_DelegateEstimator]:
+        """
+        The type of the native estimator that this wrapper delegates to.
+        """
         # noinspection PyTypeChecker
         return type(self).native_estimator_type
 
@@ -1145,11 +1151,11 @@ def make_df_estimator(
 
     The augmented version is realised as a wrapper class that
 
-    - implements additional functionality introduced by :class:`.EstimatorDF`
+    - implements enhanced functionality introduced by :class:`.EstimatorDF`
     - adopts all additional methods and attributes from the wrapped native estimator
     - delegates relevant method calls and attribute access to the native estimator,
       thus replicating the original estimator's behaviour except for the enhanced
-      and/or modified functionality introduced by :class:`.EstimatorDF`
+      functionality introduced by :class:`.EstimatorDF`
 
     :param native_estimator: the native estimator to be augmented
     :param name: the name of the resulting augmented estimator, defaults to the name
@@ -1170,8 +1176,26 @@ def make_df_transformer(
     native_transformer: Type[T_DelegateEstimator] = None,
     *,
     name: Optional[str] = None,
-    base_wrapper: Optional[Type[_EstimatorWrapperDF[T_DelegateEstimator]]] = None,
+    base_wrapper: Type[_EstimatorWrapperDF[T_DelegateEstimator]],
 ) -> Union[Type[_EstimatorWrapperDF[T_DelegateEstimator]], T_DelegateEstimator]:
+    """
+    Create an augmented version of a given transformer that conforms with the
+    scikit-learn API.
+
+    The augmented version is realised as a wrapper class that
+
+    - implements enhanced functionality introduced by :class:`.TransformerDF`
+    - adopts all additional methods and attributes from the wrapped native transformer
+    - delegates relevant method calls and attribute access to the native transformer,
+      thus replicating the original transformer's behaviour except for the enhanced
+      functionality introduced by :class:`.TransformerDF`
+
+    :param native_transformer: the native transformer to be augmented
+    :param name: the name of the resulting augmented transformer, defaults to the name
+        of the native transformer with "DF" appended
+    :param base_wrapper: the wrapper class used to create the augmented version
+    :return: the augmented transformer class
+    """
     return _EstimatorDFClassFactory().wrap(
         native_estimator=native_transformer,
         name=name,
@@ -1187,6 +1211,24 @@ def make_df_classifier(
     name: Optional[str] = None,
     base_wrapper: Optional[Type[_EstimatorWrapperDF[T_DelegateEstimator]]] = None,
 ) -> Union[Type[_EstimatorWrapperDF[T_DelegateEstimator]], T_DelegateEstimator]:
+    """
+    Create an augmented version of a given classifier that conforms with the
+    scikit-learn API.
+
+    The augmented version is realised as a wrapper class that
+
+    - implements enhanced functionality introduced by :class:`.ClassifierDF`
+    - adopts all additional methods and attributes from the wrapped native classifier
+    - delegates relevant method calls and attribute access to the native classifier,
+      thus replicating the original classifier's behaviour except for the enhanced
+      functionality introduced by :class:`.ClassifierDF`
+
+    :param native_classifier: the native classifier to be augmented
+    :param name: the name of the resulting augmented classifier, defaults to the name
+        of the native classifier with "DF" appended
+    :param base_wrapper: the wrapper class used to create the augmented version
+    :return: the augmented classifier class
+    """
     return _EstimatorDFClassFactory().wrap(
         native_estimator=native_classifier,
         name=name,
@@ -1202,6 +1244,24 @@ def make_df_regressor(
     name: Optional[str] = None,
     base_wrapper: Optional[Type[_EstimatorWrapperDF[T_DelegateEstimator]]] = None,
 ) -> Union[Type[_EstimatorWrapperDF[T_DelegateEstimator]], T_DelegateEstimator]:
+    """
+    Create an augmented version of a given regressor that conforms with the
+    scikit-learn API.
+
+    The augmented version is realised as a wrapper class that
+
+    - implements enhanced functionality introduced by :class:`.RegressorDF`
+    - adopts all additional methods and attributes from the wrapped native regressor
+    - delegates relevant method calls and attribute access to the native regressor,
+      thus replicating the original regressor's behaviour except for the enhanced
+      functionality introduced by :class:`.RegressorDF`
+
+    :param native_regressor: the native regressor to be augmented
+    :param name: the name of the resulting augmented regressor, defaults to the name
+        of the native regressor with "DF" appended
+    :param base_wrapper: the wrapper class used to create the augmented version
+    :return: the augmented regressor class
+    """
     return _EstimatorDFClassFactory().wrap(
         native_estimator=native_regressor,
         name=name,

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -1168,7 +1168,7 @@ def make_df_estimator(
 def make_df_transformer(
     transformer: Type[T_DelegateTransformer],
     *,
-    module: str = "sklearndf.transformation",
+    module: str,
     df_wrapper_type: Optional[Type[T_TransformerWrapperDF]] = None,
 ) -> Union[Type[T_TransformerWrapperDF], Type[T_DelegateTransformer]]:
     return df_transformer(
@@ -1184,7 +1184,7 @@ def make_df_transformer(
 def make_df_classifier(
     classifier: Type[T_DelegateClassifier],
     *,
-    module: str = "sklearndf.classification",
+    module: str,
     df_wrapper_type: Optional[T_ClassifierWrapperDF] = None,
 ) -> Union[Type[T_ClassifierWrapperDF], Type[T_DelegateClassifier]]:
     return df_classifier(
@@ -1200,7 +1200,7 @@ def make_df_classifier(
 def make_df_regressor(
     regressor: Type[T_DelegateRegressor],
     *,
-    module: str = "sklearndf.regression",
+    module: str,
     df_wrapper_type: Optional[T_RegressorWrapperDF] = None,
 ) -> Union[Type[T_RegressorWrapperDF], Type[T_DelegateRegressor]]:
     return df_regressor(

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -54,8 +54,11 @@ __all__ = [
     "_LearnerWrapperDF",
     "_ClassifierWrapperDF",
     "df_estimator",
+    "df_transformer",
     "df_classifier",
     "df_regressor",
+    "make_df_estimator",
+    "make_df_transformer",
     "make_df_classifier",
     "make_df_regressor",
     "_MetaClassifierWrapperDF",
@@ -838,7 +841,7 @@ class _StackingRegressorWrapperDF(
 #
 
 
-class _DFDecorator(metaclass=SingletonMeta):
+class _DFEstimatorDecorator(metaclass=SingletonMeta):
     @property
     def _df_wrapper_base_type(self) -> Type[_EstimatorWrapperDF]:
         return _EstimatorWrapperDF
@@ -1103,23 +1106,56 @@ class _DFDecorator(metaclass=SingletonMeta):
         return sklearn_native_estimators[0]
 
 
-class _DFClassifierDecorator(_DFDecorator):
+class _DFTransformerDecorator(_DFEstimatorDecorator):
+    @property
+    def _df_wrapper_base_type(self) -> Type[_TransformerWrapperDF]:
+        return _TransformerWrapperDF
+
+
+class _DFClassifierDecorator(_DFEstimatorDecorator):
     @property
     def _df_wrapper_base_type(self) -> Type[_ClassifierWrapperDF]:
         return _ClassifierWrapperDF
 
 
-class _DFRegressorDecorator(_DFDecorator):
+class _DFRegressorDecorator(_DFEstimatorDecorator):
     @property
     def _df_wrapper_base_type(self) -> Type[_RegressorWrapperDF]:
         return _RegressorWrapperDF
 
 
-df_estimator = _DFDecorator()
+df_estimator = _DFEstimatorDecorator()
+df_transformer = _DFTransformerDecorator()
 df_classifier = _DFClassifierDecorator()
 df_regressor = _DFRegressorDecorator()
 
-_DFRegressorDecorator()
+
+def make_df_estimator(
+    estimator: Type[T_DelegateEstimator],
+    *,
+    df_wrapper_type: Optional[Type[T_EstimatorWrapperDF]] = None,
+) -> Union[Type[T_EstimatorWrapperDF], Type[T_DelegateEstimator]]:
+    return df_estimator(
+        delegate_estimator=cast(
+            Type[T_DelegateEstimator],
+            type(f"{estimator.__name__}DF", (estimator,), {}),
+        ),
+        df_wrapper_type=df_wrapper_type,
+    )
+
+
+def make_df_transformer(
+    transformer: Type[T_DelegateTransformer],
+    *,
+    df_wrapper_type: Optional[Type[T_TransformerWrapperDF]] = None,
+) -> Union[Type[T_TransformerWrapperDF], Type[T_DelegateTransformer]]:
+    return df_transformer(
+        delegate_estimator=cast(
+            Type[T_DelegateTransformer],
+            type(f"{transformer.__name__}DF", (transformer,), {}),
+        ),
+        df_wrapper_type=df_wrapper_type,
+    )
 
 
 def make_df_classifier(

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -152,6 +152,12 @@ class _EstimatorWrapperDF(
 
         self._validate_delegate_estimator()
 
+    def __new__(cls: Type[T], *args, **kwargs) -> T:
+        if not hasattr(cls, "__wrapped__"):
+            raise TypeError(f"cannot instantiate abstract wrapper class {cls.__name__}")
+        else:
+            return super().__new__(cls)
+
     @property
     def is_fitted(self) -> bool:
         """[see superclass]"""

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -13,7 +13,6 @@ The wrappers also implement the additional column attributes introduced by `skle
 
 import inspect
 import logging
-import sys
 from abc import ABCMeta, abstractmethod
 from functools import update_wrapper
 from typing import (
@@ -851,7 +850,6 @@ class _DFEstimatorDecorator(metaclass=SingletonMeta):
         self,
         delegate_estimator: Type[T_DelegateEstimator] = None,
         *,
-        module: str,
         df_wrapper_type: Optional[
             Type[_EstimatorWrapperDF[T_DelegateEstimator]]
         ] = None,
@@ -867,7 +865,6 @@ class _DFEstimatorDecorator(metaclass=SingletonMeta):
         :class:`_EstimatorWrapperDF`.
 
         :param delegate_estimator: the estimator class to wrap
-        :param module: the module to which to add the new class
         :param df_wrapper_type: optional parameter indicating the
             :class:`_EstimatorWrapperDF` class to be used for wrapping; defaults to
             :class:`_EstimatorWrapperDF`
@@ -887,9 +884,7 @@ class _DFEstimatorDecorator(metaclass=SingletonMeta):
         def _decorate(
             delegate: Type[T_DelegateEstimator],
         ) -> Type[_EstimatorWrapperDF[T_DelegateEstimator]]:
-            return self._decorate(
-                df_wrapper_type=df_wrapper_type, module_name=module, delegate=delegate
-            )
+            return self._decorate(df_wrapper_type=df_wrapper_type, delegate=delegate)
 
         if delegate_estimator is None:
             return _decorate
@@ -899,7 +894,6 @@ class _DFEstimatorDecorator(metaclass=SingletonMeta):
     def _decorate(
         self,
         df_wrapper_type: Type[_EstimatorWrapperDF[T_DelegateEstimator]],
-        module_name: str,
         delegate: Type[T_DelegateEstimator],
     ) -> Type[_EstimatorWrapperDF[T_DelegateEstimator]]:
 
@@ -958,16 +952,8 @@ class _DFEstimatorDecorator(metaclass=SingletonMeta):
         # but do not keep the docstring of __init__
         df_estimator_type.__init__.__doc__ = None
 
-        # set the module and add the newly created class to the module
-        # to enable pickling
-        try:
-            module = sys.modules[module_name]
-        except KeyError as e:
-            raise KeyError(
-                f"Unknown module specified for {wrapper_name}: {module_name}"
-            ) from e
-        setattr(module, wrapper_name, df_estimator_type)
-        df_estimator_type.__module__ = module_name
+        # set the module
+        df_estimator_type.__module__ = __name__
 
         # adopt the class docstring of the wrapped sklearn estimator
         self._update_class_docstring(
@@ -1152,7 +1138,6 @@ df_regressor = _DFRegressorDecorator()
 def make_df_estimator(
     estimator: Type[T_DelegateEstimator],
     *,
-    module: str,
     df_wrapper_type: Optional[Type[T_EstimatorWrapperDF]] = None,
 ) -> Union[Type[T_EstimatorWrapperDF], Type[T_DelegateEstimator]]:
     return df_estimator(
@@ -1160,7 +1145,6 @@ def make_df_estimator(
             Type[T_DelegateEstimator],
             type(f"{estimator.__name__}DF", (estimator,), {}),
         ),
-        module=module,
         df_wrapper_type=df_wrapper_type,
     )
 
@@ -1168,7 +1152,6 @@ def make_df_estimator(
 def make_df_transformer(
     transformer: Type[T_DelegateTransformer],
     *,
-    module: str,
     df_wrapper_type: Optional[Type[T_TransformerWrapperDF]] = None,
 ) -> Union[Type[T_TransformerWrapperDF], Type[T_DelegateTransformer]]:
     return df_transformer(
@@ -1176,7 +1159,6 @@ def make_df_transformer(
             Type[T_DelegateTransformer],
             type(f"{transformer.__name__}DF", (transformer,), {}),
         ),
-        module=module,
         df_wrapper_type=df_wrapper_type,
     )
 
@@ -1184,7 +1166,6 @@ def make_df_transformer(
 def make_df_classifier(
     classifier: Type[T_DelegateClassifier],
     *,
-    module: str,
     df_wrapper_type: Optional[T_ClassifierWrapperDF] = None,
 ) -> Union[Type[T_ClassifierWrapperDF], Type[T_DelegateClassifier]]:
     return df_classifier(
@@ -1192,7 +1173,6 @@ def make_df_classifier(
             Type[T_DelegateClassifier],
             type(f"{classifier.__name__}DF", (classifier,), {}),
         ),
-        module=module,
         df_wrapper_type=df_wrapper_type,
     )
 
@@ -1200,7 +1180,6 @@ def make_df_classifier(
 def make_df_regressor(
     regressor: Type[T_DelegateRegressor],
     *,
-    module: str,
     df_wrapper_type: Optional[T_RegressorWrapperDF] = None,
 ) -> Union[Type[T_RegressorWrapperDF], Type[T_DelegateRegressor]]:
     return df_regressor(
@@ -1208,6 +1187,5 @@ def make_df_regressor(
             Type[T_DelegateRegressor],
             type(f"{regressor.__name__}DF", (regressor,), {}),
         ),
-        module=module,
         df_wrapper_type=df_wrapper_type,
     )

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -1098,6 +1098,8 @@ def _make_df_wrapper_class(
 ) -> Type[T_EstimatorWrapperDF]:
     # noinspection PyMissingOrEmptyDocstring
     class WrapperDF(base_wrapper):
+        # we need to create this __init__ method in order to apply the signature
+        # of the native estimator's __init__ method
         def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
 

--- a/src/sklearndf/classification/_classification.py
+++ b/src/sklearndf/classification/_classification.py
@@ -137,7 +137,7 @@ RadiusNeighborsClassifierDF = make_df_classifier(RadiusNeighborsClassifier)
 #
 
 VotingClassifierDF = make_df_classifier(
-    VotingClassifier, df_wrapper_type=_MetaClassifierWrapperDF
+    VotingClassifier, base_wrapper=_MetaClassifierWrapperDF
 )
 
 
@@ -176,7 +176,7 @@ class _LinearDiscriminantAnalysisWrapperDF(
 
 LinearDiscriminantAnalysisDF = make_df_classifier(
     LinearDiscriminantAnalysis,
-    df_wrapper_type=_LinearDiscriminantAnalysisWrapperDF,
+    base_wrapper=_LinearDiscriminantAnalysisWrapperDF,
 )
 
 QuadraticDiscriminantAnalysisDF = make_df_classifier(QuadraticDiscriminantAnalysis)
@@ -198,7 +198,7 @@ BernoulliNBDF = make_df_classifier(BernoulliNB)
 #
 
 CalibratedClassifierCVDF = make_df_classifier(
-    CalibratedClassifierCV, df_wrapper_type=_MetaClassifierWrapperDF
+    CalibratedClassifierCV, base_wrapper=_MetaClassifierWrapperDF
 )
 
 
@@ -245,15 +245,15 @@ LabelSpreadingDF = make_df_classifier(LabelSpreading)
 #
 
 OneVsRestClassifierDF = make_df_classifier(
-    OneVsRestClassifier, df_wrapper_type=_MetaClassifierWrapperDF
+    OneVsRestClassifier, base_wrapper=_MetaClassifierWrapperDF
 )
 
 OneVsOneClassifierDF = make_df_classifier(
-    OneVsOneClassifier, df_wrapper_type=_MetaClassifierWrapperDF
+    OneVsOneClassifier, base_wrapper=_MetaClassifierWrapperDF
 )
 
 OutputCodeClassifierDF = make_df_classifier(
-    OutputCodeClassifier, df_wrapper_type=_MetaClassifierWrapperDF
+    OutputCodeClassifier, base_wrapper=_MetaClassifierWrapperDF
 )
 
 
@@ -309,7 +309,7 @@ class _MultiOutputClassifierWrapperDF(
 
 
 MultiOutputClassifierDF = make_df_classifier(
-    MultiOutputClassifier, df_wrapper_type=_MultiOutputClassifierWrapperDF
+    MultiOutputClassifier, base_wrapper=_MultiOutputClassifierWrapperDF
 )
 
 
@@ -334,7 +334,7 @@ class _ClassifierChainWrapperDF(
 
 
 ClassifierChainDF = make_df_classifier(
-    ClassifierChain, df_wrapper_type=_ClassifierChainWrapperDF
+    ClassifierChain, base_wrapper=_ClassifierChainWrapperDF
 )
 
 

--- a/src/sklearndf/classification/_classification.py
+++ b/src/sklearndf/classification/_classification.py
@@ -51,7 +51,12 @@ from sklearn.tree import DecisionTreeClassifier, ExtraTreeClassifier
 
 from pytools.api import AllTracker
 
-from .._wrapper import _MetaClassifierWrapperDF, make_df_classifier
+from .._wrapper import (
+    _ClassifierWrapperDF,
+    _MetaClassifierWrapperDF,
+    make_df_classifier,
+)
+from ..transformation._wrapper import _NComponentsDimensionalityReductionWrapperDF
 
 log = logging.getLogger(__name__)
 
@@ -160,8 +165,21 @@ ExtraTreeClassifierDF = make_df_classifier(ExtraTreeClassifier)
 # discriminant analysis
 #
 
+
+class _LinearDiscriminantAnalysisWrapperDF(
+    _NComponentsDimensionalityReductionWrapperDF[LinearDiscriminantAnalysis],
+    _ClassifierWrapperDF[LinearDiscriminantAnalysis],
+    metaclass=ABCMeta,
+):
+    pass
+
+
+LinearDiscriminantAnalysisDF = make_df_classifier(
+    LinearDiscriminantAnalysis,
+    df_wrapper_type=_LinearDiscriminantAnalysisWrapperDF,
+)
+
 QuadraticDiscriminantAnalysisDF = make_df_classifier(QuadraticDiscriminantAnalysis)
-LinearDiscriminantAnalysisDF = make_df_classifier(LinearDiscriminantAnalysis)
 
 
 #

--- a/src/sklearndf/classification/_classification.py
+++ b/src/sklearndf/classification/_classification.py
@@ -51,8 +51,7 @@ from sklearn.tree import DecisionTreeClassifier, ExtraTreeClassifier
 
 from pytools.api import AllTracker
 
-from .. import ClassifierDF
-from .._wrapper import _ClassifierWrapperDF, _MetaClassifierWrapperDF, df_estimator
+from .._wrapper import _MetaClassifierWrapperDF, make_df_classifier
 
 log = logging.getLogger(__name__)
 
@@ -116,71 +115,25 @@ __tracker = AllTracker(globals())
 # Dummy
 #
 
-# noinspection PyAbstractClass
-
-
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class DummyClassifierDF(ClassifierDF, DummyClassifier):
-    """
-    Wraps :class:`sklearn.dummy.DummyClassifier`; accepts and
-    returns data frames.
-    """
-
-    pass
+DummyClassifierDF = make_df_classifier(DummyClassifier)
 
 
 #
 # neighbors
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class NearestCentroidDF(ClassifierDF, NearestCentroid):
-    """
-    Wraps :class:`sklearn.neighbors.nearest_centroid.NearestCentroid`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class KNeighborsClassifierDF(ClassifierDF, KNeighborsClassifier):
-    """
-    Wraps :class:`sklearn.neighbors.classification.KNeighborsClassifier`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class RadiusNeighborsClassifierDF(ClassifierDF, RadiusNeighborsClassifier):
-    """
-    Wraps :class:`sklearn.neighbors.classification.RadiusNeighborsClassifier`; accepts
-    and returns data frames.
-    """
-
-    pass
+NearestCentroidDF = make_df_classifier(NearestCentroid)
+KNeighborsClassifierDF = make_df_classifier(KNeighborsClassifier)
+RadiusNeighborsClassifierDF = make_df_classifier(RadiusNeighborsClassifier)
 
 
 #
 # voting
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MetaClassifierWrapperDF)
-class VotingClassifierDF(ClassifierDF, VotingClassifier):
-    """
-    Wraps :class:`sklearn.ensemble.voting.VotingClassifier`; accepts and returns data
-    frames.
-    """
-
-    pass
+VotingClassifierDF = make_df_classifier(
+    VotingClassifier, df_wrapper_type=_MetaClassifierWrapperDF
+)
 
 
 #
@@ -188,113 +141,27 @@ class VotingClassifierDF(ClassifierDF, VotingClassifier):
 #
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class RandomForestClassifierDF(ClassifierDF, RandomForestClassifier):
-    """
-    Wraps :class:`sklearn.ensemble.forest.RandomForestClassifier`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class ExtraTreesClassifierDF(ClassifierDF, ExtraTreesClassifier):
-    """
-    Wraps :class:`sklearn.ensemble.forest.ExtraTreesClassifier`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class GradientBoostingClassifierDF(ClassifierDF, GradientBoostingClassifier):
-    """
-    Wraps :class:`sklearn.ensemble.gradient_boosting.GradientBoostingClassifier`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class AdaBoostClassifierDF(ClassifierDF, AdaBoostClassifier):
-    """
-    Wraps :class:`sklearn.ensemble.weight_boosting.AdaBoostClassifier`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class BaggingClassifierDF(ClassifierDF, BaggingClassifier):
-    """
-    Wraps :class:`sklearn.ensemble.bagging.BaggingClassifier`; accepts and returns data
-    frames.
-    """
-
-    pass
+RandomForestClassifierDF = make_df_classifier(RandomForestClassifier)
+ExtraTreesClassifierDF = make_df_classifier(ExtraTreesClassifier)
+GradientBoostingClassifierDF = make_df_classifier(GradientBoostingClassifier)
+AdaBoostClassifierDF = make_df_classifier(AdaBoostClassifier)
+BaggingClassifierDF = make_df_classifier(BaggingClassifier)
 
 
 #
 # tree
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class DecisionTreeClassifierDF(ClassifierDF, DecisionTreeClassifier):
-    """
-    Wraps :class:`sklearn.tree.tree.DecisionTreeClassifier`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class ExtraTreeClassifierDF(ClassifierDF, ExtraTreeClassifier):
-    """
-    Wraps :class:`sklearn.tree.tree.ExtraTreeClassifier`; accepts and returns data
-    frames.
-    """
-
-    pass
+DecisionTreeClassifierDF = make_df_classifier(DecisionTreeClassifier)
+ExtraTreeClassifierDF = make_df_classifier(ExtraTreeClassifier)
 
 
 #
 # discriminant analysis
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class QuadraticDiscriminantAnalysisDF(ClassifierDF, QuadraticDiscriminantAnalysis):
-    """
-    Wraps :class:`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`; accepts
-    and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class LinearDiscriminantAnalysisDF(ClassifierDF, LinearDiscriminantAnalysis):
-    """
-    Wraps :class:`sklearn.discriminant_analysis.LinearDiscriminantAnalysis`; accepts and
-    returns data frames.
-    """
-
-    pass
+QuadraticDiscriminantAnalysisDF = make_df_classifier(QuadraticDiscriminantAnalysis)
+LinearDiscriminantAnalysisDF = make_df_classifier(LinearDiscriminantAnalysis)
 
 
 #
@@ -302,110 +169,35 @@ class LinearDiscriminantAnalysisDF(ClassifierDF, LinearDiscriminantAnalysis):
 #
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class GaussianNBDF(ClassifierDF, GaussianNB):
-    """
-    Wraps :class:`sklearn.naive_bayes.GaussianNB`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class MultinomialNBDF(ClassifierDF, MultinomialNB):
-    """
-    Wraps :class:`sklearn.naive_bayes.MultinomialNB`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class ComplementNBDF(ClassifierDF, ComplementNB):
-    """
-    Wraps :class:`sklearn.naive_bayes.ComplementNB`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class BernoulliNBDF(ClassifierDF, BernoulliNB):
-    """
-    Wraps :class:`sklearn.naive_bayes.BernoulliNB`; accepts and returns data frames.
-    """
-
-    pass
+GaussianNBDF = make_df_classifier(GaussianNB)
+MultinomialNBDF = make_df_classifier(MultinomialNB)
+ComplementNBDF = make_df_classifier(ComplementNB)
+BernoulliNBDF = make_df_classifier(BernoulliNB)
 
 
 #
 # calibration
 #
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MetaClassifierWrapperDF)
-class CalibratedClassifierCVDF(ClassifierDF, CalibratedClassifierCV):
-    """
-    Wraps :class:`sklearn.calibration.CalibratedClassifierCV`; accepts and returns data
-    frames.
-    """
-
-    pass
+CalibratedClassifierCVDF = make_df_classifier(
+    CalibratedClassifierCV, df_wrapper_type=_MetaClassifierWrapperDF
+)
 
 
 #
 # SVM
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class SVCDF(ClassifierDF, SVC):
-    """
-    Wraps :class:`sklearn.svm.classes.SVC`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class NuSVCDF(ClassifierDF, NuSVC):
-    """
-    Wraps :class:`sklearn.svm.classes.NuSVC`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class LinearSVCDF(ClassifierDF, LinearSVC):
-    """
-    Wraps :class:`sklearn.svm.classes.LinearSVC`; accepts and returns data frames.
-    """
-
-    pass
+SVCDF = make_df_classifier(SVC)
+NuSVCDF = make_df_classifier(NuSVC)
+LinearSVCDF = make_df_classifier(LinearSVC)
 
 
 #
 # gaussian process
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class GaussianProcessClassifierDF(ClassifierDF, GaussianProcessClassifier):
-    """
-    Wraps :class:`sklearn.gaussian_process.gpc.GaussianProcessClassifier`; accepts and
-    returns data frames.
-    """
-
-    pass
+GaussianProcessClassifierDF = make_df_classifier(GaussianProcessClassifier)
 
 
 #
@@ -413,146 +205,38 @@ class GaussianProcessClassifierDF(ClassifierDF, GaussianProcessClassifier):
 #
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class LogisticRegressionDF(ClassifierDF, LogisticRegression):
-    """
-    Wraps :class:`sklearn.linear_model.logistic.LogisticRegression`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class LogisticRegressionCVDF(ClassifierDF, LogisticRegressionCV):
-    """
-    Wraps :class:`sklearn.linear_model.logistic.LogisticRegressionCV`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class PassiveAggressiveClassifierDF(ClassifierDF, PassiveAggressiveClassifier):
-    """
-    Wraps :class:`sklearn.linear_model.passive_aggressive.PassiveAggressiveClassifier`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class PerceptronDF(ClassifierDF, Perceptron):
-    """
-    Wraps :class:`sklearn.linear_model.perceptron.Perceptron`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class SGDClassifierDF(ClassifierDF, SGDClassifier):
-    """
-    Wraps :class:`sklearn.linear_model.stochastic_gradient.SGDClassifier`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class RidgeClassifierDF(ClassifierDF, RidgeClassifier):
-    """
-    Wraps :class:`sklearn.linear_model.ridge.RidgeClassifier`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class RidgeClassifierCVDF(ClassifierDF, RidgeClassifierCV):
-    """
-    Wraps :class:`sklearn.linear_model.ridge.RidgeClassifierCV`; accepts and returns
-    data frames.
-    """
-
-    pass
+LogisticRegressionDF = make_df_classifier(LogisticRegression)
+LogisticRegressionCVDF = make_df_classifier(LogisticRegressionCV)
+PassiveAggressiveClassifierDF = make_df_classifier(PassiveAggressiveClassifier)
+PerceptronDF = make_df_classifier(Perceptron)
+SGDClassifierDF = make_df_classifier(SGDClassifier)
+RidgeClassifierDF = make_df_classifier(RidgeClassifier)
+RidgeClassifierCVDF = make_df_classifier(RidgeClassifierCV)
 
 
 #
 # semi-supervised
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class LabelPropagationDF(ClassifierDF, LabelPropagation):
-    """
-    Wraps :class:`sklearn.semi_supervised.label_propagation.LabelPropagation`; accepts
-    and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class LabelSpreadingDF(ClassifierDF, LabelSpreading):
-    """
-    Wraps :class:`sklearn.semi_supervised.label_propagation.LabelSpreading`; accepts and
-    returns data frames.
-    """
-
-    pass
+LabelPropagationDF = make_df_classifier(LabelPropagation)
+LabelSpreadingDF = make_df_classifier(LabelSpreading)
 
 
 #
 # multi-class
 #
 
+OneVsRestClassifierDF = make_df_classifier(
+    OneVsRestClassifier, df_wrapper_type=_MetaClassifierWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MetaClassifierWrapperDF)
-class OneVsRestClassifierDF(ClassifierDF, OneVsRestClassifier):
-    """
-    Wraps :class:`sklearn.multiclass.OneVsRestClassifier`; accepts and returns data
-    frames.
-    """
+OneVsOneClassifierDF = make_df_classifier(
+    OneVsOneClassifier, df_wrapper_type=_MetaClassifierWrapperDF
+)
 
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MetaClassifierWrapperDF)
-class OneVsOneClassifierDF(ClassifierDF, OneVsOneClassifier):
-    """
-    Wraps :class:`sklearn.multiclass.OneVsOneClassifier`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MetaClassifierWrapperDF)
-class OutputCodeClassifierDF(ClassifierDF, OutputCodeClassifier):
-    """
-    Wraps :class:`sklearn.multiclass.OutputCodeClassifier`; accepts and returns data
-    frames.
-    """
-
-    pass
+OutputCodeClassifierDF = make_df_classifier(
+    OutputCodeClassifier, df_wrapper_type=_MetaClassifierWrapperDF
+)
 
 
 #
@@ -606,15 +290,9 @@ class _MultiOutputClassifierWrapperDF(
             ]
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MultiOutputClassifierWrapperDF)
-class MultiOutputClassifierDF(ClassifierDF, MultiOutputClassifier):
-    """
-    Wraps :class:`sklearn.multioutput.MultiOutputClassifier`; accepts and returns data
-    frames.
-    """
-
-    pass
+MultiOutputClassifierDF = make_df_classifier(
+    MultiOutputClassifier, df_wrapper_type=_MultiOutputClassifierWrapperDF
+)
 
 
 #
@@ -637,31 +315,21 @@ class _ClassifierChainWrapperDF(
         )
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierChainWrapperDF)
-class ClassifierChainDF(ClassifierDF, ClassifierChain):
-    """
-    Wraps :class:`sklearn.multioutput.ClassifierChain`; accepts and returns data frames.
-    """
-
-    pass
+ClassifierChainDF = make_df_classifier(
+    ClassifierChain, df_wrapper_type=_ClassifierChainWrapperDF
+)
 
 
 #
 # neural network
 #
 
+MLPClassifierDF = make_df_classifier(MLPClassifier)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class MLPClassifierDF(ClassifierDF, MLPClassifier):
-    """
-    Wraps :class:`sklearn.neural_network.multilayer_perceptron.MLPClassifier`; accepts
-    and returns data frames.
-    """
 
-    pass
-
+#
+# validate __all__
+#
 
 __tracker.validate()
 

--- a/src/sklearndf/classification/_classification.py
+++ b/src/sklearndf/classification/_classification.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.classification`
 """
+import functools
 import logging
 from abc import ABCMeta
 from typing import Any, List, Optional, Sequence, Union
@@ -104,6 +105,15 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 #
 
 __tracker = AllTracker(globals())
+
+
+#
+# Set the module for new DF classes
+#
+
+make_df_classifier = functools.partial(
+    make_df_classifier, module="sklearndf.classification"
+)
 
 
 #

--- a/src/sklearndf/classification/_classification.py
+++ b/src/sklearndf/classification/_classification.py
@@ -1,7 +1,6 @@
 """
 Core implementation of :mod:`sklearndf.classification`
 """
-import functools
 import logging
 from abc import ABCMeta
 from typing import Any, List, Optional, Sequence, Union
@@ -105,15 +104,6 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 #
 
 __tracker = AllTracker(globals())
-
-
-#
-# Set the module for new DF classes
-#
-
-make_df_classifier = functools.partial(
-    make_df_classifier, module="sklearndf.classification"
-)
 
 
 #

--- a/src/sklearndf/classification/_classification_v0_22.py
+++ b/src/sklearndf/classification/_classification_v0_22.py
@@ -10,8 +10,7 @@ from sklearn.naive_bayes import CategoricalNB
 
 from pytools.api import AllTracker
 
-from .. import ClassifierDF
-from .._wrapper import _ClassifierWrapperDF, _StackingClassifierWrapperDF, df_estimator
+from .._wrapper import _StackingClassifierWrapperDF, make_df_classifier
 
 log = logging.getLogger(__name__)
 
@@ -31,35 +30,22 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-
 # todo: add other classification implementations for sklearn 0.22
 
 #
 # naive bayes
 #
 
-# noinspection PyAbstractClass
+CategoricalNBDF = make_df_classifier(CategoricalNB)
+
+StackingClassifierDF = make_df_classifier(
+    StackingClassifier, df_wrapper_type=_StackingClassifierWrapperDF
+)
 
 
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class CategoricalNBDF(ClassifierDF, CategoricalNB):
-    """
-    Wraps :class:`sklearn.naive_bayes.CategoricalNB`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_StackingClassifierWrapperDF)
-class StackingClassifierDF(ClassifierDF, StackingClassifier):
-    """
-    Wraps :class:`sklearn.ensemble._stacking.StackingClassifier`;
-    accepts and returns data frames.
-    """
-
-    pass
-
+#
+# validate __all__
+#
 
 __tracker.validate()
 

--- a/src/sklearndf/classification/_classification_v0_22.py
+++ b/src/sklearndf/classification/_classification_v0_22.py
@@ -2,7 +2,7 @@
 Additional implementation of :mod:`sklearndf.classification` loaded
 from sklearn 0.22 onwards
 """
-
+import functools
 import logging
 
 from sklearn.ensemble import StackingClassifier
@@ -24,6 +24,15 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 #
 
 __tracker = AllTracker(globals())
+
+
+#
+# Set the module for new DF classes
+#
+
+make_df_classifier = functools.partial(
+    make_df_classifier, module="sklearndf.classification"
+)
 
 
 #

--- a/src/sklearndf/classification/_classification_v0_22.py
+++ b/src/sklearndf/classification/_classification_v0_22.py
@@ -38,7 +38,7 @@ __tracker = AllTracker(globals())
 CategoricalNBDF = make_df_classifier(CategoricalNB)
 
 StackingClassifierDF = make_df_classifier(
-    StackingClassifier, df_wrapper_type=_StackingClassifierWrapperDF
+    StackingClassifier, base_wrapper=_StackingClassifierWrapperDF
 )
 
 

--- a/src/sklearndf/classification/_classification_v0_22.py
+++ b/src/sklearndf/classification/_classification_v0_22.py
@@ -2,7 +2,6 @@
 Additional implementation of :mod:`sklearndf.classification` loaded
 from sklearn 0.22 onwards
 """
-import functools
 import logging
 
 from sklearn.ensemble import StackingClassifier
@@ -24,15 +23,6 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 #
 
 __tracker = AllTracker(globals())
-
-
-#
-# Set the module for new DF classes
-#
-
-make_df_classifier = functools.partial(
-    make_df_classifier, module="sklearndf.classification"
-)
 
 
 #

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -6,8 +6,7 @@ import warnings
 
 from pytools.api import AllTracker
 
-from ... import ClassifierDF
-from ..._wrapper import _ClassifierWrapperDF, df_estimator
+from ..._wrapper import make_df_classifier
 
 # since we install LGBM via conda, the warning about the Clang compiler is irrelevant
 warnings.filterwarnings("ignore", message=r"Starting from version 2\.2\.1")
@@ -35,20 +34,7 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-
-#
-# lightgbm
-#
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ClassifierWrapperDF)
-class LGBMClassifierDF(ClassifierDF, LGBMClassifier):
-    """
-    Wraps :class:`lightgbm.sklearn.LGBMClassifier`; accepts and returns data frames.
-    """
-
-    pass
+LGBMClassifierDF = make_df_classifier(LGBMClassifier)
 
 
 #

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -34,7 +34,9 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-LGBMClassifierDF = make_df_classifier(LGBMClassifier)
+LGBMClassifierDF = make_df_classifier(
+    LGBMClassifier, module="sklearndf.classification.extra"
+)
 
 
 #

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -34,9 +34,7 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-LGBMClassifierDF = make_df_classifier(
-    LGBMClassifier, module="sklearndf.classification.extra"
-)
+LGBMClassifierDF = make_df_classifier(LGBMClassifier)
 
 
 #

--- a/src/sklearndf/pipeline/_pipeline.py
+++ b/src/sklearndf/pipeline/_pipeline.py
@@ -197,7 +197,9 @@ class _PipelineWrapperDF(
         return self.feature_names_in_
 
 
-PipelineDF = make_df_estimator(Pipeline, df_wrapper_type=_PipelineWrapperDF)
+PipelineDF = make_df_estimator(
+    Pipeline, module="sklearndf.pipeline", df_wrapper_type=_PipelineWrapperDF
+)
 
 
 class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCMeta):
@@ -255,7 +257,7 @@ class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCM
 
 
 FeatureUnionDF = make_df_transformer(
-    FeatureUnion, df_wrapper_type=_FeatureUnionWrapperDF
+    FeatureUnion, module="sklearndf.pipeline", df_wrapper_type=_FeatureUnionWrapperDF
 )
 
 

--- a/src/sklearndf/pipeline/_pipeline.py
+++ b/src/sklearndf/pipeline/_pipeline.py
@@ -197,9 +197,7 @@ class _PipelineWrapperDF(
         return self.feature_names_in_
 
 
-PipelineDF = make_df_estimator(
-    Pipeline, module="sklearndf.pipeline", df_wrapper_type=_PipelineWrapperDF
-)
+PipelineDF = make_df_estimator(Pipeline, df_wrapper_type=_PipelineWrapperDF)
 
 
 class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCMeta):
@@ -257,7 +255,7 @@ class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCM
 
 
 FeatureUnionDF = make_df_transformer(
-    FeatureUnion, module="sklearndf.pipeline", df_wrapper_type=_FeatureUnionWrapperDF
+    FeatureUnion, df_wrapper_type=_FeatureUnionWrapperDF
 )
 
 

--- a/src/sklearndf/pipeline/_pipeline.py
+++ b/src/sklearndf/pipeline/_pipeline.py
@@ -197,7 +197,7 @@ class _PipelineWrapperDF(
         return self.feature_names_in_
 
 
-PipelineDF = make_df_estimator(Pipeline, df_wrapper_type=_PipelineWrapperDF)
+PipelineDF = make_df_estimator(Pipeline, base_wrapper=_PipelineWrapperDF)
 
 
 class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCMeta):
@@ -254,9 +254,7 @@ class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCM
             return indices[0].append(other=indices[1:])
 
 
-FeatureUnionDF = make_df_transformer(
-    FeatureUnion, df_wrapper_type=_FeatureUnionWrapperDF
-)
+FeatureUnionDF = make_df_transformer(FeatureUnion, base_wrapper=_FeatureUnionWrapperDF)
 
 
 __tracker.validate()

--- a/src/sklearndf/pipeline/_pipeline.py
+++ b/src/sklearndf/pipeline/_pipeline.py
@@ -19,6 +19,7 @@ from .._wrapper import (
     _RegressorWrapperDF,
     _TransformerWrapperDF,
     df_estimator,
+    make_df_transformer,
 )
 
 log = logging.getLogger(__name__)
@@ -261,15 +262,9 @@ class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCM
             return indices[0].append(other=indices[1:])
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureUnionWrapperDF)
-class FeatureUnionDF(TransformerDF, FeatureUnion):
-    """
-    Wraps :class:`sklearn.pipeline.FeatureUnion` for enhanced support of pandas data
-    frames.
-    """
-
-    pass
+FeatureUnionDF = make_df_transformer(
+    FeatureUnion, df_wrapper_type=_FeatureUnionWrapperDF
+)
 
 
 __tracker.validate()

--- a/src/sklearndf/pipeline/_pipeline.py
+++ b/src/sklearndf/pipeline/_pipeline.py
@@ -13,12 +13,12 @@ from sklearn.pipeline import FeatureUnion, Pipeline
 
 from pytools.api import AllTracker
 
-from .. import ClassifierDF, EstimatorDF, RegressorDF, TransformerDF
+from .. import EstimatorDF, TransformerDF
 from .._wrapper import (
     _ClassifierWrapperDF,
     _RegressorWrapperDF,
     _TransformerWrapperDF,
-    df_estimator,
+    make_df_estimator,
     make_df_transformer,
 )
 
@@ -197,15 +197,7 @@ class _PipelineWrapperDF(
         return self.feature_names_in_
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_PipelineWrapperDF)
-class PipelineDF(ClassifierDF, RegressorDF, TransformerDF, Pipeline):
-    """
-    Wraps :class:`sklearn.pipeline.Pipeline`; accepts and returns data
-    frames.
-    """
-
-    pass
+PipelineDF = make_df_estimator(Pipeline, df_wrapper_type=_PipelineWrapperDF)
 
 
 class _FeatureUnionWrapperDF(_TransformerWrapperDF[FeatureUnion], metaclass=ABCMeta):

--- a/src/sklearndf/regression/_regression.py
+++ b/src/sklearndf/regression/_regression.py
@@ -175,11 +175,11 @@ NuSVRDF = make_df_regressor(NuSVR)
 #
 
 MultiOutputRegressorDF = make_df_regressor(
-    MultiOutputRegressor, df_wrapper_type=_MetaRegressorWrapperDF
+    MultiOutputRegressor, base_wrapper=_MetaRegressorWrapperDF
 )
 
 RegressorChainDF = make_df_regressor(
-    RegressorChain, df_wrapper_type=_MetaRegressorWrapperDF
+    RegressorChain, base_wrapper=_MetaRegressorWrapperDF
 )
 
 
@@ -235,7 +235,7 @@ LassoLarsCVDF = make_df_regressor(LassoLarsCV)
 
 BaggingRegressorDF = make_df_regressor(BaggingRegressor)
 VotingRegressorDF = make_df_regressor(
-    VotingRegressor, df_wrapper_type=_MetaRegressorWrapperDF
+    VotingRegressor, base_wrapper=_MetaRegressorWrapperDF
 )
 GradientBoostingRegressorDF = make_df_regressor(GradientBoostingRegressor)
 AdaBoostRegressorDF = make_df_regressor(AdaBoostRegressor)
@@ -278,7 +278,7 @@ class _IsotonicRegressionWrapperDF(
 
 
 IsotonicRegressionDF = make_df_regressor(
-    IsotonicRegression, df_wrapper_type=_IsotonicRegressionWrapperDF
+    IsotonicRegression, base_wrapper=_IsotonicRegressionWrapperDF
 )
 
 
@@ -309,14 +309,14 @@ ExtraTreeRegressorDF = make_df_regressor(ExtraTreeRegressor)
 #
 
 
-CCADF = make_df_regressor(CCA, df_wrapper_type=_RegressorTransformerWrapperDF)
+CCADF = make_df_regressor(CCA, base_wrapper=_RegressorTransformerWrapperDF)
 
 PLSRegressionDF = make_df_regressor(
-    PLSRegression, df_wrapper_type=_RegressorTransformerWrapperDF
+    PLSRegression, base_wrapper=_RegressorTransformerWrapperDF
 )
 
 PLSCanonicalDF = make_df_regressor(
-    PLSCanonical, df_wrapper_type=_RegressorTransformerWrapperDF
+    PLSCanonical, base_wrapper=_RegressorTransformerWrapperDF
 )
 
 

--- a/src/sklearndf/regression/_regression.py
+++ b/src/sklearndf/regression/_regression.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.regression`
 """
+import functools
 import logging
 from abc import ABCMeta
 from typing import Any, Generic, Optional, TypeVar, Union
@@ -130,10 +131,17 @@ T_Regressor = TypeVar("T_Regressor", bound=RegressorMixin)
 
 __tracker = AllTracker(globals())
 
+#
+# Set the module for new DF classes
+#
+
+make_df_regressor = functools.partial(make_df_regressor, module="sklearndf.regression")
+
 
 #
 # Class definitions
 #
+
 
 #
 # wrapper for hybrid regressor/transformer classes

--- a/src/sklearndf/regression/_regression.py
+++ b/src/sklearndf/regression/_regression.py
@@ -56,8 +56,7 @@ from sklearn.tree import DecisionTreeRegressor, ExtraTreeRegressor
 
 from pytools.api import AllTracker
 
-from .. import RegressorDF, TransformerDF
-from .._wrapper import _MetaRegressorWrapperDF, _RegressorWrapperDF, df_estimator
+from .._wrapper import _MetaRegressorWrapperDF, _RegressorWrapperDF, make_df_regressor
 
 # noinspection PyProtectedMember
 from ..transformation._wrapper import _ColumnPreservingTransformerWrapperDF
@@ -158,485 +157,96 @@ class _RegressorTransformerWrapperDF(
 # Dummy
 #
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class DummyRegressorDF(RegressorDF, DummyRegressor):
-    """
-    Wraps :class:`sklearn.dummy.DummyRegressor`; accepts and
-    returns data frames.
-    """
-
-    pass
+DummyRegressorDF = make_df_regressor(DummyRegressor)
 
 
 #
 # SVM
 #
 
-
-# noinspection PyAbstractClass
-
-
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LinearSVRDF(RegressorDF, LinearSVR):
-    """
-    Wraps :class:`sklearn.svm.classes.LinearSVR`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class SVRDF(RegressorDF, SVR):
-    """
-    Wraps :class:`sklearn.svm.classes.SVR`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class NuSVRDF(RegressorDF, NuSVR):
-    """
-    Wraps :class:`sklearn.svm.classes.NuSVR`; accepts and returns data frames.
-    """
-
-    pass
+LinearSVRDF = make_df_regressor(LinearSVR)
+SVRDF = make_df_regressor(SVR)
+NuSVRDF = make_df_regressor(NuSVR)
 
 
 #
 # multi-output
 #
 
+MultiOutputRegressorDF = make_df_regressor(
+    MultiOutputRegressor, df_wrapper_type=_MetaRegressorWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MetaRegressorWrapperDF)
-class MultiOutputRegressorDF(RegressorDF, MultiOutputRegressor):
-    """
-    Wraps :class:`sklearn.multioutput.MultiOutputRegressor`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MetaRegressorWrapperDF)
-class RegressorChainDF(RegressorDF, RegressorChain):
-    """
-    Wraps :class:`sklearn.multioutput.RegressorChain`; accepts and returns data frames.
-    """
-
-    pass
+RegressorChainDF = make_df_regressor(
+    RegressorChain, df_wrapper_type=_MetaRegressorWrapperDF
+)
 
 
 #
 # neighbors
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class KNeighborsRegressorDF(RegressorDF, KNeighborsRegressor):
-    """
-    Wraps :class:`sklearn.neighbors.regression.KNeighborsRegressor`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class RadiusNeighborsRegressorDF(RegressorDF, RadiusNeighborsRegressor):
-    """
-    Wraps :class:`sklearn.neighbors.regression.RadiusNeighborsRegressor`; accepts and
-    returns data frames.
-    """
-
-    pass
+KNeighborsRegressorDF = make_df_regressor(KNeighborsRegressor)
+RadiusNeighborsRegressorDF = make_df_regressor(RadiusNeighborsRegressor)
 
 
 #
 # neural_network
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class MLPRegressorDF(RegressorDF, MLPRegressor):
-    """
-    Wraps :class:`sklearn.neural_network.multilayer_perceptron.MLPRegressor`; accepts
-    and returns data frames.
-    """
-
-    pass
+MLPRegressorDF = make_df_regressor(MLPRegressor)
 
 
 #
 # linear_model
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LinearRegressionDF(RegressorDF, LinearRegression):
-    """
-    Wraps :class:`sklearn.linear_model.base.LinearRegression`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class RidgeDF(RegressorDF, Ridge):
-    """
-    Wraps :class:`sklearn.linear_model.ridge.Ridge`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class RidgeCVDF(RegressorDF, RidgeCV):
-    """
-    Wraps :class:`sklearn.linear_model.ridge.RidgeCV`; accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class SGDRegressorDF(RegressorDF, SGDRegressor):
-    """
-    Wraps :class:`sklearn.linear_model.stochastic_gradient.SGDRegressor`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class HuberRegressorDF(RegressorDF, HuberRegressor):
-    """
-    Wraps :class:`sklearn.linear_model.huber.HuberRegressor`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class TheilSenRegressorDF(RegressorDF, TheilSenRegressor):
-    """
-    Wraps :class:`sklearn.linear_model.theil_sen.TheilSenRegressor`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class BayesianRidgeDF(RegressorDF, BayesianRidge):
-    """
-    Wraps :class:`sklearn.linear_model.bayes.BayesianRidge`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class ARDRegressionDF(RegressorDF, ARDRegression):
-    """
-    Wraps :class:`sklearn.linear_model.bayes.ARDRegression`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class OrthogonalMatchingPursuitDF(RegressorDF, OrthogonalMatchingPursuit):
-    """
-    Wraps :class:`sklearn.linear_model.omp.OrthogonalMatchingPursuit`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class OrthogonalMatchingPursuitCVDF(RegressorDF, OrthogonalMatchingPursuitCV):
-    """
-    Wraps :class:`sklearn.linear_model.omp.OrthogonalMatchingPursuitCV`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class RANSACRegressorDF(RegressorDF, RANSACRegressor):
-    """
-    Wraps :class:`sklearn.linear_model.ransac.RANSACRegressor`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class ElasticNetDF(RegressorDF, ElasticNet):
-    """
-    Wraps :class:`sklearn.linear_model.coordinate_descent.ElasticNet`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LassoCVDF(RegressorDF, LassoCV):
-    """
-    Wraps :class:`sklearn.linear_model.coordinate_descent.LassoCV`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class ElasticNetCVDF(RegressorDF, ElasticNetCV):
-    """
-    Wraps :class:`sklearn.linear_model.coordinate_descent.ElasticNetCV`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class MultiTaskElasticNetCVDF(RegressorDF, MultiTaskElasticNetCV):
-    """
-    Wraps :class:`sklearn.linear_model.coordinate_descent.MultiTaskElasticNetCV`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class MultiTaskLassoCVDF(RegressorDF, MultiTaskLassoCV):
-    """
-    Wraps :class:`sklearn.linear_model.coordinate_descent.MultiTaskLassoCV`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class MultiTaskElasticNetDF(RegressorDF, MultiTaskElasticNet):
-    """
-    Wraps :class:`sklearn.linear_model.coordinate_descent.MultiTaskElasticNet`; accepts
-    and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class MultiTaskLassoDF(RegressorDF, MultiTaskLasso):
-    """
-    Wraps :class:`sklearn.linear_model.coordinate_descent.MultiTaskLasso`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LassoDF(RegressorDF, Lasso):
-    """
-    Wraps :class:`sklearn.linear_model.coordinate_descent.Lasso`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class PassiveAggressiveRegressorDF(RegressorDF, PassiveAggressiveRegressor):
-    """
-    Wraps :class:`sklearn.linear_model.passive_aggressive.PassiveAggressiveRegressor`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LarsDF(RegressorDF, Lars):
-    """
-    Wraps :class:`sklearn.linear_model.least_angle.Lars`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LassoLarsDF(RegressorDF, LassoLars):
-    """
-    Wraps :class:`sklearn.linear_model.least_angle.LassoLars`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LassoLarsICDF(RegressorDF, LassoLarsIC):
-    """
-    Wraps :class:`sklearn.linear_model.least_angle.LassoLarsIC`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LarsCVDF(RegressorDF, LarsCV):
-    """
-    Wraps :class:`sklearn.linear_model.least_angle.LarsCV`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LassoLarsCVDF(RegressorDF, LassoLarsCV):
-    """
-    Wraps :class:`sklearn.linear_model.least_angle.LassoLarsCV`; accepts and returns
-    data frames.
-    """
-
-    pass
+LinearRegressionDF = make_df_regressor(LinearRegression)
+RidgeDF = make_df_regressor(Ridge)
+RidgeCVDF = make_df_regressor(RidgeCV)
+SGDRegressorDF = make_df_regressor(SGDRegressor)
+HuberRegressorDF = make_df_regressor(HuberRegressor)
+TheilSenRegressorDF = make_df_regressor(TheilSenRegressor)
+BayesianRidgeDF = make_df_regressor(BayesianRidge)
+ARDRegressionDF = make_df_regressor(ARDRegression)
+OrthogonalMatchingPursuitDF = make_df_regressor(OrthogonalMatchingPursuit)
+OrthogonalMatchingPursuitCVDF = make_df_regressor(OrthogonalMatchingPursuitCV)
+RANSACRegressorDF = make_df_regressor(RANSACRegressor)
+ElasticNetDF = make_df_regressor(ElasticNet)
+LassoCVDF = make_df_regressor(LassoCV)
+ElasticNetCVDF = make_df_regressor(ElasticNetCV)
+MultiTaskElasticNetCVDF = make_df_regressor(MultiTaskElasticNetCV)
+MultiTaskLassoCVDF = make_df_regressor(MultiTaskLassoCV)
+MultiTaskElasticNetDF = make_df_regressor(MultiTaskElasticNet)
+MultiTaskLassoDF = make_df_regressor(MultiTaskLasso)
+LassoDF = make_df_regressor(Lasso)
+PassiveAggressiveRegressorDF = make_df_regressor(PassiveAggressiveRegressor)
+LarsDF = make_df_regressor(Lars)
+LassoLarsDF = make_df_regressor(LassoLars)
+LassoLarsICDF = make_df_regressor(LassoLarsIC)
+LarsCVDF = make_df_regressor(LarsCV)
+LassoLarsCVDF = make_df_regressor(LassoLarsCV)
 
 
 #
 # ensemble
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class BaggingRegressorDF(RegressorDF, BaggingRegressor):
-    """
-    Wraps :class:`sklearn.ensemble.bagging.BaggingRegressor`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MetaRegressorWrapperDF)
-class VotingRegressorDF(RegressorDF, VotingRegressor):
-    """
-    Wraps :class:`sklearn.ensemble.voting.VotingRegressor`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class GradientBoostingRegressorDF(RegressorDF, GradientBoostingRegressor):
-    """
-    Wraps :class:`sklearn.ensemble.gradient_boosting.GradientBoostingRegressor`; accepts
-    and returns data frames.
-    """
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class AdaBoostRegressorDF(RegressorDF, AdaBoostRegressor):
-    """
-    Wraps :class:`sklearn.ensemble.weight_boosting.AdaBoostRegressor`; accepts and
-    returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class RandomForestRegressorDF(RegressorDF, RandomForestRegressor):
-    """
-    Wraps :class:`sklearn.ensemble.forest.RandomForestRegressor`; accepts and returns
-    data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class ExtraTreesRegressorDF(RegressorDF, ExtraTreesRegressor):
-    """
-    Wraps :class:`sklearn.ensemble.forest.ExtraTreesRegressor`; accepts and returns data
-    frames.
-    """
-
-    pass
+BaggingRegressorDF = make_df_regressor(BaggingRegressor)
+VotingRegressorDF = make_df_regressor(
+    VotingRegressor, df_wrapper_type=_MetaRegressorWrapperDF
+)
+GradientBoostingRegressorDF = make_df_regressor(GradientBoostingRegressor)
+AdaBoostRegressorDF = make_df_regressor(AdaBoostRegressor)
+RandomForestRegressorDF = make_df_regressor(RandomForestRegressor)
+ExtraTreesRegressorDF = make_df_regressor(ExtraTreesRegressor)
 
 
 #
 # gaussian_process
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class GaussianProcessRegressorDF(RegressorDF, GaussianProcessRegressor):
-    """
-    Wraps :class:`sklearn.gaussian_process.gpr.GaussianProcessRegressor`; accepts and
-    returns data frames.
-    """
-
-    pass
+GaussianProcessRegressorDF = make_df_regressor(GaussianProcessRegressor)
 
 
 #
@@ -666,72 +276,31 @@ class _IsotonicRegressionWrapperDF(
         return None if y is None else y.values
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_IsotonicRegressionWrapperDF)
-class IsotonicRegressionDF(RegressorDF, TransformerDF, IsotonicRegression):
-    """
-    Wraps :class:`sklearn.isotonic.IsotonicRegression`; accepts and returns data frames.
-    """
-
-    pass
+IsotonicRegressionDF = make_df_regressor(
+    IsotonicRegression, df_wrapper_type=_IsotonicRegressionWrapperDF
+)
 
 
 #
 # compose
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class TransformedTargetRegressorDF(RegressorDF, TransformedTargetRegressor):
-    """
-    Wraps :class:`sklearn.compose._target.TransformedTargetRegressor`; accepts and
-    returns data frames.
-    """
-
-    pass
+TransformedTargetRegressorDF = make_df_regressor(TransformedTargetRegressor)
 
 
 #
 # kernel_ridge
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class KernelRidgeDF(RegressorDF, KernelRidge):
-    """
-    Wraps :class:`sklearn.kernel_ridge.KernelRidge`; accepts and returns data frames.
-    """
-
-    pass
+KernelRidgeDF = make_df_regressor(KernelRidge)
 
 
 #
 # tree
 #
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class DecisionTreeRegressorDF(RegressorDF, DecisionTreeRegressor):
-    """
-    Wraps :class:`sklearn.tree.tree.DecisionTreeRegressor`; accepts and returns data
-    frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class ExtraTreeRegressorDF(RegressorDF, ExtraTreeRegressor):
-    """
-    Wraps :class:`sklearn.tree.tree.ExtraTreeRegressor`; accepts and returns data
-    frames.
-    """
-
-    pass
+DecisionTreeRegressorDF = make_df_regressor(DecisionTreeRegressor)
+ExtraTreeRegressorDF = make_df_regressor(ExtraTreeRegressor)
 
 
 #
@@ -739,38 +308,20 @@ class ExtraTreeRegressorDF(RegressorDF, ExtraTreeRegressor):
 #
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorTransformerWrapperDF)
-class CCADF(RegressorDF, TransformerDF, CCA):
-    """
-    Wraps :class:`sklearn.cross_decomposition.cca_.CCA`; accepts and returns data
-    frames.
-    """
+CCADF = make_df_regressor(CCA, df_wrapper_type=_RegressorTransformerWrapperDF)
 
-    pass
+PLSRegressionDF = make_df_regressor(
+    PLSRegression, df_wrapper_type=_RegressorTransformerWrapperDF
+)
 
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorTransformerWrapperDF)
-class PLSRegressionDF(RegressorDF, TransformerDF, PLSRegression):
-    """
-    Wraps :class:`sklearn.cross_decomposition.pls_.PLSRegression`; accepts and returns
-    data frames.
-    """
-
-    pass
+PLSCanonicalDF = make_df_regressor(
+    PLSCanonical, df_wrapper_type=_RegressorTransformerWrapperDF
+)
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorTransformerWrapperDF)
-class PLSCanonicalDF(RegressorDF, TransformerDF, PLSCanonical):
-    """
-    Wraps :class:`sklearn.cross_decomposition.pls_.PLSCanonical`; accepts and returns
-    data frames.
-    """
-
-    pass
-
+#
+# validate __all__
+#
 
 __tracker.validate()
 

--- a/src/sklearndf/regression/_regression.py
+++ b/src/sklearndf/regression/_regression.py
@@ -1,7 +1,6 @@
 """
 Core implementation of :mod:`sklearndf.regression`
 """
-import functools
 import logging
 from abc import ABCMeta
 from typing import Any, Generic, Optional, TypeVar, Union
@@ -130,12 +129,6 @@ T_Regressor = TypeVar("T_Regressor", bound=RegressorMixin)
 #
 
 __tracker = AllTracker(globals())
-
-#
-# Set the module for new DF classes
-#
-
-make_df_regressor = functools.partial(make_df_regressor, module="sklearndf.regression")
 
 
 #

--- a/src/sklearndf/regression/_regression_v0_22.py
+++ b/src/sklearndf/regression/_regression_v0_22.py
@@ -37,9 +37,7 @@ __tracker = AllTracker(globals())
 #
 
 StackingRegressorDF = make_df_regressor(
-    StackingRegressor,
-    module="sklearndf.regression",
-    df_wrapper_type=_StackingRegressorWrapperDF,
+    StackingRegressor, df_wrapper_type=_StackingRegressorWrapperDF
 )
 
 

--- a/src/sklearndf/regression/_regression_v0_22.py
+++ b/src/sklearndf/regression/_regression_v0_22.py
@@ -37,7 +37,9 @@ __tracker = AllTracker(globals())
 #
 
 StackingRegressorDF = make_df_regressor(
-    StackingRegressor, df_wrapper_type=_StackingRegressorWrapperDF
+    StackingRegressor,
+    module="sklearndf.regression",
+    df_wrapper_type=_StackingRegressorWrapperDF,
 )
 
 

--- a/src/sklearndf/regression/_regression_v0_22.py
+++ b/src/sklearndf/regression/_regression_v0_22.py
@@ -10,10 +10,7 @@ from sklearn.ensemble import StackingRegressor
 
 from pytools.api import AllTracker
 
-from .. import RegressorDF
-from .._wrapper import _StackingRegressorWrapperDF, df_estimator
-
-# noinspection PyProtectedMember
+from .._wrapper import _StackingRegressorWrapperDF, make_df_regressor
 
 log = logging.getLogger(__name__)
 
@@ -39,17 +36,14 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
+StackingRegressorDF = make_df_regressor(
+    StackingRegressor, df_wrapper_type=_StackingRegressorWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_StackingRegressorWrapperDF)
-class StackingRegressorDF(RegressorDF, StackingRegressor):
-    """
-    Wraps :class:`sklearn.ensemble._stacking.StackingRegressor`; accepts and
-     returns data frames.
-    """
 
-    pass
-
+#
+# validate __all__
+#
 
 __tracker.validate()
 

--- a/src/sklearndf/regression/_regression_v0_22.py
+++ b/src/sklearndf/regression/_regression_v0_22.py
@@ -37,7 +37,7 @@ __tracker = AllTracker(globals())
 #
 
 StackingRegressorDF = make_df_regressor(
-    StackingRegressor, df_wrapper_type=_StackingRegressorWrapperDF
+    StackingRegressor, base_wrapper=_StackingRegressorWrapperDF
 )
 
 

--- a/src/sklearndf/regression/_regression_v0_23.py
+++ b/src/sklearndf/regression/_regression_v0_23.py
@@ -2,7 +2,7 @@
 Core implementation of :mod:`sklearndf.regression` loaded
 from sklearn 0.23 onwards
 """
-
+import functools
 import logging
 from typing import TypeVar
 
@@ -42,8 +42,16 @@ __tracker = AllTracker(globals())
 
 
 #
+# Set the module for new DF classes
+#
+
+make_df_regressor = functools.partial(make_df_regressor, module="sklearndf.regression")
+
+
+#
 # Class definitions
 #
+
 
 PoissonRegressorDF = make_df_regressor(PoissonRegressor)
 GammaRegressorDF = make_df_regressor(GammaRegressor)

--- a/src/sklearndf/regression/_regression_v0_23.py
+++ b/src/sklearndf/regression/_regression_v0_23.py
@@ -12,8 +12,7 @@ from sklearn.linear_model._glm import GeneralizedLinearRegressor
 
 from pytools.api import AllTracker
 
-from .. import RegressorDF
-from .._wrapper import _RegressorWrapperDF, df_estimator
+from .._wrapper import make_df_regressor
 
 # noinspection PyProtectedMember
 
@@ -46,55 +45,15 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
+PoissonRegressorDF = make_df_regressor(PoissonRegressor)
+GammaRegressorDF = make_df_regressor(GammaRegressor)
+TweedieRegressorDF = make_df_regressor(TweedieRegressor)
+GeneralizedLinearRegressorDF = make_df_regressor(GeneralizedLinearRegressor)
+
 
 #
-# GLM regressors added with v0.23
+# validate __all__
 #
-# noinspection PyAbstractClass
-
-
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class PoissonRegressorDF(RegressorDF, PoissonRegressor):
-    """
-    Wraps :class:`sklearn.linear_model._glm.glm.PoissonRegressor`; accepts and
-     returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class GammaRegressorDF(RegressorDF, GammaRegressor):
-    """
-    Wraps :class:`sklearn.linear_model._glm.glm.GammaRegressor`; accepts and
-     returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class TweedieRegressorDF(RegressorDF, TweedieRegressor):
-    """
-    Wraps :class:`sklearn.linear_model._glm.glm.TweedieRegressor`; accepts and
-     returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class GeneralizedLinearRegressorDF(RegressorDF, GeneralizedLinearRegressor):
-    """
-    Wraps :class:`sklearn.linear_model._glm.glm.GeneralizedLinearRegressor`; accepts and
-     returns data frames.
-    """
-
-    pass
-
 
 __tracker.validate()
 

--- a/src/sklearndf/regression/_regression_v0_23.py
+++ b/src/sklearndf/regression/_regression_v0_23.py
@@ -2,7 +2,6 @@
 Core implementation of :mod:`sklearndf.regression` loaded
 from sklearn 0.23 onwards
 """
-import functools
 import logging
 from typing import TypeVar
 
@@ -39,13 +38,6 @@ T_Regressor = TypeVar("T_Regressor", bound=RegressorMixin)
 #
 
 __tracker = AllTracker(globals())
-
-
-#
-# Set the module for new DF classes
-#
-
-make_df_regressor = functools.partial(make_df_regressor, module="sklearndf.regression")
 
 
 #

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -34,7 +34,7 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-LGBMRegressorDF = make_df_regressor(LGBMRegressor, module="sklearndf.regression.extra")
+LGBMRegressorDF = make_df_regressor(LGBMRegressor)
 
 
 #

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -34,7 +34,7 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-LGBMRegressorDF = make_df_regressor(LGBMRegressor)
+LGBMRegressorDF = make_df_regressor(LGBMRegressor, module="sklearndf.regression.extra")
 
 
 #

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -6,8 +6,7 @@ import warnings
 
 from pytools.api import AllTracker
 
-from ... import RegressorDF
-from ..._wrapper import _RegressorWrapperDF, df_estimator
+from ..._wrapper import make_df_regressor
 
 # since we install LGBM via conda, the warning about the Clang compiler is irrelevant
 warnings.filterwarnings("ignore", message=r"Starting from version 2\.2\.1")
@@ -35,21 +34,12 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
+LGBMRegressorDF = make_df_regressor(LGBMRegressor)
+
 
 #
-# lightgbm
+# validate __all__
 #
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_RegressorWrapperDF)
-class LGBMRegressorDF(RegressorDF, LGBMRegressor):
-    """
-    Wraps :class:`lightgbm.sklearn.LGBMRegressor`; accepts and returns data frames.
-    """
-
-    pass
-
 
 __tracker.validate()
 

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -40,7 +40,6 @@ from sklearn.decomposition import (
     SparsePCA,
     TruncatedSVD,
 )
-from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.feature_extraction import DictVectorizer, FeatureHasher
 from sklearn.feature_extraction.text import HashingVectorizer, TfidfTransformer
 from sklearn.feature_selection import (
@@ -126,7 +125,6 @@ __all__ = [
     "LabelBinarizerDF",
     "LabelEncoderDF",
     "LatentDirichletAllocationDF",
-    "LinearDiscriminantAnalysisDF",
     "LocallyLinearEmbeddingDF",
     "MaxAbsScalerDF",
     "MinMaxScalerDF",
@@ -648,17 +646,12 @@ TruncatedSVDDF = make_df_transformer(
 
 
 #
-# Transformer which have an n_components attribute
+# Transformers which have an n_components attribute
 # Implemented through NComponentsDimensionalityReductionWrapperDF
 #
 
 KernelPCADF = make_df_transformer(
     KernelPCA, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
-)
-
-LinearDiscriminantAnalysisDF = make_df_transformer(
-    LinearDiscriminantAnalysis,
-    df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF,
 )
 
 LocallyLinearEmbeddingDF = make_df_transformer(

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -190,7 +190,7 @@ __tracker = AllTracker(globals())
 
 
 FeatureAgglomerationDF = make_df_transformer(
-    FeatureAgglomeration, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    FeatureAgglomeration, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 
@@ -261,7 +261,7 @@ class _ColumnTransformerWrapperDF(
 
 
 ColumnTransformerDF = make_df_transformer(
-    ColumnTransformer, df_wrapper_type=_ColumnTransformerWrapperDF
+    ColumnTransformer, base_wrapper=_ColumnTransformerWrapperDF
 )
 
 
@@ -271,23 +271,23 @@ ColumnTransformerDF = make_df_transformer(
 
 
 PLSSVDDF = make_df_transformer(
-    PLSSVD, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    PLSSVD, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 FeatureHasherDF = make_df_transformer(
-    FeatureHasher, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    FeatureHasher, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 DictVectorizerDF = make_df_transformer(
-    DictVectorizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    DictVectorizer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 HashingVectorizerDF = make_df_transformer(
-    HashingVectorizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    HashingVectorizer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 TfidfTransformerDF = make_df_transformer(
-    TfidfTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    TfidfTransformer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 
@@ -353,7 +353,7 @@ class _ImputerWrapperDF(_TransformerWrapperDF[T_Imputer], metaclass=ABCMeta):
             return features_original
 
 
-SimpleImputerDF = make_df_transformer(SimpleImputer, df_wrapper_type=_ImputerWrapperDF)
+SimpleImputerDF = make_df_transformer(SimpleImputer, base_wrapper=_ImputerWrapperDF)
 
 
 class _MissingIndicatorWrapperDF(
@@ -368,11 +368,11 @@ class _MissingIndicatorWrapperDF(
 
 
 MissingIndicatorDF = make_df_transformer(
-    MissingIndicator, df_wrapper_type=_MissingIndicatorWrapperDF
+    MissingIndicator, base_wrapper=_MissingIndicatorWrapperDF
 )
 
 IterativeImputerDF = make_df_transformer(
-    IterativeImputer, df_wrapper_type=_ImputerWrapperDF
+    IterativeImputer, base_wrapper=_ImputerWrapperDF
 )
 
 
@@ -384,7 +384,7 @@ class _IsomapWrapperDF(
         return self.native_estimator.embedding_.shape[1]
 
 
-IsomapDF = make_df_transformer(Isomap, df_wrapper_type=_IsomapWrapperDF)
+IsomapDF = make_df_transformer(Isomap, base_wrapper=_IsomapWrapperDF)
 
 
 class _AdditiveChi2SamplerWrapperDF(
@@ -396,7 +396,7 @@ class _AdditiveChi2SamplerWrapperDF(
 
 
 AdditiveChi2SamplerDF = make_df_transformer(
-    AdditiveChi2Sampler, df_wrapper_type=_AdditiveChi2SamplerWrapperDF
+    AdditiveChi2Sampler, base_wrapper=_AdditiveChi2SamplerWrapperDF
 )
 
 
@@ -406,7 +406,7 @@ AdditiveChi2SamplerDF = make_df_transformer(
 
 NeighborhoodComponentsAnalysisDF = make_df_transformer(
     NeighborhoodComponentsAnalysis,
-    df_wrapper_type=_ColumnPreservingTransformerWrapperDF,
+    base_wrapper=_ColumnPreservingTransformerWrapperDF,
 )
 
 
@@ -416,19 +416,19 @@ NeighborhoodComponentsAnalysisDF = make_df_transformer(
 
 
 MinMaxScalerDF = make_df_transformer(
-    MinMaxScaler, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    MinMaxScaler, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 StandardScalerDF = make_df_transformer(
-    StandardScaler, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    StandardScaler, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 MaxAbsScalerDF = make_df_transformer(
-    MaxAbsScaler, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    MaxAbsScaler, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 RobustScalerDF = make_df_transformer(
-    RobustScaler, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    RobustScaler, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 
@@ -445,43 +445,43 @@ class _PolynomialFeaturesWrapperDF(
 
 
 PolynomialFeaturesDF = make_df_transformer(
-    PolynomialFeatures, df_wrapper_type=_PolynomialFeaturesWrapperDF
+    PolynomialFeatures, base_wrapper=_PolynomialFeaturesWrapperDF
 )
 
 NormalizerDF = make_df_transformer(
-    Normalizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    Normalizer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 BinarizerDF = make_df_transformer(
-    Binarizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    Binarizer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 KernelCentererDF = make_df_transformer(
-    KernelCenterer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    KernelCenterer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 QuantileTransformerDF = make_df_transformer(
-    QuantileTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    QuantileTransformer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 PowerTransformerDF = make_df_transformer(
-    PowerTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    PowerTransformer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 FunctionTransformerDF = make_df_transformer(
-    FunctionTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    FunctionTransformer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 LabelEncoderDF = make_df_transformer(
-    LabelEncoder, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    LabelEncoder, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 LabelBinarizerDF = make_df_transformer(
-    LabelBinarizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    LabelBinarizer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 MultiLabelBinarizerDF = make_df_transformer(
-    MultiLabelBinarizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    MultiLabelBinarizer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 
@@ -521,11 +521,11 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
 
 
 OneHotEncoderDF = make_df_transformer(
-    OneHotEncoder, df_wrapper_type=_OneHotEncoderWrapperDF
+    OneHotEncoder, base_wrapper=_OneHotEncoderWrapperDF
 )
 
 OrdinalEncoderDF = make_df_transformer(
-    OrdinalEncoder, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    OrdinalEncoder, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 
@@ -572,7 +572,7 @@ class _KBinsDiscretizerWrapperDF(
 
 
 KBinsDiscretizerDF = make_df_transformer(
-    KBinsDiscretizer, df_wrapper_type=_KBinsDiscretizerWrapperDF
+    KBinsDiscretizer, base_wrapper=_KBinsDiscretizerWrapperDF
 )
 
 
@@ -582,66 +582,66 @@ KBinsDiscretizerDF = make_df_transformer(
 #
 
 BernoulliRBMDF = make_df_transformer(
-    BernoulliRBM, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    BernoulliRBM, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 DictionaryLearningDF = make_df_transformer(
-    DictionaryLearning, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    DictionaryLearning, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 FactorAnalysisDF = make_df_transformer(
-    FactorAnalysis, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    FactorAnalysis, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 FastICADF = make_df_transformer(
-    FastICA, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    FastICA, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 GaussianRandomProjectionDF = make_df_transformer(
     GaussianRandomProjection,
-    df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF,
+    base_wrapper=_ComponentsDimensionalityReductionWrapperDF,
 )
 
 IncrementalPCADF = make_df_transformer(
-    IncrementalPCA, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    IncrementalPCA, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 LatentDirichletAllocationDF = make_df_transformer(
     LatentDirichletAllocation,
-    df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF,
+    base_wrapper=_ComponentsDimensionalityReductionWrapperDF,
 )
 
 MiniBatchDictionaryLearningDF = make_df_transformer(
     MiniBatchDictionaryLearning,
-    df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF,
+    base_wrapper=_ComponentsDimensionalityReductionWrapperDF,
 )
 
 MiniBatchSparsePCADF = make_df_transformer(
-    MiniBatchSparsePCA, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    MiniBatchSparsePCA, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 NMFDF = make_df_transformer(
-    NMF, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    NMF, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 PCADF = make_df_transformer(
-    PCA, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+    PCA, base_wrapper=_NComponentsDimensionalityReductionWrapperDF
 )
 
 SparseCoderDF = make_df_transformer(
-    SparseCoder, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    SparseCoder, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 SparsePCADF = make_df_transformer(
-    SparsePCA, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    SparsePCA, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 SparseRandomProjectionDF = make_df_transformer(
-    SparseRandomProjection, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    SparseRandomProjection, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 TruncatedSVDDF = make_df_transformer(
-    TruncatedSVD, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+    TruncatedSVD, base_wrapper=_ComponentsDimensionalityReductionWrapperDF
 )
 
 
@@ -651,23 +651,23 @@ TruncatedSVDDF = make_df_transformer(
 #
 
 KernelPCADF = make_df_transformer(
-    KernelPCA, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+    KernelPCA, base_wrapper=_NComponentsDimensionalityReductionWrapperDF
 )
 
 LocallyLinearEmbeddingDF = make_df_transformer(
-    LocallyLinearEmbedding, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+    LocallyLinearEmbedding, base_wrapper=_NComponentsDimensionalityReductionWrapperDF
 )
 
 NystroemDF = make_df_transformer(
-    Nystroem, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+    Nystroem, base_wrapper=_NComponentsDimensionalityReductionWrapperDF
 )
 
 RBFSamplerDF = make_df_transformer(
-    RBFSampler, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+    RBFSampler, base_wrapper=_NComponentsDimensionalityReductionWrapperDF
 )
 
 SkewedChi2SamplerDF = make_df_transformer(
-    SkewedChi2Sampler, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+    SkewedChi2Sampler, base_wrapper=_NComponentsDimensionalityReductionWrapperDF
 )
 
 
@@ -678,33 +678,33 @@ SkewedChi2SamplerDF = make_df_transformer(
 #
 
 VarianceThresholdDF = make_df_transformer(
-    VarianceThreshold, df_wrapper_type=_FeatureSelectionWrapperDF
+    VarianceThreshold, base_wrapper=_FeatureSelectionWrapperDF
 )
 
-RFEDF = make_df_transformer(RFE, df_wrapper_type=_FeatureSelectionWrapperDF)
+RFEDF = make_df_transformer(RFE, base_wrapper=_FeatureSelectionWrapperDF)
 
-RFECVDF = make_df_transformer(RFECV, df_wrapper_type=_FeatureSelectionWrapperDF)
+RFECVDF = make_df_transformer(RFECV, base_wrapper=_FeatureSelectionWrapperDF)
 
 SelectFromModelDF = make_df_transformer(
-    SelectFromModel, df_wrapper_type=_FeatureSelectionWrapperDF
+    SelectFromModel, base_wrapper=_FeatureSelectionWrapperDF
 )
 
 SelectPercentileDF = make_df_transformer(
-    SelectPercentile, df_wrapper_type=_FeatureSelectionWrapperDF
+    SelectPercentile, base_wrapper=_FeatureSelectionWrapperDF
 )
 
 SelectKBestDF = make_df_transformer(
-    SelectKBest, df_wrapper_type=_FeatureSelectionWrapperDF
+    SelectKBest, base_wrapper=_FeatureSelectionWrapperDF
 )
 
-SelectFprDF = make_df_transformer(SelectFpr, df_wrapper_type=_FeatureSelectionWrapperDF)
+SelectFprDF = make_df_transformer(SelectFpr, base_wrapper=_FeatureSelectionWrapperDF)
 
-SelectFdrDF = make_df_transformer(SelectFdr, df_wrapper_type=_FeatureSelectionWrapperDF)
+SelectFdrDF = make_df_transformer(SelectFdr, base_wrapper=_FeatureSelectionWrapperDF)
 
-SelectFweDF = make_df_transformer(SelectFwe, df_wrapper_type=_FeatureSelectionWrapperDF)
+SelectFweDF = make_df_transformer(SelectFwe, base_wrapper=_FeatureSelectionWrapperDF)
 
 GenericUnivariateSelectDF = make_df_transformer(
-    GenericUnivariateSelect, df_wrapper_type=_FeatureSelectionWrapperDF
+    GenericUnivariateSelect, base_wrapper=_FeatureSelectionWrapperDF
 )
 
 

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -91,7 +91,7 @@ from sklearn.random_projection import GaussianRandomProjection, SparseRandomProj
 from pytools.api import AllTracker
 
 from .. import TransformerDF
-from .._wrapper import _TransformerWrapperDF, df_estimator
+from .._wrapper import _TransformerWrapperDF, make_df_transformer
 from ._wrapper import (
     _BaseDimensionalityReductionWrapperDF,
     _BaseMultipleInputsPerOutputTransformerWrapperDF,
@@ -187,15 +187,9 @@ __tracker = AllTracker(globals())
 #
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class FeatureAgglomerationDF(TransformerDF, FeatureAgglomeration):
-    """
-    Wraps :class:`sklearn.cluster.FeatureAgglomeration`;
-    accepts and returns data frames.
-    """
-
-    pass
+FeatureAgglomerationDF = make_df_transformer(
+    FeatureAgglomeration, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
 
 #
@@ -264,15 +258,9 @@ class _ColumnTransformerWrapperDF(
         )
 
 
-# noinspection PyAbstractClass,DuplicatedCode
-@df_estimator(df_wrapper_type=_ColumnTransformerWrapperDF)
-class ColumnTransformerDF(TransformerDF, ColumnTransformer):
-    """
-    Wraps :class:`sklearn.compose.ColumnTransformer`;
-    accepts and returns data frames.
-    """
-
-    pass
+ColumnTransformerDF = make_df_transformer(
+    ColumnTransformer, df_wrapper_type=_ColumnTransformerWrapperDF
+)
 
 
 #
@@ -280,59 +268,25 @@ class ColumnTransformerDF(TransformerDF, ColumnTransformer):
 #
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class PLSSVDDF(TransformerDF, PLSSVD):
-    """
-    Wraps :class:`sklearn.cross_decomposition.pls_.PLSSVD`;
-    accepts and returns data frames.
-    """
+PLSSVDDF = make_df_transformer(
+    PLSSVD, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-    pass
+FeatureHasherDF = make_df_transformer(
+    FeatureHasher, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
+DictVectorizerDF = make_df_transformer(
+    DictVectorizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class FeatureHasherDF(TransformerDF, FeatureHasher):
-    """
-    Wraps :class:`sklearn.feature_extraction.FeatureHasher`;
-    accepts and returns data frames.
-    """
+HashingVectorizerDF = make_df_transformer(
+    HashingVectorizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class DictVectorizerDF(TransformerDF, DictVectorizer):
-    """
-    Wraps :class:`sklearn.feature_extraction.dict_vectorizer.DictVectorizer`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class HashingVectorizerDF(TransformerDF, HashingVectorizer):
-    """
-    Wraps :class:`sklearn.feature_extraction.text.HashingVectorizer`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class TfidfTransformerDF(TransformerDF, TfidfTransformer):
-    """
-    Wraps :class:`sklearn.feature_extraction.text.TfidfTransformer`;
-    accepts and returns data frames.
-    """
-
-    pass
+TfidfTransformerDF = make_df_transformer(
+    TfidfTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
 
 #
@@ -340,8 +294,6 @@ class TfidfTransformerDF(TransformerDF, TfidfTransformer):
 #
 
 # we cannot move this to package _wrapper as it references MissingIndicatorDF
-
-
 class _ImputerWrapperDF(_TransformerWrapperDF[T_Imputer], metaclass=ABCMeta):
     """
     Impute missing values with data frames as input and output.
@@ -399,15 +351,7 @@ class _ImputerWrapperDF(_TransformerWrapperDF[T_Imputer], metaclass=ABCMeta):
             return features_original
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ImputerWrapperDF)
-class SimpleImputerDF(TransformerDF, SimpleImputer):
-    """
-    Wraps :class:`sklearn.impute.MissingIndicator`;
-    accepts and returns data frames.
-    """
-
-    pass
+SimpleImputerDF = make_df_transformer(SimpleImputer, df_wrapper_type=_ImputerWrapperDF)
 
 
 class _MissingIndicatorWrapperDF(
@@ -421,26 +365,13 @@ class _MissingIndicatorWrapperDF(
         return pd.Series(index=features_out, data=features_original)
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_MissingIndicatorWrapperDF)
-class MissingIndicatorDF(TransformerDF, MissingIndicator):
-    """
-    Wraps :class:`sklearn.impute.MissingIndicator`;
-    accepts and returns data frames.
-    """
+MissingIndicatorDF = make_df_transformer(
+    MissingIndicator, df_wrapper_type=_MissingIndicatorWrapperDF
+)
 
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ImputerWrapperDF)
-class IterativeImputerDF(TransformerDF, IterativeImputer):
-    """
-    Wraps :class:`sklearn.impute.IterativeImputer`;
-    accepts and returns data frames.
-    """
-
-    pass
+IterativeImputerDF = make_df_transformer(
+    IterativeImputer, df_wrapper_type=_ImputerWrapperDF
+)
 
 
 class _IsomapWrapperDF(
@@ -451,15 +382,7 @@ class _IsomapWrapperDF(
         return self.native_estimator.embedding_.shape[1]
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_IsomapWrapperDF)
-class IsomapDF(TransformerDF, IterativeImputer):
-    """
-    Wraps :class:`sklearn.manifold.Isomap`;
-    accepts and returns data frames.
-    """
-
-    pass
+IsomapDF = make_df_transformer(Isomap, df_wrapper_type=_IsomapWrapperDF)
 
 
 class _AdditiveChi2SamplerWrapperDF(
@@ -470,30 +393,19 @@ class _AdditiveChi2SamplerWrapperDF(
         return len(self._features_in) * (2 * self.native_estimator.sample_steps + 1)
 
 
-# noinspection PyAbstractClass,DuplicatedCode
-@df_estimator(df_wrapper_type=_AdditiveChi2SamplerWrapperDF)
-class AdditiveChi2SamplerDF(TransformerDF, AdditiveChi2Sampler):
-    """
-    Wraps :class:`sklearn.kernel_approximation.AdditiveChi2Sampler`;
-    accepts and returns data frames.
-    """
-
-    pass
+AdditiveChi2SamplerDF = make_df_transformer(
+    AdditiveChi2Sampler, df_wrapper_type=_AdditiveChi2SamplerWrapperDF
+)
 
 
 #
 # neighbors
 #
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class NeighborhoodComponentsAnalysisDF(TransformerDF, NeighborhoodComponentsAnalysis):
-    """
-    Wraps :class:`sklearn.neighbors.NeighborhoodComponentsAnalysis`;
-    accepts and returns data frames.
-    """
-
-    pass
+NeighborhoodComponentsAnalysisDF = make_df_transformer(
+    NeighborhoodComponentsAnalysis,
+    df_wrapper_type=_ColumnPreservingTransformerWrapperDF,
+)
 
 
 #
@@ -501,48 +413,21 @@ class NeighborhoodComponentsAnalysisDF(TransformerDF, NeighborhoodComponentsAnal
 #
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class MinMaxScalerDF(TransformerDF, MinMaxScaler):
-    """
-    Wraps :class:`sklearn.preprocessing.MinMaxScaler`;
-    accepts and returns data frames.
-    """
+MinMaxScalerDF = make_df_transformer(
+    MinMaxScaler, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-    pass
+StandardScalerDF = make_df_transformer(
+    StandardScaler, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
+MaxAbsScalerDF = make_df_transformer(
+    MaxAbsScaler, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class StandardScalerDF(TransformerDF, StandardScaler):
-    """
-    Wraps :class:`sklearn.preprocessing.StandardScaler`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class MaxAbsScalerDF(TransformerDF, MaxAbsScaler):
-    """
-    Wraps :class:`sklearn.preprocessing.MaxAbsScaler`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class RobustScalerDF(TransformerDF, RobustScaler):
-    """
-    Wraps :class:`sklearn.preprocessing.RobustScaler`;
-    accepts and returns data frames.
-    """
-
-    pass
+RobustScalerDF = make_df_transformer(
+    RobustScaler, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
 
 class _PolynomialFeaturesWrapperDF(
@@ -557,115 +442,45 @@ class _PolynomialFeaturesWrapperDF(
         )
 
 
-# noinspection PyAbstractClass,DuplicatedCode
-@df_estimator(df_wrapper_type=_PolynomialFeaturesWrapperDF)
-class PolynomialFeaturesDF(TransformerDF, PolynomialFeatures):
-    """
-    Wraps :class:`sklearn.preprocessing.PolynomialFeatures`;
-    accepts and returns data frames.
-    """
+PolynomialFeaturesDF = make_df_transformer(
+    PolynomialFeatures, df_wrapper_type=_PolynomialFeaturesWrapperDF
+)
 
-    pass
+NormalizerDF = make_df_transformer(
+    Normalizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
+BinarizerDF = make_df_transformer(
+    Binarizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class NormalizerDF(TransformerDF, Normalizer):
-    """
-    Wraps :class:`sklearn.preprocessing.Normalizer`;
-    accepts and returns data frames.
-    """
+KernelCentererDF = make_df_transformer(
+    KernelCenterer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-    pass
+QuantileTransformerDF = make_df_transformer(
+    QuantileTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
+PowerTransformerDF = make_df_transformer(
+    PowerTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-# noinspection PyAbstractClass
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class BinarizerDF(TransformerDF, Binarizer):
-    """
-    Wraps :class:`sklearn.preprocessing.Binarizer`;
-    accepts and returns data frames.
-    """
+FunctionTransformerDF = make_df_transformer(
+    FunctionTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-    pass
+LabelEncoderDF = make_df_transformer(
+    LabelEncoder, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
+LabelBinarizerDF = make_df_transformer(
+    LabelBinarizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class KernelCentererDF(TransformerDF, KernelCenterer):
-    """
-    Wraps :class:`sklearn.preprocessing.KernelCenterer`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class QuantileTransformerDF(TransformerDF, QuantileTransformer):
-    """
-    Wraps :class:`sklearn.preprocessing.QuantileTransformer`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class PowerTransformerDF(TransformerDF, PowerTransformer):
-    """
-    Wraps :class:`sklearn.preprocessing.PowerTransformer`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class FunctionTransformerDF(TransformerDF, FunctionTransformer):
-    """
-    Wraps :class:`sklearn.preprocessing.FunctionTransformer`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class LabelEncoderDF(TransformerDF, LabelEncoder):
-    """
-    Wraps :class:`sklearn.preprocessing.LabelEncoder`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class LabelBinarizerDF(TransformerDF, LabelBinarizer):
-    """
-    Wraps :class:`sklearn.preprocessing.LabelBinarizer`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class MultiLabelBinarizerDF(TransformerDF, MultiLabelBinarizer):
-    """
-    Wraps :class:`sklearn.preprocessing.MultiLabelBinarizer`;
-    accepts and returns data frames.
-    """
-
-    pass
+MultiLabelBinarizerDF = make_df_transformer(
+    MultiLabelBinarizer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
 
 class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=ABCMeta):
@@ -703,26 +518,13 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
         )
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_OneHotEncoderWrapperDF)
-class OneHotEncoderDF(TransformerDF, OneHotEncoder):
-    """
-    Wraps :class:`sklearn.preprocessing.OneHotEncoder`;
-    accepts and returns data frames.
-    """
+OneHotEncoderDF = make_df_transformer(
+    OneHotEncoder, df_wrapper_type=_OneHotEncoderWrapperDF
+)
 
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class OrdinalEncoderDF(TransformerDF, OrdinalEncoder):
-    """
-    Wraps :class:`sklearn.preprocessing.OrdinalEncoder`;
-    accepts and returns data frames.
-    """
-
-    pass
+OrdinalEncoderDF = make_df_transformer(
+    OrdinalEncoder, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
 
 class _KBinsDiscretizerWrapperDF(
@@ -767,15 +569,9 @@ class _KBinsDiscretizerWrapperDF(
             )
 
 
-# noinspection PyAbstractClass,DuplicatedCode
-@df_estimator(df_wrapper_type=_KBinsDiscretizerWrapperDF)
-class KBinsDiscretizerDF(TransformerDF, KBinsDiscretizer):
-    """
-    Wrap :class:`sklearn.preprocessing.KBinsDiscretizer`;
-    accepts and returns dataframes.
-    """
-
-    pass
+KBinsDiscretizerDF = make_df_transformer(
+    KBinsDiscretizer, df_wrapper_type=_KBinsDiscretizerWrapperDF
+)
 
 
 #
@@ -783,170 +579,68 @@ class KBinsDiscretizerDF(TransformerDF, KBinsDiscretizer):
 # Implemented through _ComponentsDimensionalityReductionWrapperDF
 #
 
+BernoulliRBMDF = make_df_transformer(
+    BernoulliRBM, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class BernoulliRBMDF(TransformerDF, BernoulliRBM):
-    """
-    Wraps :class:`sklearn.neural_network.BernoulliRBM`;
-    accepts and returns data frames.
-    """
+DictionaryLearningDF = make_df_transformer(
+    DictionaryLearning, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
-    pass
+FactorAnalysisDF = make_df_transformer(
+    FactorAnalysis, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
+FastICADF = make_df_transformer(
+    FastICA, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class DictionaryLearningDF(TransformerDF, DictionaryLearning):
-    """
-    Wraps :class:`decomposition.dict_learning.DictionaryLearning`;
-    accepts and returns data frames.
-    """
+GaussianRandomProjectionDF = make_df_transformer(
+    GaussianRandomProjection,
+    df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF,
+)
 
-    pass
+IncrementalPCADF = make_df_transformer(
+    IncrementalPCA, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
+LatentDirichletAllocationDF = make_df_transformer(
+    LatentDirichletAllocation,
+    df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF,
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class FactorAnalysisDF(TransformerDF, FactorAnalysis):
-    """
-    Wraps :class:`decomposition.factor_analysis.FactorAnalysis`;
-    accepts and returns data frames.
-    """
+MiniBatchDictionaryLearningDF = make_df_transformer(
+    MiniBatchDictionaryLearning,
+    df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF,
+)
 
-    pass
+MiniBatchSparsePCADF = make_df_transformer(
+    MiniBatchSparsePCA, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
+NMFDF = make_df_transformer(
+    NMF, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class FastICADF(TransformerDF, FastICA):
-    """
-    Wraps :class:`decomposition.fastica_.FastICA`;
-    accepts and returns data frames.
-    """
+PCADF = make_df_transformer(
+    PCA, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+)
 
-    pass
+SparseCoderDF = make_df_transformer(
+    SparseCoder, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
+SparsePCADF = make_df_transformer(
+    SparsePCA, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class GaussianRandomProjectionDF(TransformerDF, GaussianRandomProjection):
-    """
-    Wraps :class:`sklearn.random_projection.GaussianRandomProjection`;
-    accepts and returns data frames.
-    """
+SparseRandomProjectionDF = make_df_transformer(
+    SparseRandomProjection, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class IncrementalPCADF(TransformerDF, IncrementalPCA):
-    """
-    Wraps :class:`decomposition.incremental_pca.IncrementalPCA`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class LatentDirichletAllocationDF(TransformerDF, LatentDirichletAllocation):
-    """
-    Wraps :class:`decomposition.online_lda.LatentDirichletAllocation`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class MiniBatchDictionaryLearningDF(TransformerDF, MiniBatchDictionaryLearning):
-    """
-    Wraps :class:`decomposition.dict_learning.MiniBatchDictionaryLearning`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class MiniBatchSparsePCADF(TransformerDF, MiniBatchSparsePCA):
-    """
-    Wraps :class:`decomposition.sparse_pca.MiniBatchSparsePCA`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class NMFDF(NMF, TransformerDF):
-    """
-    Wraps :class:`decomposition.NMF`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF)
-class PCADF(TransformerDF, PCA):
-    """
-    Wraps :class:`decomposition.pca.PCA`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class SparseCoderDF(TransformerDF, SparseCoder):
-    """
-    Wraps :class:`decomposition.dict_learning.SparseCoder`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class SparsePCADF(TransformerDF, SparsePCA):
-    """
-    Wraps :class:`decomposition.sparse_pca.SparsePCA`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class SparseRandomProjectionDF(TransformerDF, SparseRandomProjection):
-    """
-    Wraps :class:`sklearn.random_projection.SparseRandomProjection`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF)
-class TruncatedSVDDF(TransformerDF, TruncatedSVD):
-    """
-    Wraps :class:`decomposition.truncated_svd.TruncatedSVD`;
-    accepts and returns data frames.
-    """
-
-    pass
+TruncatedSVDDF = make_df_transformer(
+    TruncatedSVD, df_wrapper_type=_ComponentsDimensionalityReductionWrapperDF
+)
 
 
 #
@@ -954,191 +648,72 @@ class TruncatedSVDDF(TransformerDF, TruncatedSVD):
 # Implemented through NComponentsDimensionalityReductionWrapperDF
 #
 
+KernelPCADF = make_df_transformer(
+    KernelPCA, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF)
-class KernelPCADF(TransformerDF, KernelPCA):
-    """
-    Wraps :class:`decomposition.kernel_pca.KernelPCA`;
-    accepts and returns data frames.
-    """
+LinearDiscriminantAnalysisDF = make_df_transformer(
+    LinearDiscriminantAnalysis,
+    df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF,
+)
 
-    pass
+LocallyLinearEmbeddingDF = make_df_transformer(
+    LocallyLinearEmbedding, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+)
 
+NystroemDF = make_df_transformer(
+    Nystroem, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF)
-class LinearDiscriminantAnalysisDF(TransformerDF, LinearDiscriminantAnalysis):
-    """
-    Wraps :class:`sklearn.discriminant_analysis.LinearDiscriminantAnalysis`;
-    accepts and returns data frames.
-    """
+RBFSamplerDF = make_df_transformer(
+    RBFSampler, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+)
 
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF)
-class LocallyLinearEmbeddingDF(TransformerDF, LocallyLinearEmbedding):
-    """
-    Wraps :class:`sklearn.manifold.LocallyLinearEmbedding`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF)
-class NystroemDF(TransformerDF, Nystroem):
-    """
-    Wraps :class:`sklearn.kernel_approximation.Nystroem`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF)
-class RBFSamplerDF(TransformerDF, RBFSampler):
-    """
-    Wraps :class:`sklearn.kernel_approximation.RBFSampler`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF)
-class SkewedChi2SamplerDF(TransformerDF, SkewedChi2Sampler):
-    """
-    Wraps :class:`sklearn.kernel_approximation.SkewedChi2Sampler`;
-    accepts and returns data frames.
-    """
-
-    pass
+SkewedChi2SamplerDF = make_df_transformer(
+    SkewedChi2Sampler, df_wrapper_type=_NComponentsDimensionalityReductionWrapperDF
+)
 
 
 #
 # feature_selection
 #
-#
-# Transformer which have an get_support method
-# Implemented through _FeatureSelectionWrapperDF
+# Transformers with a get_support method, implemented via _FeatureSelectionWrapperDF
 #
 
+VarianceThresholdDF = make_df_transformer(
+    VarianceThreshold, df_wrapper_type=_FeatureSelectionWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class VarianceThresholdDF(TransformerDF, VarianceThreshold):
-    """
-    Wraps :class:`sklearn.feature_selection.VarianceThreshold`;
-    accepts and returns data frames.
-    """
+RFEDF = make_df_transformer(RFE, df_wrapper_type=_FeatureSelectionWrapperDF)
 
-    pass
+RFECVDF = make_df_transformer(RFECV, df_wrapper_type=_FeatureSelectionWrapperDF)
 
+SelectFromModelDF = make_df_transformer(
+    SelectFromModel, df_wrapper_type=_FeatureSelectionWrapperDF
+)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class RFEDF(TransformerDF, RFE):
-    """
-    Wraps :class:`sklearn.feature_selection.RFE`;
-    accepts and returns data frames.
-    """
+SelectPercentileDF = make_df_transformer(
+    SelectPercentile, df_wrapper_type=_FeatureSelectionWrapperDF
+)
 
-    pass
+SelectKBestDF = make_df_transformer(
+    SelectKBest, df_wrapper_type=_FeatureSelectionWrapperDF
+)
 
+SelectFprDF = make_df_transformer(SelectFpr, df_wrapper_type=_FeatureSelectionWrapperDF)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class RFECVDF(TransformerDF, RFECV):
-    """
-    Wraps :class:`sklearn.feature_selection.RFECV`;
-    accepts and returns data frames.
-    """
+SelectFdrDF = make_df_transformer(SelectFdr, df_wrapper_type=_FeatureSelectionWrapperDF)
 
-    pass
+SelectFweDF = make_df_transformer(SelectFwe, df_wrapper_type=_FeatureSelectionWrapperDF)
+
+GenericUnivariateSelectDF = make_df_transformer(
+    GenericUnivariateSelect, df_wrapper_type=_FeatureSelectionWrapperDF
+)
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class SelectFromModelDF(TransformerDF, SelectFromModel):
-    """
-    Wraps :class:`sklearn.feature_selection.SelectFromModel`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class SelectPercentileDF(TransformerDF, SelectPercentile):
-    """
-    Wraps :class:`sklearn.feature_selection.SelectPercentile`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class SelectKBestDF(TransformerDF, SelectKBest):
-    """
-    Wraps :class:`sklearn.feature_selection.SelectKBest`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class SelectFprDF(TransformerDF, SelectFpr):
-    """
-    Wraps :class:`sklearn.feature_selection.SelectFpr`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class SelectFdrDF(TransformerDF, SelectFdr):
-    """
-    Wraps :class:`sklearn.feature_selection.SelectFdr`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class SelectFweDF(TransformerDF, SelectFwe):
-    """
-    Wraps :class:`sklearn.feature_selection.SelectFwe`;
-    accepts and returns data frames.
-    """
-
-    pass
-
-
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_FeatureSelectionWrapperDF)
-class GenericUnivariateSelectDF(TransformerDF, GenericUnivariateSelect):
-    """
-    Wraps :class:`sklearn.feature_selection.GenericUnivariateSelect`;
-    accepts and returns data frames.
-    """
-
-    pass
-
+#
+# validate __all__
+#
 
 __tracker.validate()
 

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -15,7 +15,7 @@ Core implementation of :mod:`sklearndf.transformation`
 #            :class:`$2.$1`;\n    accepts and returns data frames.\n    """
 #            \n    pass\n\n
 # - clean up imports; import only the module names not the individual classes
-
+import functools
 import logging
 from abc import ABCMeta
 from functools import reduce
@@ -181,6 +181,19 @@ T_Imputer = TypeVar("T_Imputer", SimpleImputer, IterativeImputer)
 #
 
 __tracker = AllTracker(globals())
+
+#
+# Set the module for new DF classes
+#
+
+make_df_transformer = functools.partial(
+    make_df_transformer, module="sklearndf.transformation"
+)
+
+
+#
+# Class definitions
+#
 
 #
 # cluster

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -15,7 +15,6 @@ Core implementation of :mod:`sklearndf.transformation`
 #            :class:`$2.$1`;\n    accepts and returns data frames.\n    """
 #            \n    pass\n\n
 # - clean up imports; import only the module names not the individual classes
-import functools
 import logging
 from abc import ABCMeta
 from functools import reduce
@@ -181,14 +180,6 @@ T_Imputer = TypeVar("T_Imputer", SimpleImputer, IterativeImputer)
 #
 
 __tracker = AllTracker(globals())
-
-#
-# Set the module for new DF classes
-#
-
-make_df_transformer = functools.partial(
-    make_df_transformer, module="sklearndf.transformation"
-)
 
 
 #

--- a/src/sklearndf/transformation/_transformation_v0_22.py
+++ b/src/sklearndf/transformation/_transformation_v0_22.py
@@ -44,7 +44,7 @@ __tracker = AllTracker(globals())
 # impute
 #
 
-KNNImputerDF = make_df_transformer(KNNImputer, df_wrapper_type=_ImputerWrapperDF)
+KNNImputerDF = make_df_transformer(KNNImputer, base_wrapper=_ImputerWrapperDF)
 
 
 #

--- a/src/sklearndf/transformation/_transformation_v0_22.py
+++ b/src/sklearndf/transformation/_transformation_v0_22.py
@@ -21,8 +21,9 @@ import logging
 
 from sklearn.impute import KNNImputer
 
-from .. import TransformerDF
-from .._wrapper import df_estimator
+from pytools.api import AllTracker
+
+from .._wrapper import make_df_transformer
 from ._transformation import _ImputerWrapperDF
 
 log = logging.getLogger(__name__)
@@ -31,20 +32,26 @@ __all__ = ["KNNImputerDF"]
 
 __imported_estimators = {name for name in globals().keys() if name.endswith("DF")}
 
+
+#
+# Ensure all symbols introduced below are included in __all__
+#
+
+__tracker = AllTracker(globals())
+
+
 #
 # impute
 #
 
+KNNImputerDF = make_df_transformer(KNNImputer, df_wrapper_type=_ImputerWrapperDF)
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ImputerWrapperDF)
-class KNNImputerDF(TransformerDF, KNNImputer):
-    """
-    Wraps :class:`sklearn.impute._knn.KNNImputer`;
-    accepts and returns data frames.
-    """
 
-    pass
+#
+# validate __all__
+#
+
+__tracker.validate()
 
 
 #

--- a/src/sklearndf/transformation/_transformation_v0_22.py
+++ b/src/sklearndf/transformation/_transformation_v0_22.py
@@ -44,9 +44,7 @@ __tracker = AllTracker(globals())
 # impute
 #
 
-KNNImputerDF = make_df_transformer(
-    KNNImputer, module="sklearndf.transformation", df_wrapper_type=_ImputerWrapperDF
-)
+KNNImputerDF = make_df_transformer(KNNImputer, df_wrapper_type=_ImputerWrapperDF)
 
 
 #

--- a/src/sklearndf/transformation/_transformation_v0_22.py
+++ b/src/sklearndf/transformation/_transformation_v0_22.py
@@ -44,7 +44,9 @@ __tracker = AllTracker(globals())
 # impute
 #
 
-KNNImputerDF = make_df_transformer(KNNImputer, df_wrapper_type=_ImputerWrapperDF)
+KNNImputerDF = make_df_transformer(
+    KNNImputer, module="sklearndf.transformation", df_wrapper_type=_ImputerWrapperDF
+)
 
 
 #

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -129,11 +129,8 @@ class _BorutaPyWrapperDF(
         return self.feature_names_in_[self.native_estimator.support_]
 
 
-BorutaDF = make_df_transformer(
-    BorutaPy,
-    module="sklearndf.transformation.extra",
-    df_wrapper_type=_BorutaPyWrapperDF,
-)
-
+BorutaDF = make_df_transformer(BorutaPy, df_wrapper_type=_BorutaPyWrapperDF)
+# override name BorutaPyDF
+BorutaDF.__name__ = "BorutaDF"
 
 __tracker.validate()

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -130,7 +130,7 @@ class _BorutaPyWrapperDF(
 
 
 BorutaDF = make_df_transformer(
-    BorutaPy, name="BorutaDF", df_wrapper_type=_BorutaPyWrapperDF
+    BorutaPy, name="BorutaDF", base_wrapper=_BorutaPyWrapperDF
 )
 
 __tracker.validate()

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -13,7 +13,7 @@ from sklearn.base import BaseEstimator
 from pytools.api import AllTracker, inheritdoc
 
 from ... import TransformerDF
-from ..._wrapper import _MetaEstimatorWrapperDF, df_estimator
+from ..._wrapper import _MetaEstimatorWrapperDF, make_df_transformer
 from .._wrapper import _ColumnSubsetTransformerWrapperDF, _NDArrayTransformerWrapperDF
 
 log = logging.getLogger(__name__)
@@ -129,62 +129,7 @@ class _BorutaPyWrapperDF(
         return self.feature_names_in_[self.native_estimator.support_]
 
 
-# noinspection PyAbstractClass,PyUnresolvedReferences
-@df_estimator(df_wrapper_type=_BorutaPyWrapperDF)
-class BorutaDF(TransformerDF, BorutaPy):
-    """
-    Feature Selection with the Boruta method with dataframes as input and output.
-
-
-    Given a dataset and an estimator, the Boruta method selects the features that
-    perform better than noise for the problem. See `BorutaPy
-    <https://github.com/scikit-learn-contrib/boruta_py>`_.
-
-    :class:`BorutaDF` wraps :class:`BorutaPy
-    <https://github.com/scikit-learn-contrib/boruta_py>` with dataframes
-    as input and output.
-
-    The parameters are the parameters from the boruta :class:`BorutaPy`. For
-    convenience we list below the description of the parameters as they appear in
-    https://github.com/scikit-learn-contrib/boruta_py.
-
-    :param estimator: object
-        A supervised learning estimator, with a 'fit' method that returns the
-        ``feature_importances_`` attribute. Important features must correspond to
-        high absolute values in the ``feature_importances_``.
-    :param n_estimators: int or string, default = 1000
-        If int sets the number of estimators in the chosen ensemble method.
-        If 'auto' this is determined automatically based on the size of the
-        dataset. The other parameters of the used estimators need to be set
-        with initialisation.
-    :param perc: int, default = 100
-        Instead of the max we use the percentile defined by the user, to pick
-        our threshold for comparison between shadow and real features. The max
-        tend to be too stringent. This provides a finer control over this. The
-        lower perc is the more false positives will be picked as relevant but
-        also the less relevant features will be left out. The usual trade-off.
-        The default is essentially the vanilla Boruta corresponding to the max.
-    :param alpha: float, default = 0.05
-        Level at which the corrected p-values will get rejected in both
-        correction steps.
-    :param two_step: Boolean, default = True
-        If you want to use the original implementation of Boruta with Bonferroni
-        correction only set this to False.
-    :param max_iter: int, default = 100
-        The number of maximum iterations to perform.
-    :param random_state: int, RandomState instance or None; default=None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by ``np.random``.
-    :param verbose: int, default=0
-        Controls verbosity of output:
-        - 0: no output
-        - 1: displays iteration number
-        - 2: which features have been selected already
-    """
-
-    pass
+BorutaDF = make_df_transformer(BorutaPy, df_wrapper_type=_BorutaPyWrapperDF)
 
 
 __tracker.validate()

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -129,8 +129,8 @@ class _BorutaPyWrapperDF(
         return self.feature_names_in_[self.native_estimator.support_]
 
 
-BorutaDF = make_df_transformer(BorutaPy, df_wrapper_type=_BorutaPyWrapperDF)
-# override name BorutaPyDF
-BorutaDF.__name__ = "BorutaDF"
+BorutaDF = make_df_transformer(
+    BorutaPy, name="BorutaDF", df_wrapper_type=_BorutaPyWrapperDF
+)
 
 __tracker.validate()

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -129,7 +129,11 @@ class _BorutaPyWrapperDF(
         return self.feature_names_in_[self.native_estimator.support_]
 
 
-BorutaDF = make_df_transformer(BorutaPy, df_wrapper_type=_BorutaPyWrapperDF)
+BorutaDF = make_df_transformer(
+    BorutaPy,
+    module="sklearndf.transformation.extra",
+    df_wrapper_type=_BorutaPyWrapperDF,
+)
 
 
 __tracker.validate()

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -98,16 +98,12 @@ class DummyTransformer(Transformer):
 
 
 DummyTransformerDF = make_df_transformer(
-    DummyTransformer,
-    module="test",
-    df_wrapper_type=_ColumnPreservingTransformerWrapperDF,
+    DummyTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
 )
 
 
 NoTransformerDF = make_df_estimator(
-    NoTransformer,
-    module="test",
-    df_wrapper_type=_ColumnPreservingTransformerWrapperDF,
+    NoTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
 )
 
 

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -22,7 +22,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_selection import f_classif
 
 from sklearndf import TransformerDF
-from sklearndf._wrapper import df_estimator
+from sklearndf._wrapper import df_estimator, make_df_estimator
 from sklearndf.classification import SVCDF, LogisticRegressionDF
 from sklearndf.pipeline import PipelineDF
 from sklearndf.regression import DummyRegressorDF, LassoDF, LinearRegressionDF
@@ -104,10 +104,9 @@ class DummyTransformerDF(TransformerDF, DummyTransformer):
     pass
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class NoTransformerDF(TransformerDF, NoTransformer):
-    pass
+NoTransformerDF = make_df_estimator(
+    NoTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
 
 def test_pipeline_df_memory(

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -98,13 +98,15 @@ class DummyTransformer(Transformer):
 
 
 DummyTransformerDF = make_df_transformer(
-    DummyTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    DummyTransformer,
+    module="test",
+    df_wrapper_type=_ColumnPreservingTransformerWrapperDF,
 )
 
 
 NoTransformerDF = make_df_estimator(
     NoTransformer,
-    module="sklearndf",
+    module="test",
     df_wrapper_type=_ColumnPreservingTransformerWrapperDF,
 )
 

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -21,8 +21,7 @@ from sklearn import clone
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_selection import f_classif
 
-from sklearndf import TransformerDF
-from sklearndf._wrapper import df_estimator, make_df_estimator
+from sklearndf._wrapper import make_df_estimator, make_df_transformer
 from sklearndf.classification import SVCDF, LogisticRegressionDF
 from sklearndf.pipeline import PipelineDF
 from sklearndf.regression import DummyRegressorDF, LassoDF, LinearRegressionDF
@@ -98,10 +97,9 @@ class DummyTransformer(Transformer):
         return self
 
 
-# noinspection PyAbstractClass
-@df_estimator(df_wrapper_type=_ColumnPreservingTransformerWrapperDF)
-class DummyTransformerDF(TransformerDF, DummyTransformer):
-    pass
+DummyTransformerDF = make_df_transformer(
+    DummyTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+)
 
 
 NoTransformerDF = make_df_estimator(

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -98,12 +98,12 @@ class DummyTransformer(Transformer):
 
 
 DummyTransformerDF = make_df_transformer(
-    DummyTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    DummyTransformer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 
 NoTransformerDF = make_df_estimator(
-    NoTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    NoTransformer, base_wrapper=_ColumnPreservingTransformerWrapperDF
 )
 
 

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -103,7 +103,9 @@ DummyTransformerDF = make_df_transformer(
 
 
 NoTransformerDF = make_df_estimator(
-    NoTransformer, df_wrapper_type=_ColumnPreservingTransformerWrapperDF
+    NoTransformer,
+    module="sklearndf",
+    df_wrapper_type=_ColumnPreservingTransformerWrapperDF,
 )
 
 

--- a/test/test/sklearndf/test_base.py
+++ b/test/test/sklearndf/test_base.py
@@ -1,10 +1,7 @@
 # inspired by:
 # https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/tests/test_base.py
-from abc import ABCMeta
 
 import numpy as np
-
-# noinspection PyPackageRequirements
 import scipy.sparse as sp
 from numpy.testing import assert_array_equal, assert_raises
 from sklearn import clone
@@ -12,10 +9,7 @@ from sklearn.base import BaseEstimator, is_classifier
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
 
-from sklearndf import EstimatorDF
-
-# noinspection PyProtectedMember
-from sklearndf._wrapper import _EstimatorWrapperDF, df_estimator
+from sklearndf._wrapper import make_df_estimator
 from sklearndf.classification import SVCDF, DecisionTreeClassifierDF
 from sklearndf.pipeline import PipelineDF
 from sklearndf.transformation import OneHotEncoderDF
@@ -39,19 +33,9 @@ class _DummyEstimator3(BaseEstimator):
         self.d = d
 
 
-@df_estimator(df_wrapper_type=_EstimatorWrapperDF)
-class _DummyEstimatorDF(EstimatorDF, _DummyEstimator, metaclass=ABCMeta):
-    pass
-
-
-@df_estimator(df_wrapper_type=_EstimatorWrapperDF)
-class _DummyEstimator2DF(EstimatorDF, _DummyEstimator2, metaclass=ABCMeta):
-    pass
-
-
-@df_estimator(df_wrapper_type=_EstimatorWrapperDF)
-class _DummyEstimator3DF(EstimatorDF, _DummyEstimator3, metaclass=ABCMeta):
-    pass
+_DummyEstimatorDF = make_df_estimator(_DummyEstimator)
+_DummyEstimator2DF = make_df_estimator(_DummyEstimator2)
+_DummyEstimator3DF = make_df_estimator(_DummyEstimator3)
 
 
 def test_clone() -> None:
@@ -155,6 +139,7 @@ def test_get_params() -> None:
     assert "a__d" in test.get_params(deep=True)
     assert "a__d" not in test.get_params(deep=False)
 
+    # noinspection PyTypeChecker
     test.set_params(a__d=2)
     assert test.a.d == 2
     assert_raises(ValueError, test.set_params, a__a=2)

--- a/test/test/sklearndf/test_base.py
+++ b/test/test/sklearndf/test_base.py
@@ -33,9 +33,9 @@ class _DummyEstimator3(BaseEstimator):
         self.d = d
 
 
-_DummyEstimatorDF = make_df_estimator(_DummyEstimator, module="sklearndf")
-_DummyEstimator2DF = make_df_estimator(_DummyEstimator2, module="sklearndf")
-_DummyEstimator3DF = make_df_estimator(_DummyEstimator3, module="sklearndf")
+_DummyEstimatorDF = make_df_estimator(_DummyEstimator)
+_DummyEstimator2DF = make_df_estimator(_DummyEstimator2)
+_DummyEstimator3DF = make_df_estimator(_DummyEstimator3)
 
 
 def test_clone() -> None:

--- a/test/test/sklearndf/test_base.py
+++ b/test/test/sklearndf/test_base.py
@@ -28,7 +28,7 @@ class _DummyEstimator2(BaseEstimator):
 
 
 class _DummyEstimator3(BaseEstimator):
-    def __init__(self, c=None, d=None) -> None:
+    def __init__(self, c=0, d=None) -> None:
         self.c = c
         self.d = d
 
@@ -115,16 +115,18 @@ def test_repr() -> None:
     my_estimator = _DummyEstimatorDF()
     repr(my_estimator)
 
-    test = _DummyEstimator2DF(_DummyEstimator3DF(), _DummyEstimator3DF())
+    test = _DummyEstimator2DF(
+        _DummyEstimator3DF(c=None, d=None), _DummyEstimator3DF(c=1, d=2)
+    )
 
     assert repr(test) == (
-        "_DummyEstimator2DF(a=_DummyEstimator3DF(c=None, d=None),\n"
-        "                   b=_DummyEstimator3DF(c=None, d=None))"
+        "_DummyEstimator2DF("
+        "a=_DummyEstimator3DF(c=None), b=_DummyEstimator3DF(c=1, d=2))"
     )
 
     some_est = _DummyEstimator2DF(a=["long_params"] * 1000)
 
-    assert len(repr(some_est)) == 702
+    assert len(repr(some_est)) == 675
 
 
 def test_str() -> None:

--- a/test/test/sklearndf/test_base.py
+++ b/test/test/sklearndf/test_base.py
@@ -33,9 +33,9 @@ class _DummyEstimator3(BaseEstimator):
         self.d = d
 
 
-_DummyEstimatorDF = make_df_estimator(_DummyEstimator)
-_DummyEstimator2DF = make_df_estimator(_DummyEstimator2)
-_DummyEstimator3DF = make_df_estimator(_DummyEstimator3)
+_DummyEstimatorDF = make_df_estimator(_DummyEstimator, module="sklearndf")
+_DummyEstimator2DF = make_df_estimator(_DummyEstimator2, module="sklearndf")
+_DummyEstimator3DF = make_df_estimator(_DummyEstimator3, module="sklearndf")
 
 
 def test_clone() -> None:


### PR DESCRIPTION
Simplify the creation of `...DF` estimators through the introduction of factory functions.

DF-enabled versions of classifiers and regressors implementing the scikit-learn API can be created as follows:
 
``` python
MyClassifierDF = make_df_classifier(MyClassifier)
MyRegressorDF = make_df_regressor(MyRegressor)
```

The name of the receiving variable should always match the original estimator with an appended `DF`.
