### PR TITLE
BUILD: use regular pytest & pytest-cov, run pytest nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ stages:
               flit install -s
               cd $(System.DefaultWorkingDirectory)/sklearndf/
               pytest \
-                 --cov facet \
+                 --cov sklearndf \
                  --cov-config "tox.ini" \
                  --cov-report=xml:coverage.xml --cov-report=html:htmlcov \
                  --junitxml pytest.xml \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,12 +111,7 @@ stages:
     jobs:
     - job:
       displayName: 'pytest @ develop environment'
-      condition: >
-        and(
-        ne(variables.master_or_release, 'True'),
-        ne(variables.is_scheduled, 'True'),
-        eq(stageDependencies.detect_build_config_changes.checkout_and_diff.outputs['diff.conda_build_config_changed'], '0')
-        )
+      condition: ne(variables.master_or_release, 'True')
 
       pool:
           vmImage: 'ubuntu-latest'
@@ -149,10 +144,12 @@ stages:
               cd $(System.DefaultWorkingDirectory)/pytools/
               flit install -s
               cd $(System.DefaultWorkingDirectory)/sklearndf/
-              pip install pytest-azurepipelines
-              coverage run -m pytest test/test/
-              coverage xml
-              coverage html
+              pytest \
+                 --cov facet \
+                 --cov-config "tox.ini" \
+                 --cov-report=xml:coverage.xml --cov-report=html:htmlcov \
+                 --junitxml pytest.xml \
+                 . -s
           displayName: 'pytest'
 
         - task: PublishTestResults@2


### PR DESCRIPTION
- Replaced stale pytest-azurepipelines plugin (last release 2019) with pytest/pytest-cov that we already have in the environment.
- Have pytest stage also run in case of nightly builds, hence, code coverage and test metrics will be always available on develop branch builds