### PR TITLE
TEST: run encoder test with 'if_binary' only from sklearn 0.23

### DIFF
--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -23,6 +23,7 @@ from sklearndf.transformation import (
     SparseCoderDF,
 )
 from sklearndf.transformation.extra import OutlierRemoverDF
+from test import check_sklearn_version
 from test.sklearndf import (
     check_expected_not_fitted_error,
     get_sklearndf_wrapper_class,
@@ -190,22 +191,23 @@ def test_one_hot_encoding() -> None:
         ).rename_axis(columns="feature_out"),
     )
 
-    assert_frame_equal(
-        OneHotEncoderDF(drop="if_binary", sparse=False).fit_transform(
-            test_data_categorical
-        ),
-        pd.DataFrame(
-            {
-                "a_yes": [1.0, 1.0, 0.0],
-                "b_blue": [0.0, 1.0, 0.0],
-                "b_green": [0.0, 0.0, 1.0],
-                "b_red": [1.0, 0.0, 0.0],
-                "c_child": [1.0, 0.0, 0.0],
-                "c_father": [0.0, 1.0, 0.0],
-                "c_mother": [0.0, 0.0, 1.0],
-            }
-        ).rename_axis(columns="feature_out"),
-    )
+    if check_sklearn_version(minimum="0.23"):
+        assert_frame_equal(
+            OneHotEncoderDF(drop="if_binary", sparse=False).fit_transform(
+                test_data_categorical
+            ),
+            pd.DataFrame(
+                {
+                    "a_yes": [1.0, 1.0, 0.0],
+                    "b_blue": [0.0, 1.0, 0.0],
+                    "b_green": [0.0, 0.0, 1.0],
+                    "b_red": [1.0, 0.0, 0.0],
+                    "c_child": [1.0, 0.0, 0.0],
+                    "c_father": [0.0, 1.0, 0.0],
+                    "c_mother": [0.0, 0.0, 1.0],
+                }
+            ).rename_axis(columns="feature_out"),
+        )
 
     assert_frame_equal(
         OneHotEncoderDF(drop="first", sparse=False).fit_transform(


### PR DESCRIPTION
Only run OneHotEncoderDF tests using the `drop='if_binary'` argument, on sklearn version that supports it (>=0.23).