### PR TITLE
FIX: allow imported definitions in AllTracker for sklearn wrapper classes

### DIFF
--- a/src/sklearndf/classification/_classification.py
+++ b/src/sklearndf/classification/_classification.py
@@ -104,7 +104,7 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/classification/_classification_v0_22.py
+++ b/src/sklearndf/classification/_classification_v0_22.py
@@ -23,7 +23,7 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -27,7 +27,7 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/pipeline/_pipeline.py
+++ b/src/sklearndf/pipeline/_pipeline.py
@@ -20,7 +20,7 @@ __all__ = ["PipelineDF", "FeatureUnionDF"]
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/regression/_regression.py
+++ b/src/sklearndf/regression/_regression.py
@@ -122,7 +122,7 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/regression/_regression_v0_22.py
+++ b/src/sklearndf/regression/_regression_v0_22.py
@@ -30,7 +30,7 @@ T_Regressor = TypeVar("T_Regressor", bound=RegressorMixin)
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/regression/_regression_v0_23.py
+++ b/src/sklearndf/regression/_regression_v0_23.py
@@ -37,7 +37,7 @@ T_Regressor = TypeVar("T_Regressor", bound=RegressorMixin)
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -27,7 +27,7 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -158,7 +158,7 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/transformation/_transformation_v0_22.py
+++ b/src/sklearndf/transformation/_transformation_v0_22.py
@@ -37,7 +37,7 @@ __imported_estimators = {name for name in globals().keys() if name.endswith("DF"
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -31,7 +31,7 @@ T_Self = TypeVar("T_Self")
 # Ensure all symbols introduced below are included in __all__
 #
 
-__tracker = AllTracker(globals())
+__tracker = AllTracker(globals(), allow_imported_definitions=True)
 
 
 #


### PR DESCRIPTION
This PR overrides the new ``AllTracker`` mechanism designed to prevent re-exporting imports from other modules. This mechanism is triggered by generated DF wrapper classes, so we disable it in the packages providing the DF wrappers.