### PR TITLE
BUILD: correct the working directory & deps for PyPi upload

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -501,7 +501,7 @@ stages:
 
           - script: |
               set -eux
-              cd $(System.DefaultWorkingDirectory)
+              cd $(System.DefaultWorkingDirectory)/sklearndf
               pip install flit
               flit publish
               echo "##vso[task.setvariable variable=pypi_published]True"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -503,6 +503,7 @@ stages:
               set -eux
               cd $(System.DefaultWorkingDirectory)/sklearndf
               pip install flit
+              flit install -s
               flit publish
               echo "##vso[task.setvariable variable=pypi_published]True"
             displayName: 'Publish to PyPi'


### PR DESCRIPTION
Corrects: 
https://dev.azure.com/gamma-facet/facet/_build/results?buildId=3094&view=logs&j=5f8fe092-e504-55d5-bea6-4c19fb56d81e&t=8d741944-b1d9-587d-8248-d81758c7fabe

As sklearndf checks out multiple repositories (pytools + sklearndf), PyPi publish pipeline stage has to be adapted changing to the correct one.