### PR TITLE
BUILD: prepare for 1.0.2 release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -501,7 +501,7 @@ stages:
 
           - script: |
               set -eux
-              cd $(System.DefaultWorkingDirectory)
+              cd $(System.DefaultWorkingDirectory)/sklearndf
               pip install flit
               flit publish
               echo "##vso[task.setvariable variable=pypi_published]True"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -390,7 +390,7 @@ stages:
             displayName: 'use Python 3.7'
 
           - checkout: self
-            path: pytools
+          - checkout: pytools
 
           - task: Bash@3
             env:
@@ -416,7 +416,7 @@ stages:
                 ), "This check should only run on versioned branches – check pipeline."
 
                 branch_version = branch.split("/", maxsplit=1)[1]
-                package_version = ToxBuilder("pytools", "default").package_version
+                package_version = ToxBuilder("sklearndf", "default").package_version
 
                 assert (
                     package_version == branch_version
@@ -461,7 +461,7 @@ stages:
             inputs:
               targetType: inline
               script: |
-                set -e
+                set -eux
                 echo "Getting version"
                 pip install packaging
                 cd $(System.DefaultWorkingDirectory)/sklearndf/src

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -503,6 +503,7 @@ stages:
               set -eux
               cd $(System.DefaultWorkingDirectory)/sklearndf
               pip install flit
+              flit install -s
               flit publish
               echo "##vso[task.setvariable variable=pypi_published]True"
             displayName: 'Publish to PyPi'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = "Apache Software License v2.0"
 requires = [
     # direct requirements of sklearndf
     "boruta         >= 0.3",
-    "gamma-pytools  >=1.0.2rc0,<2",
+    "gamma-pytools  >=1.0.2,<2",
     "lightgbm       >= 3.0",
     "numpy          >=1.16,<1.21",
     "packaging      >=20",

--- a/src/sklearndf/_version.py
+++ b/src/sklearndf/_version.py
@@ -2,4 +2,4 @@
 Define the package version for gamma-sklearndf – done here so that it can be used
 without external dependencies (pandas, sklearn, ...).
 """
-__version__ = "1.0.2rc0"
+__version__ = "1.0.2"

--- a/test/test/sklearndf/test_package_version.py
+++ b/test/test/sklearndf/test_package_version.py
@@ -40,3 +40,22 @@ def test_package_version() -> None:
     assert (
         dev_version not in releases
     ), f"Current package version {dev_version} already on PyPi"
+
+    is_minor_or_major_release = dev_version.endswith(".0")
+
+    if is_minor_or_major_release:
+        pre_releases = [
+            version
+            for version in releases
+            if re.match(f"{dev_version}rc\\d+$", version)
+        ]
+
+        assert pre_releases, (
+            f"Release of major or minor version {dev_version} "
+            f"requires at least one pre-release, e.g. {dev_version}rc0"
+        )
+
+        log.info(
+            f"Pre-release(s) {pre_releases} exist(s) – "
+            f"release of major/minor version {dev_version} allowed"
+        )


### PR DESCRIPTION
Final changes ahead of proper 1.0.2 release:
- set package version
- add similar test for existing RC versions for each minor/major release as already in place for pytools