### PR TITLE
BUG: do not mirror native estimator class attributes and protected members

### DIFF
--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -879,11 +879,11 @@ def df_estimator(
 
         # mirror all attributes of the wrapped sklearn class, as long
         # as they are not inherited from the wrapper base class
-        for k, v in _mirror_attributes(
+        _mirror_attributes(
+            df_estimator_type=df_estimator_type,
             delegate_type=sklearn_native_estimator_type,
             wrapper_module=sklearndf_wrapper_module,
-        ).items():
-            setattr(df_wrapper_type, k, v)
+        )
 
         # add link to the wrapped class, for use in python module 'inspect'
         df_estimator_type.__wrapped__ = sklearn_native_estimator_type
@@ -910,27 +910,30 @@ def df_estimator(
         return df_estimator_type
 
     def _mirror_attributes(
-        delegate_type: Type[T_DelegateEstimator], wrapper_module: str
-    ) -> Dict[str, Any]:
+        df_estimator_type: Type[T_EstimatorWrapperDF],
+        delegate_type: Type[T_DelegateEstimator],
+        wrapper_module: str,
+    ) -> None:
 
         inherit_from_base_wrapper: Set[str] = set(dir(df_wrapper_type))
 
-        new_dict = {
-            name: _make_alias(
+        for name, member in vars(delegate_type).items():
+
+            if (
+                member is None
+                or name.startswith("_")
+                or name in inherit_from_base_wrapper
+            ):
+                continue
+
+            alias = _make_alias(
                 module=wrapper_module,
                 name=name,
                 delegate_cls=delegate_type,
                 delegate=member,
             )
-            for name, member in vars(delegate_type).items()
-            if not (
-                member is None
-                or name.startswith("__")
-                or name in inherit_from_base_wrapper
-            )
-        }
-
-        return new_dict
+            if alias is not None:
+                setattr(df_estimator_type, name, alias)
 
     def _make_alias(module: str, name: str, delegate_cls: type, delegate: T) -> T:
         def _make_forwarder() -> callable:
@@ -949,26 +952,15 @@ def df_estimator(
             docstring = f"See :meth:`{full_name}`"
             function.__doc__ = docstring
             return function
-        else:
-            docstring = f"See documentation of :class:`{class_name}`."
-            if inspect.isdatadescriptor(delegate):
-                return property(
-                    fget=lambda self: delegate.__get__(self._delegate_estimator),
-                    fset=lambda self, value: delegate.__set__(
-                        self._delegate_estimator, value
-                    ),
-                    fdel=lambda self: delegate.__delete__(self._delegate_estimator),
-                    doc=docstring,
-                )
-            else:
-                return property(
-                    fget=lambda self: getattr(self._delegate_estimator, name),
-                    fset=lambda self, value: setattr(
-                        self._delegate_estimator, name, value
-                    ),
-                    fdel=lambda self: delattr(self._delegate_estimator, name),
-                    doc=docstring,
-                )
+        elif inspect.isdatadescriptor(delegate):
+            return property(
+                fget=lambda self: delegate.__get__(self._delegate_estimator),
+                fset=lambda self, value: delegate.__set__(
+                    self._delegate_estimator, value
+                ),
+                fdel=lambda self: delegate.__delete__(self._delegate_estimator),
+                doc=f"See documentation of :class:`{class_name}`.",
+            )
 
     def _update_wrapper(
         wrapper: Any,

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -18,7 +18,6 @@ from functools import update_wrapper
 from typing import (
     Any,
     Callable,
-    Dict,
     Generic,
     Iterable,
     List,

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -863,6 +863,7 @@ def df_estimator(
         sklearndf_wrapper_module = decoratee.__module__
 
         # dynamically create the wrapper class
+        # noinspection PyPep8Naming,PyMissingOrEmptyDocstring
         class df_estimator_type(df_wrapper_type):
             def __init__(self, *args, **kwargs) -> None:
                 super().__init__(*args, **kwargs)

--- a/src/sklearndf/_wrapper.py
+++ b/src/sklearndf/_wrapper.py
@@ -935,7 +935,9 @@ def df_estimator(
             if alias is not None:
                 setattr(df_estimator_type, name, alias)
 
-    def _make_alias(module: str, name: str, delegate_cls: type, delegate: T) -> T:
+    def _make_alias(
+        module: str, name: str, delegate_cls: type, delegate: T
+    ) -> Optional[T]:
         def _make_forwarder() -> callable:
             def _forwarder(self, *args, **kwargs) -> Any:
                 return delegate(self._delegate_estimator, *args, **kwargs)


### PR DESCRIPTION
When constructing a DF wrapper class for a native Scikit-learn estimator, do not mirror protected members of the native estimator (implementation detail), and do not attempt to mirror class constants (cannot be represented by a property in the wrapper class)