### PR TITLE
FIX: OneHotEncoderDF bug for drop argument usage

### DIFF
--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -681,18 +681,33 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
         :return: the series with index the column names of the output dataframe and
         values the corresponding input column names.
         """
-        return pd.Series(
-            index=pd.Index(
+        index = pd.Index(
                 self.native_estimator.get_feature_names(self.feature_names_in_)
-            ),
-            data=[
+            )
+        if self.drop == 'first':
+            data = [
                 column_original
                 for column_original, category in zip(
                     self.feature_names_in_, self.native_estimator.categories_
                 )
-                for _ in category
+                for _ in category[1:]
             ],
-        )
+        elif self.drop == 'if_binary':
+            # todo to be tested
+            data = [
+                column_original
+                for column_original, category in zip(
+                    self.feature_names_in_, self.native_estimator.categories_
+                )
+                for _ in category[1:] if len(category) == 2
+            ],
+        else:
+            data = [column_original for column_original, category in zip(
+                self.feature_names_in_, self.native_estimator.categories_
+            )
+                for _ in category
+            ]
+        return pd.Series(index=index, data=data )
 
 
 # noinspection PyAbstractClass

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -692,36 +692,36 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
         Removes the first column of the categorical if argument drop='first' is given
         Removes only the first categorical column of binary features if drop='if_binary'
         """
-        index = pd.Index(
+        feature_names_out = pd.Index(
             self.native_estimator.get_feature_names(self.feature_names_in_)
         )
+
         if self.drop == "first":
-            data = [
+            feature_names_in = [
                 column_original
                 for column_original, category in zip(
                     self.feature_names_in_, self.native_estimator.categories_
                 )
-                for _ in category[1:]
+                for _ in range(len(category) - 1)
             ]
         elif self.drop == "if_binary":
-            data = []
-            for column_original, category in zip(
-                self.feature_names_in_, self.native_estimator.categories_
-            ):
-                if len(category) == 2:
-                    data.append(column_original)
-                else:
-                    for _ in category:
-                        data.append(column_original)
+            feature_names_in = [
+                column_original
+                for column_original, category in zip(
+                    self.feature_names_in_, self.native_estimator.categories_
+                )
+                for _ in (range(1) if len(category) == 2 else category)
+            ]
         else:
-            data = [
+            feature_names_in = [
                 column_original
                 for column_original, category in zip(
                     self.feature_names_in_, self.native_estimator.categories_
                 )
                 for _ in category
             ]
-        return pd.Series(index=index, data=data)
+
+        return pd.Series(index=feature_names_out, data=feature_names_in)
 
 
 # noinspection PyAbstractClass

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -683,15 +683,11 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
             raise NotImplementedError("sparse matrices not supported; use sparse=False")
 
     def _get_features_original(self) -> pd.Series:
-        """
-        Return the series mapping output column names to original columns names.
+        # Return the series mapping output column names to original column names.
+        #
+        # Remove 1st category column if argument drop == 'first'
+        # Remove 1st category column only of binary features if arg drop == 'if_binary'
 
-        :return: the series with index the column names of the output dataframe and
-        values the corresponding input column names.
-
-        Removes the first column of the categorical if argument drop='first' is given
-        Removes only the first categorical column of binary features if drop='if_binary'
-        """
         feature_names_out = pd.Index(
             self.native_estimator.get_feature_names(self.feature_names_in_)
         )

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -691,23 +691,23 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
                     self.feature_names_in_, self.native_estimator.categories_
                 )
                 for _ in category[1:]
-            ],
+            ]
         elif self.drop == 'if_binary':
-            # todo to be tested
-            data = [
-                column_original
-                for column_original, category in zip(
-                    self.feature_names_in_, self.native_estimator.categories_
-                )
-                for _ in category[1:] if len(category) == 2
-            ],
+            data = []
+            for column_original, category in zip(
+                    self.feature_names_in_, self.native_estimator.categories_):
+                if len(category) == 2:
+                    data.append(column_original)
+                else:
+                    for _ in category:
+                        data.append(column_original)
         else:
             data = [column_original for column_original, category in zip(
                 self.feature_names_in_, self.native_estimator.categories_
             )
                 for _ in category
             ]
-        return pd.Series(index=index, data=data )
+        return pd.Series(index=index, data=data)
 
 
 # noinspection PyAbstractClass

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -688,6 +688,9 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
 
         :return: the series with index the column names of the output dataframe and
         values the corresponding input column names.
