### PR TITLE
BUILD: optimize conda build config

### DIFF
--- a/condabuild/meta.yaml
+++ b/condabuild/meta.yaml
@@ -13,6 +13,7 @@ requirements:
   host:
     - pip>=20.*
     - python {{ environ.get('FACET_V_PYTHON', '=3.8.*') }}
+    - numpy {{ environ.get('FACET_V_NUMPY', '>=1.11.*') }}
     - flit>=3.0.*
 # note: sklearndf.__init__ already needs pytools, pandas & sklearn:
     - pandas{{ environ.get('FACET_V_PANDAS') }}

--- a/condabuild/meta.yaml
+++ b/condabuild/meta.yaml
@@ -47,7 +47,6 @@ test:
     - python -c 'import sklearndf;
                  import os;
                  assert sklearndf.__version__ == os.environ["PKG_VERSION"]'
-    - pytest -vs ${FACET_PATH}/pytools/test
     - pytest -vs ${FACET_PATH}/sklearndf/test
 
 about:


### PR DESCRIPTION
- specify numpy host version to prevent conda warning message
- do not test dependent packages to avoid potential version conflicts