### PR TITLE
BUILD: support pytools from 1.0.2rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ Repository = "https://github.com/BCG-Gamma/sklearndf"
 [build.matrix.min]
 # direct requirements of sklearndf
 boruta         = "=0.3.*"
-gamma-pytools  = "=1.0.2"
+gamma-pytools  = "=1.0.2.*"
 lightgbm       = "=3.0.*"
 numpy          = "=1.16.*"
 pandas         = "=0.24.*"


### PR DESCRIPTION
This PR relaxes the `min` build matrix such that it works with pytools v1.0.2rc0 and later.

I expect this will allow checks to pass for BCG-Gamma/facet#248.