### PR TITLE
BUILD: allow any version of pytools 1.0 in sklearndf matrix builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = "Apache Software License v2.0"
 requires = [
     # direct requirements of sklearndf
     "boruta         >= 0.3",
-    "gamma-pytools  >= 1.0.2,<2",
+    "gamma-pytools  >= 1.0.*,<2",
     "lightgbm       >= 3.0",
     "numpy          >=1.16,<1.20",
     "packaging      >=20",
@@ -73,7 +73,7 @@ Repository = "https://github.com/BCG-Gamma/sklearndf"
 [build.matrix.min]
 # direct requirements of sklearndf
 boruta         = "=0.3.*"
-gamma-pytools  = "=1.0.2"
+gamma-pytools  = "=1.0.*"
 lightgbm       = "=3.0.*"
 numpy          = "=1.16.*"
 pandas         = "=0.24.*"


### PR DESCRIPTION
Previously the "min" matrix build required pytools 1.0.2, which would need to be built off of the current `develop` branch. This does not work since the pipeline uses the `1.1.x` branch. By allowing the "min" build to use any `1.0.*` version, it can use `1.0.1` which is available on PyPi and Conda.