+
+        Removes the first column of the categorical if argument drop='first' is given
+        Removes only the first categorical column of binary features if drop='if_binary'
         """
         index = pd.Index(
             self.native_estimator.get_feature_names(self.feature_names_in_)

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -690,9 +690,9 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
         values the corresponding input column names.
         """
         index = pd.Index(
-                self.native_estimator.get_feature_names(self.feature_names_in_)
-            )
-        if self.drop == 'first':
+            self.native_estimator.get_feature_names(self.feature_names_in_)
+        )
+        if self.drop == "first":
             data = [
                 column_original
                 for column_original, category in zip(
@@ -700,19 +700,22 @@ class _OneHotEncoderWrapperDF(_TransformerWrapperDF[OneHotEncoder], metaclass=AB
                 )
                 for _ in category[1:]
             ]
-        elif self.drop == 'if_binary':
+        elif self.drop == "if_binary":
             data = []
             for column_original, category in zip(
-                    self.feature_names_in_, self.native_estimator.categories_):
+                self.feature_names_in_, self.native_estimator.categories_
+            ):
                 if len(category) == 2:
                     data.append(column_original)
                 else:
                     for _ in category:
                         data.append(column_original)
         else:
-            data = [column_original for column_original, category in zip(
-                self.feature_names_in_, self.native_estimator.categories_
-            )
+            data = [
+                column_original
+                for column_original, category in zip(
+                    self.feature_names_in_, self.native_estimator.categories_
+                )
                 for _ in category
             ]
         return pd.Series(index=index, data=data)

--- a/test/test/sklearndf/transformation/test_imputers.py
+++ b/test/test/sklearndf/transformation/test_imputers.py
@@ -14,13 +14,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 IMPUTERS_TO_TEST = list_classes(
-    from_modules=sklearndf.transformation, matching=r".*Imputer*DF", excluding=[]
+    from_modules=sklearndf.transformation, matching=r".*Imputer.*DF", excluding=[]
 )
 
 
 @pytest.mark.parametrize(
     argnames=["imputer_cls", "add_indicator"],
-    argvalues=itertools.product(IMPUTERS_TO_TEST, (True, False)),
+    argvalues=itertools.product(IMPUTERS_TO_TEST, [True, False]),
 )
 def test_imputer(
     imputer_cls: Type[TransformerDF],

--- a/test/test/sklearndf/transformation/test_imputers.py
+++ b/test/test/sklearndf/transformation/test_imputers.py
@@ -18,28 +18,6 @@ IMPUTERS_TO_TEST = list_classes(
 )
 
 
-@pytest.fixture
-def test_data_x() -> pd.DataFrame:
-    return pd.DataFrame(
-        data=[[7, 2, 3], [4, np.nan, 6], [10, 5, 9]], columns=["a", "b", "c"]
-    )
-
-
-@pytest.fixture
-def test_data_x_with_all_nan() -> pd.DataFrame:
-    return pd.DataFrame(
-        data=[[7, np.nan, 3], [4, np.nan, 6], [np.nan, np.nan, np.nan]],
-        columns=["a", "b", "c"],
-    )
-
-
-@pytest.fixture
-def test_data_y() -> pd.DataFrame:
-    return pd.DataFrame(
-        data=[[np.nan, 2, 3], [4, np.nan, 6], [10, np.nan, 9]], columns=["a", "b", "c"]
-    )
-
-
 @pytest.mark.parametrize(
     argnames=["imputer_cls", "add_indicator"],
     argvalues=itertools.product(IMPUTERS_TO_TEST, (True, False)),
@@ -47,22 +25,28 @@ def test_data_y() -> pd.DataFrame:
 def test_imputer(
     imputer_cls: Type[TransformerDF],
     add_indicator: bool,
-    test_data_x: pd.DataFrame,
-    test_data_y: pd.DataFrame,
-    test_data_x_with_all_nan: pd.DataFrame,
 ) -> None:
     """
-    Test imputer classes using the combinations of arguments from ``@pytest.mark.parametrize``
-    
+    Test imputer classes using the combinations of arguments from
+    ``@pytest.mark.parametrize``
+
     :param imputer_cls: the imputer class to test
     :param add_indicator: whether to add an indicator column
-    :param test_data_x: data used to fit the imputer
-    :param test_data_y: data to be transformed by the fitted imputer
-    :param test_data_x_with_all_nan: alternative data used to fit the imputer, including NaN values
     :return:
     """
-    imputerdf = imputer_cls(add_indicator=add_indicator)
-    imputer_cls_orig = type(imputerdf.native_estimator)
+    imputer_df = imputer_cls(add_indicator=add_indicator)
+    imputer_cls_orig = type(imputer_df.native_estimator)
+
+    test_data_x = pd.DataFrame(
+        data=[[7, 2, 3], [4, np.nan, 6], [10, 5, 9]], columns=["a", "b", "c"]
+    )
+    test_data_x_with_all_nan = pd.DataFrame(
+        data=[[7, np.nan, 3], [4, np.nan, 6], [np.nan, np.nan, np.nan]],
+        columns=["a", "b", "c"],
+    )
+    test_data_y = pd.DataFrame(
+        data=[[np.nan, 2, 3], [4, np.nan, 6], [10, np.nan, 9]], columns=["a", "b", "c"]
+    )
 
     # noinspection PyArgumentList
     imputer_orig = imputer_cls_orig(add_indicator=add_indicator)
@@ -71,8 +55,8 @@ def test_imputer(
     # noinspection PyUnresolvedReferences
     y_transformed = imputer_orig.transform(test_data_y)
 
-    imputerdf.fit(test_data_x)
-    y_transformed_df = imputerdf.transform(test_data_y)
+    imputer_df.fit(test_data_x)
+    y_transformed_df = imputer_df.transform(test_data_y)
 
     assert np.array_equal(
         np.round(y_transformed, 4), np.round(y_transformed_df.values, 4)
@@ -89,8 +73,8 @@ def test_imputer(
     # noinspection PyUnresolvedReferences
     y_transformed = imputer_orig.transform(test_data_y)
 
-    imputerdf.fit(test_data_x_with_all_nan)
-    y_transformed_df = imputerdf.transform(test_data_y)
+    imputer_df.fit(test_data_x_with_all_nan)
+    y_transformed_df = imputer_df.transform(test_data_y)
 
     assert np.array_equal(
         np.round(y_transformed, 4), np.round(y_transformed_df.values, 4)

--- a/test/test/sklearndf/transformation/test_imputers.py
+++ b/test/test/sklearndf/transformation/test_imputers.py
@@ -52,12 +52,13 @@ def test_imputer(
     test_data_x_with_all_nan: pd.DataFrame,
 ) -> None:
     """
-    uses the combinations of arguments from @pytest.mark.parametrize
-    :param imputer_cls: uses
-    :param add_indicator:
-    :param test_data_x: fixtures no need to be added in the function calls
-    :param test_data_y: fixtures no need to be added in the function calls
-    :param test_data_x_with_all_nan: fixtures no need to be added in the function calls
+    Test imputer classes using the combinations of arguments from ``@pytest.mark.parametrize``
+    
+    :param imputer_cls: the imputer class to test
+    :param add_indicator: whether to add an indicator column
+    :param test_data_x: data used to fit the imputer
+    :param test_data_y: data to be transformed by the fitted imputer
+    :param test_data_x_with_all_nan: alternative data used to fit the imputer, including NaN values
     :return:
     """
     imputerdf = imputer_cls(add_indicator=add_indicator)

--- a/test/test/sklearndf/transformation/test_imputers.py
+++ b/test/test/sklearndf/transformation/test_imputers.py
@@ -51,6 +51,15 @@ def test_imputer(
     test_data_y: pd.DataFrame,
     test_data_x_with_all_nan: pd.DataFrame,
 ) -> None:
+    """
+    uses the combinations of arguments from @pytest.mark.parametrize
+    :param imputer_cls: uses
+    :param add_indicator:
+    :param test_data_x: fixtures no need to be added in the function calls
+    :param test_data_y: fixtures no need to be added in the function calls
+    :param test_data_x_with_all_nan: fixtures no need to be added in the function calls
+    :return:
+    """
     imputerdf = imputer_cls(add_indicator=add_indicator)
     imputer_cls_orig = type(imputerdf.native_estimator)
 


### PR DESCRIPTION
Fixes #133 

This PR fixes the missing handling of column indices and length when the drop argument is used in "if_binary" or "first" mode