### PR TITLE
BUILD: set to version 1.0.2rc0

### DIFF
--- a/src/sklearndf/_version.py
+++ b/src/sklearndf/_version.py
@@ -2,4 +2,4 @@
 Define the package version for gamma-sklearndf – done here so that it can be used
 without external dependencies (pandas, sklearn, ...).
 """
-__version__ = "1.0.2"
+__version__ = "1.0.2rc0"


### PR DESCRIPTION
The relase for `1.0.2` of sklearndf is around the corner, we will do a pre-release first.