### PR TITLE
BUILD: flexibly build pytools 1.0 or 1.1 during matrix build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,7 +299,7 @@ stages:
           displayName: 'Use Python $(FACET_V_PYTHON_BUILD)'
 
         - checkout: self
-        - checkout: ${{ PYTOOLS_REPO }}
+        - checkout: ${{ variables['PYTOOLS_REPO'] }}
 
         - script: dir $(Build.SourcesDirectory)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,6 @@ resources:
       endpoint: BCG-Gamma
       name: BCG-Gamma/pytools
       ref: develop
-      path: s/pytools_min
     - repository: pytools_latest
       type: github
       endpoint: BCG-Gamma
@@ -301,6 +300,7 @@ stages:
 
         - checkout: self
         - checkout: pytools_min
+          path: s/pytools_min
         - checkout: pytools_latest
 
         - script: dir $(Build.SourcesDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,11 +19,16 @@ schedules:
 
 resources:
   repositories:
-    - repository: pytools
+    - repository: pytools_min
       type: github
       endpoint: BCG-Gamma
       name: BCG-Gamma/pytools
-      ref: 1.1.x # todo - update to stable release
+      ref: develop
+    - repository: pytools_latest
+      type: github
+      endpoint: BCG-Gamma
+      name: BCG-Gamma/pytools
+      ref: 1.1.x
 
 variables:
   ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')) }}:
@@ -128,7 +133,7 @@ stages:
           displayName: 'use Python 3.7'
 
         - checkout: self
-        - checkout: pytools
+        - checkout: pytools_max
 
         - script: dir $(Build.SourcesDirectory)
 
@@ -138,14 +143,14 @@ stages:
             script: |
               set -e
               eval "$(conda shell.bash hook)"
-              cd $(System.DefaultWorkingDirectory)/sklearndf/
+              cd $(System.DefaultWorkingDirectory)/sklearndf
               export PYTHONPATH=$(System.DefaultWorkingDirectory)/sklearndf/src/
               conda env create -f environment.yml
               conda activate sklearndf-develop
               pip install flit
-              cd $(System.DefaultWorkingDirectory)/pytools/
+              cd $(System.DefaultWorkingDirectory)/pytools
               flit install -s
-              cd $(System.DefaultWorkingDirectory)/sklearndf/
+              cd $(System.DefaultWorkingDirectory)/sklearndf
               pip install pytest-azurepipelines
               coverage run -m pytest test/test/
               coverage xml
@@ -205,7 +210,7 @@ stages:
           displayName: 'Use Python $(FACET_V_PYTHON_BUILD)'
 
         - checkout: self
-        - checkout: pytools
+        - checkout: pytools_latest
 
         - script: dir $(Build.SourcesDirectory)
 
@@ -261,34 +266,32 @@ stages:
             FACET_V_PYTHON_BUILD: '=3.7.*'
             BUILD_SYSTEM: 'conda'
             PKG_DEPENDENCIES: 'default'
+            PYTOOLS_REPO: 'pytools_latest'
           minimum_dependencies_conda:
             FACET_V_PYTHON_BUILD: '=3.6.*'
             BUILD_SYSTEM: 'conda'
             PKG_DEPENDENCIES: 'min'
+            PYTOOLS_REPO: 'pytools_min'
           maximum_dependencies_conda:
             FACET_V_PYTHON_BUILD: '=3.8.*'
             BUILD_SYSTEM: 'conda'
             PKG_DEPENDENCIES: 'max'
-          unconstrained_dependencies_conda:
-            FACET_V_PYTHON_BUILD: '>=3.6'
-            PKG_DEPENDENCIES: 'unconstrained'
-            BUILD_SYSTEM: 'conda'
+            PYTOOLS_REPO: 'pytools_latest'
           default_dependencies_tox:
             FACET_V_PYTHON_BUILD: '=3.7.*'
             BUILD_SYSTEM: 'tox'
             PKG_DEPENDENCIES: 'default'
+            PYTOOLS_REPO: 'pytools_latest'
           minimum_dependencies_tox:
             FACET_V_PYTHON_BUILD: '=3.6.*'
             BUILD_SYSTEM: 'tox'
             PKG_DEPENDENCIES: 'min'
+            PYTOOLS_REPO: 'pytools_min'
           maximum_dependencies_tox:
             FACET_V_PYTHON_BUILD: '=3.8.*'
             BUILD_SYSTEM: 'tox'
             PKG_DEPENDENCIES: 'max'
-          unconstrained_dependencies_tox:
-            FACET_V_PYTHON_BUILD: '>=3.6'
-            PKG_DEPENDENCIES: 'unconstrained'
-            BUILD_SYSTEM: 'tox'      
+            PYTOOLS_REPO: 'pytools_latest'
       steps:
         - task: UsePythonVersion@0
           inputs:
@@ -296,7 +299,7 @@ stages:
           displayName: 'Use Python $(FACET_V_PYTHON_BUILD)'
 
         - checkout: self
-        - checkout: pytools
+        - checkout: $[PYTOOLS_REPO]
 
         - script: dir $(Build.SourcesDirectory)
 
@@ -391,7 +394,7 @@ stages:
             displayName: 'use Python 3.7'
 
           - checkout: self
-          - checkout: pytools
+          - checkout: pytools_latest
 
           - task: Bash@3
             inputs:
@@ -475,7 +478,7 @@ stages:
           displayName: 'Install the deploy SSH key'
 
         - checkout: self
-        - checkout: pytools
+        - checkout: pytools_latest
 
         - script: dir $(Build.SourcesDirectory)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,7 +133,7 @@ stages:
           displayName: 'use Python 3.7'
 
         - checkout: self
-        - checkout: pytools_max
+        - checkout: pytools_latest
 
         - script: dir $(Build.SourcesDirectory)
 
@@ -299,7 +299,7 @@ stages:
           displayName: 'Use Python $(FACET_V_PYTHON_BUILD)'
 
         - checkout: self
-        - checkout: $[PYTOOLS_REPO]
+        - checkout: '$(PYTOOLS_REPO)'
 
         - script: dir $(Build.SourcesDirectory)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
     branchName: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
   master_or_release: $[ or(startsWith(variables['branchName'], 'release'), eq(variables['branchName'], 'master')) ]
-  is_scheduled: $[ eq(variables['Build.Reason'], 'Schedule') ]
+  is_scheduled: $[ or(eq(variables['Build.Reason'], 'Schedule'), variables['forceScheduled']) ]
 
 stages:
   # check code quality first to fail fast (isort, flake8, black)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ resources:
       endpoint: BCG-Gamma
       name: BCG-Gamma/pytools
       ref: develop
+      path: s/pytools_min
     - repository: pytools_latest
       type: github
       endpoint: BCG-Gamma
@@ -266,7 +267,7 @@ stages:
             FACET_V_PYTHON_BUILD: '=3.7.*'
             BUILD_SYSTEM: 'conda'
             PKG_DEPENDENCIES: 'default'
-            PYTOOLS_REPO: 'pytools_latest'
+            PYTOOLS_REPO: 'pytools'
           minimum_dependencies_conda:
             FACET_V_PYTHON_BUILD: '=3.6.*'
             BUILD_SYSTEM: 'conda'
@@ -276,12 +277,12 @@ stages:
             FACET_V_PYTHON_BUILD: '=3.8.*'
             BUILD_SYSTEM: 'conda'
             PKG_DEPENDENCIES: 'max'
-            PYTOOLS_REPO: 'pytools_latest'
+            PYTOOLS_REPO: 'pytools'
           default_dependencies_tox:
             FACET_V_PYTHON_BUILD: '=3.7.*'
             BUILD_SYSTEM: 'tox'
             PKG_DEPENDENCIES: 'default'
-            PYTOOLS_REPO: 'pytools_latest'
+            PYTOOLS_REPO: 'pytools'
           minimum_dependencies_tox:
             FACET_V_PYTHON_BUILD: '=3.6.*'
             BUILD_SYSTEM: 'tox'
@@ -291,7 +292,7 @@ stages:
             FACET_V_PYTHON_BUILD: '=3.8.*'
             BUILD_SYSTEM: 'tox'
             PKG_DEPENDENCIES: 'max'
-            PYTOOLS_REPO: 'pytools_latest'
+            PYTOOLS_REPO: 'pytools'
       steps:
         - task: UsePythonVersion@0
           inputs:
@@ -299,7 +300,8 @@ stages:
           displayName: 'Use Python $(FACET_V_PYTHON_BUILD)'
 
         - checkout: self
-        - checkout: ${{ variables['PYTOOLS_REPO'] }}
+        - checkout: pytools_min
+        - checkout: pytools_latest
 
         - script: dir $(Build.SourcesDirectory)
 
@@ -322,7 +324,7 @@ stages:
             targetType: 'inline'
             script: |
               if [ "$BUILD_SYSTEM" = "conda" ] ; then eval "$(conda shell.bash hook)" ; fi
-              cd $(Build.SourcesDirectory)/pytools
+              cd $(Build.SourcesDirectory)/$(PYTOOLS_REPO)
               ./make.py pytools $(BUILD_SYSTEM) $(PKG_DEPENDENCIES)
               cd $(Build.SourcesDirectory)/sklearndf
               ./make.py sklearndf $(BUILD_SYSTEM) $(PKG_DEPENDENCIES)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,7 +299,7 @@ stages:
           displayName: 'Use Python $(FACET_V_PYTHON_BUILD)'
 
         - checkout: self
-        - checkout: '$(PYTOOLS_REPO)'
+        - checkout: ${{ PYTOOLS_REPO }}
 
         - script: dir $(Build.SourcesDirectory)
 


### PR DESCRIPTION
Matrix builds of sklearndf require pytools 1.0 for the _min_ build and 1.1 for the _default_ and _max_ builds.