### PR TITLE
BUILD: add copy of old docs-versions folder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -631,6 +631,8 @@ stages:
               cp -r $(Build.ArtifactStagingDirectory)/old_docs/docs .
               echo "Current docs contents:"
               tree docs
+              mkdir -p $(System.DefaultWorkingDirectory)/sklearndf/sphinx/build/
+              cp -R docs/docs-version $(System.DefaultWorkingDirectory)/sklearndf/sphinx/build/
               echo "Building sphinx docs"
               conda activate sklearndf-develop
               cd $(System.DefaultWorkingDirectory)/sklearndf


### PR DESCRIPTION
This corrects the scenario that older `version.js` files are not patched, by copying pre-existing `docs-version` folders where the makefile for docs expects them.