### PR TITLE
FIX: dynamically determine the _estimator_type attribute

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,16 @@ Release Notes
 *sklearndf* 1.1
 ---------------
 
+1.1.2
+~~~~~
+
+This release improves compatibility with scikit-learn and fixes bugs.
+
+- API: add full support for the
+  `_estimator_type <https://scikit-learn.org/stable/glossary.html#term-_estimator_type>`__
+  attribute
+
+
 1.1.1
 ~~~~~
 

--- a/src/sklearndf/classification/wrapper/_wrapper.py
+++ b/src/sklearndf/classification/wrapper/_wrapper.py
@@ -4,7 +4,7 @@ Core implementation of :mod:`sklearndf.classification.wrapper`
 
 import logging
 from abc import ABCMeta
-from typing import Any, Generic, List, Optional, Sequence, TypeVar, Union
+from typing import Any, Callable, Generic, List, Optional, Sequence, TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -14,7 +14,7 @@ from sklearn.multioutput import ClassifierChain, MultiOutputClassifier
 
 from pytools.api import AllTracker
 
-from sklearndf import LearnerDF
+from sklearndf import ClassifierDF, LearnerDF
 from sklearndf.transformation.wrapper import NComponentsDimensionalityReductionWrapperDF
 from sklearndf.wrapper import (
     ClassifierWrapperDF,
@@ -147,6 +147,13 @@ class ClassifierChainWrapperDF(
         )
 
 
+# noinspection PyProtectedMember
+from ...wrapper._adapter import ClassifierNPDF as _ClassifierNPDF
+
+# noinspection PyProtectedMember
+from ...wrapper._wrapper import _StackableClassifierDF
+
+
 class StackingClassifierWrapperDF(
     StackingEstimatorWrapperDF[T_NativeClassifier],
     ClassifierWrapperDF,
@@ -171,6 +178,16 @@ class StackingClassifierWrapperDF(
             return [f"{name}_{c}" for name in names for c in classes]
         else:
             return names
+
+    def _make_stackable_learner_df(
+        self, learner: ClassifierDF
+    ) -> _StackableClassifierDF:
+        return _StackableClassifierDF(learner)
+
+    def _make_learner_np_df(
+        self, delegate: ClassifierDF, column_names: Callable[[], Sequence[str]]
+    ) -> _ClassifierNPDF:
+        return _ClassifierNPDF(delegate, column_names)
 
 
 #

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -92,11 +92,6 @@ class PipelineWrapperDF(
         """
         return self.native_estimator.steps
 
-    @property
-    def _estimator_type(self) -> str:
-        # noinspection PyProtectedMember
-        return self.native_estimator._estimator_type
-
     def __len__(self) -> int:
         """The number of steps of the pipeline."""
         return len(self.native_estimator.steps)

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -92,6 +92,11 @@ class PipelineWrapperDF(
         """
         return self.native_estimator.steps
 
+    @property
+    def _estimator_type(self) -> str:
+        # noinspection PyProtectedMember
+        return self.native_estimator._estimator_type
+
     def __len__(self) -> int:
         """The number of steps of the pipeline."""
         return len(self.native_estimator.steps)

--- a/src/sklearndf/regression/wrapper/_wrapper.py
+++ b/src/sklearndf/regression/wrapper/_wrapper.py
@@ -4,7 +4,7 @@ Core implementation of :mod:`sklearndf.regression.wrapper`
 
 import logging
 from abc import ABCMeta
-from typing import Any, Generic, Optional, TypeVar, Union
+from typing import Any, Callable, Generic, Optional, Sequence, TypeVar, Union
 
 import pandas as pd
 from sklearn.base import RegressorMixin
@@ -12,7 +12,7 @@ from sklearn.isotonic import IsotonicRegression
 
 from pytools.api import AllTracker
 
-from sklearndf import LearnerDF
+from sklearndf import LearnerDF, RegressorDF
 from sklearndf.transformation.wrapper import ColumnPreservingTransformerWrapperDF
 from sklearndf.wrapper import (
     MetaEstimatorWrapperDF,
@@ -64,6 +64,13 @@ class MetaRegressorWrapperDF(
     pass
 
 
+# noinspection PyProtectedMember
+from ...wrapper._adapter import RegressorNPDF as _RegressorNPDF
+
+# noinspection PyProtectedMember
+from ...wrapper._wrapper import _StackableRegressorDF
+
+
 class StackingRegressorWrapperDF(
     StackingEstimatorWrapperDF[T_NativeRegressor],
     RegressorWrapperDF,
@@ -80,6 +87,14 @@ class StackingRegressorWrapperDF(
         from sklearndf.regression import RidgeCVDF
 
         return RidgeCVDF()
+
+    def _make_stackable_learner_df(self, learner: LearnerDF) -> _StackableRegressorDF:
+        return _StackableRegressorDF(learner)
+
+    def _make_learner_np_df(
+        self, delegate: RegressorDF, column_names: Callable[[], Sequence[str]]
+    ) -> _RegressorNPDF:
+        return _RegressorNPDF(delegate, column_names)
 
 
 class RegressorTransformerWrapperDF(

--- a/src/sklearndf/regression/wrapper/_wrapper.py
+++ b/src/sklearndf/regression/wrapper/_wrapper.py
@@ -4,7 +4,7 @@ Core implementation of :mod:`sklearndf.regression.wrapper`
 
 import logging
 from abc import ABCMeta
-from typing import Any, Callable, Generic, Optional, Sequence, TypeVar, Union
+from typing import Callable, Generic, Optional, Sequence, TypeVar
 
 import numpy as np
 import pandas as pd

--- a/src/sklearndf/wrapper/_adapter.py
+++ b/src/sklearndf/wrapper/_adapter.py
@@ -82,8 +82,6 @@ class EstimatorNPDF(
         super().__init__()
         self.delegate = delegate
         self.column_names = column_names
-        self._estimator_type = getattr(delegate, "_estimator_type", None)
-        self._pairwise = getattr(delegate, "_pairwise", None)
 
     @property
     def is_fitted(self) -> bool:

--- a/src/sklearndf/wrapper/_adapter.py
+++ b/src/sklearndf/wrapper/_adapter.py
@@ -10,12 +10,17 @@ import pandas as pd
 
 from pytools.api import AllTracker, inheritdoc
 
-from sklearndf import ClassifierDF, EstimatorDF, RegressorDF, TransformerDF
+from sklearndf import ClassifierDF, EstimatorDF, LearnerDF, RegressorDF, TransformerDF
 
 log = logging.getLogger(__name__)
 
-__all__ = ["EstimatorNPDF"]
-
+__all__ = [
+    "ClassifierNPDF",
+    "EstimatorNPDF",
+    "LearnerNPDF",
+    "RegressorNPDF",
+    "TransformerNPDF",
+]
 
 #
 # type variables
@@ -23,6 +28,10 @@ __all__ = ["EstimatorNPDF"]
 
 T_Self = TypeVar("T_Self")
 T_DelegateEstimatorDF = TypeVar("T_DelegateEstimatorDF", bound=EstimatorDF)
+T_DelegateLearnerDF = TypeVar("T_DelegateLearnerDF", bound=LearnerDF)
+T_DelegateClassifierDF = TypeVar("T_DelegateClassifierDF", bound=ClassifierDF)
+T_DelegateRegressorDF = TypeVar("T_DelegateRegressorDF", bound=RegressorDF)
+T_DelegateTransformerDF = TypeVar("T_DelegateTransformerDF", bound=TransformerDF)
 
 #
 # Ensure all symbols introduced below are included in __all__
@@ -34,9 +43,6 @@ __tracker = AllTracker(globals())
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
 class EstimatorNPDF(
-    ClassifierDF,
-    RegressorDF,
-    TransformerDF,
     EstimatorDF,
     Generic[T_DelegateEstimatorDF],
 ):
@@ -84,11 +90,6 @@ class EstimatorNPDF(
         """[see superclass]"""
         return self.delegate.is_fitted
 
-    @property
-    def classes_(self) -> Sequence[Any]:
-        """[see superclass]"""
-        return self.delegate.classes_
-
     def fit(
         self: T_Self,
         X: Union[np.ndarray, pd.DataFrame],
@@ -99,81 +100,6 @@ class EstimatorNPDF(
         return self.delegate.fit(
             self._ensure_X_frame(X), self._ensure_y_series_or_frame(y), **fit_params
         )
-
-    def transform(self, X: Union[np.ndarray, pd.DataFrame]) -> pd.DataFrame:
-        """[see superclass]"""
-        return self.delegate.predict(self._ensure_X_frame(X))
-
-    def inverse_transform(self, X: Union[np.ndarray, pd.DataFrame]) -> pd.DataFrame:
-        """[see superclass]"""
-        return self.delegate.inverse_transform(self._ensure_X_frame(X))
-
-    def fit_transform(
-        self,
-        X: Union[np.ndarray, pd.DataFrame],
-        y: Optional[Union[np.ndarray, pd.Series, pd.DataFrame]] = None,
-        **fit_params: Any,
-    ) -> pd.DataFrame:
-        """[see superclass]"""
-        return self.delegate.fit_transform(
-            self._ensure_X_frame(X), self._ensure_y_series_or_frame(y), **fit_params
-        )
-
-    def predict_proba(
-        self, X: Union[np.ndarray, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
-        """[see superclass]"""
-        return self.delegate.predict_proba(self._ensure_X_frame(X), **predict_params)
-
-    def predict_log_proba(
-        self, X: Union[np.ndarray, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
-        """[see superclass]"""
-        return self.delegate.predict_log_proba(
-            self._ensure_X_frame(X), **predict_params
-        )
-
-    def decision_function(
-        self, X: Union[np.ndarray, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.Series, pd.DataFrame]:
-        """[see superclass]"""
-        return self.delegate.decision_function(
-            self._ensure_X_frame(X), **predict_params
-        )
-
-    def predict(
-        self, X: Union[np.ndarray, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.Series, pd.DataFrame]:
-        """[see superclass]"""
-        return self.delegate.predict(self._ensure_X_frame(X), **predict_params)
-
-    def fit_predict(
-        self,
-        X: Union[np.ndarray, pd.DataFrame],
-        y: Union[np.ndarray, pd.Series],
-        **fit_params: Any,
-    ) -> Union[pd.Series, pd.DataFrame]:
-        """[see superclass]"""
-        return self.delegate.fit_predict(
-            self._ensure_X_frame(X), self._ensure_y_series_or_frame(y), **fit_params
-        )
-
-    def score(
-        self,
-        X: Union[np.ndarray, pd.DataFrame],
-        y: Union[np.ndarray, pd.Series],
-        sample_weight: Optional[pd.Series] = None,
-    ) -> float:
-        """[see superclass]"""
-        return self.delegate.score(
-            self._ensure_X_frame(X),
-            self._ensure_y_series_or_frame(y),
-            sample_weight=sample_weight,
-        )
-
-    def _get_features_original(self) -> pd.Series:
-        # noinspection PyProtectedMember
-        return self.delegate._get_features_original()
 
     def _get_features_in(self) -> pd.Index:
         return self.delegate._get_features_in()
@@ -219,6 +145,130 @@ class EstimatorNPDF(
                 )
         else:
             return y
+
+
+# noinspection PyPep8Naming
+@inheritdoc(match="""[see superclass]""")
+class LearnerNPDF(
+    EstimatorNPDF[T_DelegateLearnerDF], LearnerDF, Generic[T_DelegateLearnerDF]
+):
+    """[see superclass]"""
+
+    def predict(
+        self, X: Union[np.ndarray, pd.DataFrame], **predict_params: Any
+    ) -> Union[pd.Series, pd.DataFrame]:
+        """[see superclass]"""
+        return self.delegate.predict(self._ensure_X_frame(X), **predict_params)
+
+    def fit_predict(
+        self,
+        X: Union[np.ndarray, pd.DataFrame],
+        y: Union[np.ndarray, pd.Series],
+        **fit_params: Any,
+    ) -> Union[pd.Series, pd.DataFrame]:
+        """[see superclass]"""
+        return self.delegate.fit_predict(
+            self._ensure_X_frame(X), self._ensure_y_series_or_frame(y), **fit_params
+        )
+
+    def score(
+        self,
+        X: Union[np.ndarray, pd.DataFrame],
+        y: Union[np.ndarray, pd.Series],
+        sample_weight: Optional[pd.Series] = None,
+    ) -> float:
+        """[see superclass]"""
+        return self.delegate.score(
+            self._ensure_X_frame(X),
+            self._ensure_y_series_or_frame(y),
+            sample_weight=sample_weight,
+        )
+
+
+# noinspection PyPep8Naming
+@inheritdoc(match="""[see superclass]""")
+class ClassifierNPDF(
+    LearnerNPDF[T_DelegateClassifierDF],
+    ClassifierDF,
+    Generic[T_DelegateClassifierDF],
+):
+    """[see superclass]"""
+
+    @property
+    def classes_(self) -> Sequence[Any]:
+        """[see superclass]"""
+        return self.delegate.classes_
+
+    def predict_proba(
+        self, X: Union[np.ndarray, pd.DataFrame], **predict_params: Any
+    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+        """[see superclass]"""
+        return self.delegate.predict_proba(self._ensure_X_frame(X), **predict_params)
+
+    def predict_log_proba(
+        self, X: Union[np.ndarray, pd.DataFrame], **predict_params: Any
+    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+        """[see superclass]"""
+        return self.delegate.predict_log_proba(
+            self._ensure_X_frame(X), **predict_params
+        )
+
+    def decision_function(
+        self, X: Union[np.ndarray, pd.DataFrame], **predict_params: Any
+    ) -> Union[pd.Series, pd.DataFrame]:
+        """[see superclass]"""
+        return self.delegate.decision_function(
+            self._ensure_X_frame(X), **predict_params
+        )
+
+    def _get_features_in(self) -> pd.Index:
+        return self.delegate._get_features_in()
+
+    def _get_n_outputs(self) -> int:
+        return self.delegate._get_n_outputs()
+
+
+# noinspection PyPep8Naming
+@inheritdoc(match="""[see superclass]""")
+class RegressorNPDF(
+    LearnerNPDF[T_DelegateRegressorDF],
+    RegressorDF,
+    Generic[T_DelegateRegressorDF],
+):
+    """[see superclass]"""
+
+
+# noinspection PyPep8Naming
+@inheritdoc(match="""[see superclass]""")
+class TransformerNPDF(
+    EstimatorNPDF[T_DelegateTransformerDF],
+    TransformerDF,
+    Generic[T_DelegateTransformerDF],
+):
+    """[see superclass]"""
+
+    def transform(self, X: Union[np.ndarray, pd.DataFrame]) -> pd.DataFrame:
+        """[see superclass]"""
+        return self.delegate.predict(self._ensure_X_frame(X))
+
+    def inverse_transform(self, X: Union[np.ndarray, pd.DataFrame]) -> pd.DataFrame:
+        """[see superclass]"""
+        return self.delegate.inverse_transform(self._ensure_X_frame(X))
+
+    def fit_transform(
+        self,
+        X: Union[np.ndarray, pd.DataFrame],
+        y: Optional[Union[np.ndarray, pd.Series, pd.DataFrame]] = None,
+        **fit_params: Any,
+    ) -> pd.DataFrame:
+        """[see superclass]"""
+        return self.delegate.fit_transform(
+            self._ensure_X_frame(X), self._ensure_y_series_or_frame(y), **fit_params
+        )
+
+    def _get_features_original(self) -> pd.Series:
+        # noinspection PyProtectedMember
+        return self.delegate._get_features_original()
 
 
 #

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -13,7 +13,7 @@ The wrappers also implement the additional column attributes introduced by `skle
 
 import inspect
 import logging
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 from functools import update_wrapper
 from typing import (
     Any,
@@ -48,7 +48,7 @@ from sklearn.base import (
 from pytools.api import AllTracker, inheritdoc, public_module_prefix
 from pytools.meta import compose_meta
 
-from ._adapter import EstimatorNPDF
+from ._adapter import LearnerNPDF
 from sklearndf import ClassifierDF, EstimatorDF, LearnerDF, RegressorDF, TransformerDF
 
 log = logging.getLogger(__name__)
@@ -81,12 +81,12 @@ T_NativeLearner = TypeVar("T_NativeLearner", RegressorMixin, ClassifierMixin)
 T_NativeRegressor = TypeVar("T_NativeRegressor", bound=RegressorMixin)
 T_NativeClassifier = TypeVar("T_NativeClassifier", bound=ClassifierMixin)
 
-# noinspection PyTypeChecker
 T_EstimatorWrapperDF = TypeVar("T_EstimatorWrapperDF", bound="EstimatorWrapperDF")
 T_TransformerWrapperDF = TypeVar("T_TransformerWrapperDF", bound="TransformerWrapperDF")
 T_RegressorWrapperDF = TypeVar("T_RegressorWrapperDF", bound="RegressorWrapperDF")
 T_ClassifierWrapperDF = TypeVar("T_ClassifierWrapperDF", bound="ClassifierWrapperDF")
 
+T_LearnerDF = TypeVar("T_LearnerDF", bound="LearnerDF")
 
 #
 # Ensure all symbols introduced below are included in __all__
@@ -833,22 +833,22 @@ class StackingEstimatorWrapperDF(
                 # stacking estimator being fitted
                 return self
 
-        native = self.native_estimator
-        estimators = native.estimators
-        final_estimator = native.final_estimator
+        native: T_NativeEstimator = self.native_estimator
+        estimators: Sequence[Tuple[str, BaseEstimator]] = native.estimators
+        final_estimator: BaseEstimator = native.final_estimator
 
         try:
             native.estimators = [
                 (
                     name,
-                    _StackableLearnerDF(estimator)
+                    self._make_stackable_learner_df(estimator)
                     if isinstance(estimator, LearnerDF)
                     else estimator,
                 )
                 for name, estimator in native.estimators
             ]
-            native.final_estimator = EstimatorNPDF(
-                native.final_estimator or self._make_default_final_estimator(),
+            native.final_estimator = self._make_learner_np_df(
+                delegate=native.final_estimator or self._make_default_final_estimator(),
                 column_names=_ColumnNameFn(),
             )
 
@@ -866,6 +866,16 @@ class StackingEstimatorWrapperDF(
 
         return super().fit_predict(X, y, **fit_params)
 
+    @abstractmethod
+    def _make_stackable_learner_df(self, learner: LearnerDF) -> "_StackableLearnerDF":
+        pass
+
+    @abstractmethod
+    def _make_learner_np_df(
+        self, delegate: LearnerDF, column_names: Callable[[], Sequence[str]]
+    ) -> LearnerNPDF:
+        pass
+
     def _get_estimators_features_out(self) -> List[str]:
         return [name for name, estimator in self.estimators if estimator != "drop"]
 
@@ -879,7 +889,7 @@ class StackingEstimatorWrapperDF(
 
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
-class _StackableLearnerDF(ClassifierDF, RegressorDF, LearnerDF):
+class _StackableLearnerDF(LearnerDF, Generic[T_LearnerDF]):
     """
     Returns numpy arrays from all prediction functions, instead of pandas series or
     data frames.
@@ -888,7 +898,7 @@ class _StackableLearnerDF(ClassifierDF, RegressorDF, LearnerDF):
     one final learner.
     """
 
-    def __init__(self, delegate: Union[ClassifierDF, RegressorDF, LearnerDF]) -> None:
+    def __init__(self, delegate: T_LearnerDF) -> None:
         self.delegate = delegate
         self._estimator_type = getattr(delegate, "_estimator_type", None)
         self._pairwise = getattr(delegate, "_pairwise", None)
@@ -897,11 +907,6 @@ class _StackableLearnerDF(ClassifierDF, RegressorDF, LearnerDF):
     def is_fitted(self) -> bool:
         """[see superclass]"""
         return self.delegate.is_fitted
-
-    @property
-    def classes_(self) -> Sequence[Any]:
-        """[see superclass]"""
-        return self.delegate.classes_
 
     def fit(
         self: T_Self, X: pd.DataFrame, y: np.ndarray = None, **fit_params: Any
@@ -923,26 +928,6 @@ class _StackableLearnerDF(ClassifierDF, RegressorDF, LearnerDF):
         return self.delegate.fit_predict(
             X, self._convert_y_to_series(X, y), **fit_params
         ).values
-
-    def predict_proba(
-        self, X: pd.DataFrame, **predict_params: Any
-    ) -> Union[np.ndarray, List[np.ndarray]]:
-        """[see superclass]"""
-        return self._convert_prediction_to_numpy(
-            self.delegate.predict_proba(X, **predict_params)
-        )
-
-    def predict_log_proba(
-        self, X: pd.DataFrame, **predict_params: Any
-    ) -> Union[np.ndarray, List[np.ndarray]]:
-        """[see superclass]"""
-        return self._convert_prediction_to_numpy(
-            self.delegate.predict_log_proba(X, **predict_params)
-        )
-
-    def decision_function(self, X: pd.DataFrame, **predict_params: Any) -> np.ndarray:
-        """[see superclass]"""
-        return self.delegate.decision_function(X, **predict_params).values
 
     def score(
         self, X: pd.DataFrame, y: np.ndarray, sample_weight: Optional[pd.Series] = None
@@ -985,6 +970,42 @@ class _StackableLearnerDF(ClassifierDF, RegressorDF, LearnerDF):
             return [proba.values for proba in prediction]
         else:
             return prediction.values
+
+
+# noinspection PyPep8Naming
+@inheritdoc(match="""[see superclass]""")
+class _StackableClassifierDF(_StackableLearnerDF[ClassifierDF], ClassifierDF):
+    """[see superclass]"""
+
+    @property
+    def classes_(self) -> Sequence[Any]:
+        """[see superclass]"""
+        return self.delegate.classes_
+
+    def predict_proba(
+        self, X: pd.DataFrame, **predict_params: Any
+    ) -> Union[np.ndarray, List[np.ndarray]]:
+        """[see superclass]"""
+        return self._convert_prediction_to_numpy(
+            self.delegate.predict_proba(X, **predict_params)
+        )
+
+    def predict_log_proba(
+        self, X: pd.DataFrame, **predict_params: Any
+    ) -> Union[np.ndarray, List[np.ndarray]]:
+        """[see superclass]"""
+        return self._convert_prediction_to_numpy(
+            self.delegate.predict_log_proba(X, **predict_params)
+        )
+
+    def decision_function(self, X: pd.DataFrame, **predict_params: Any) -> np.ndarray:
+        """[see superclass]"""
+        return self.delegate.decision_function(X, **predict_params).values
+
+
+@inheritdoc(match="""[see superclass]""")
+class _StackableRegressorDF(_StackableLearnerDF[RegressorDF], RegressorDF):
+    """[see superclass]"""
 
 
 #
@@ -1334,6 +1355,7 @@ def _make_alias(
         )
         function.__doc__ = f"See :meth:`{full_name}`"
         return function
+
     elif inspect.isdatadescriptor(delegate):
         # noinspection PyShadowingNames
         return property(
@@ -1342,6 +1364,7 @@ def _make_alias(
             fdel=lambda self: delegate.__delete__(self._native_estimator),
             doc=f"See documentation of :class:`{class_name}`.",
         )
+
     else:
         return None
 

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -180,6 +180,14 @@ class EstimatorWrapperDF(
         """
         return self._native_estimator
 
+    @property
+    def _estimator_type(self) -> Optional[str]:
+        try:
+            # noinspection PyProtectedMember
+            return self.native_estimator._estimator_type
+        except AttributeError:
+            return None
+
     @classmethod
     def from_fitted(
         cls: Type[T_EstimatorWrapperDF],

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -159,8 +159,6 @@ class EstimatorWrapperDF(
             ) = fitted_delegate_context
 
         self._native_estimator = _native_estimator
-        self._estimator_type = getattr(_native_estimator, "_estimator_type", None)
-        self._pairwise = getattr(_native_estimator, "_pairwise", None)
 
         self._validate_delegate_estimator()
 
@@ -900,8 +898,6 @@ class _StackableLearnerDF(LearnerDF, Generic[T_LearnerDF]):
 
     def __init__(self, delegate: T_LearnerDF) -> None:
         self.delegate = delegate
-        self._estimator_type = getattr(delegate, "_estimator_type", None)
-        self._pairwise = getattr(delegate, "_pairwise", None)
 
     @property
     def is_fitted(self) -> bool:

--- a/test/test/sklearndf/pipeline/test_classification_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_classification_pipeline_df.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.base import is_classifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.preprocessing import OneHotEncoder
 
@@ -22,6 +23,8 @@ def test_classification_pipeline_df(
             one_hot_encode_columns=iris_features.select_dtypes(include=object).columns,
         ),
     )
+
+    assert is_classifier(cls_p_df)
 
     cls_p_df.fit(X=iris_features, y=iris_target_sr)
     cls_p_df.predict(X=iris_features)

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -17,7 +17,7 @@ from numpy.testing import (
     assert_raises_regex,
 )
 from sklearn import clone
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator, TransformerMixin, is_classifier, is_regressor
 from sklearn.feature_selection import f_classif
 
 from sklearndf.classification import SVCDF, LogisticRegressionDF
@@ -227,6 +227,10 @@ def test_pipeline_df__init() -> None:
         svc__a=None, svc__b=None, svc=clf, **pipe.get_params(deep=False)
     )
 
+    assert not is_classifier(pipe)
+    assert not is_regressor(pipe)
+    assert pipe._estimator_type is None
+
     # Check that params are set
     pipe.set_params(svc__a=0.1)
     assert clf.a == 0.1
@@ -238,6 +242,9 @@ def test_pipeline_df__init() -> None:
     clf = SVCDF()
     filter1 = SelectKBestDF(f_classif)
     pipe = PipelineDF([(step_anova, filter1), (step_svc, clf)])
+
+    # Check that the pipeline correctly detects that it is a classifier
+    assert is_classifier(pipe)
 
     # Check that estimators are not cloned on pipeline construction
     assert pipe.named_steps[step_anova] is filter1

--- a/test/test/sklearndf/pipeline/test_regression_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_regression_pipeline_df.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from lightgbm import LGBMRegressor
+from sklearn.base import is_regressor
 from sklearn.preprocessing import OneHotEncoder
 
 from sklearndf.pipeline import RegressorPipelineDF
@@ -24,6 +25,8 @@ def test_regression_pipeline_df(
             ).columns,
         ),
     )
+
+    assert is_regressor(rpdf)
 
     rpdf.fit(X=boston_features, y=boston_target_sr)
     rpdf.predict(X=boston_features)

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -44,15 +44,6 @@ CLASSIFIER_INIT_PARAMETERS = {
 
 
 @pytest.mark.parametrize(argnames="sklearndf_cls", argvalues=CLASSIFIERS_TO_TEST)
-def test_wrapped_constructor(sklearndf_cls: Type[ClassifierDF]) -> None:
-    """ Test standard constructor of wrapped sklearn classifiers """
-    # noinspection PyArgumentList
-    _: ClassifierDF = sklearndf_cls(
-        **CLASSIFIER_INIT_PARAMETERS.get(sklearndf_cls.__name__, {})
-    )
-
-
-@pytest.mark.parametrize(argnames="sklearndf_cls", argvalues=CLASSIFIERS_TO_TEST)
 def test_wrapped_fit_predict(
     sklearndf_cls: Type[ClassifierDF],
     iris_features: pd.DataFrame,

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -4,6 +4,7 @@ from typing import Type
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.base import is_classifier
 from sklearn.multioutput import ClassifierChain, MultiOutputClassifier
 
 import sklearndf.classification as classification
@@ -56,6 +57,8 @@ def test_wrapped_fit_predict(
     classifier: ClassifierDF = sklearndf_cls(
         **CLASSIFIER_INIT_PARAMETERS.get(sklearndf_cls.__name__, {})
     )
+
+    assert is_classifier(classifier)
 
     is_chain = isinstance(classifier.native_estimator, ClassifierChain)
 

--- a/test/test/sklearndf/test_meta_estimators.py
+++ b/test/test/sklearndf/test_meta_estimators.py
@@ -2,6 +2,7 @@ import logging
 
 import pandas as pd
 import pytest
+from sklearn.base import is_classifier, is_regressor
 from sklearn.impute import SimpleImputer
 
 from sklearndf import __sklearn_0_22__, __sklearn_version__
@@ -41,7 +42,8 @@ def test_meta_estimators() -> None:
             ]
         )
 
-    MultiOutputRegressorDF(estimator=RandomForestRegressorDF())
+    regressor = MultiOutputRegressorDF(estimator=RandomForestRegressorDF())
+    assert is_regressor(regressor)
 
     with pytest.raises(
         TypeError,
@@ -54,7 +56,8 @@ def test_meta_estimators() -> None:
             estimator=RegressorPipelineDF(regressor=RandomForestRegressorDF())
         )
 
-    ClassifierChainDF(base_estimator=RandomForestClassifierDF())
+    classifier = ClassifierChainDF(base_estimator=RandomForestClassifierDF())
+    assert is_classifier(classifier)
 
     with pytest.raises(
         TypeError,
@@ -102,6 +105,9 @@ def test_stacking_regressor(
             ),
         ]
     )
+
+    assert is_regressor(pipeline)
+
     pipeline.fit(boston_features, boston_target_sr)
     print(pipeline.predict(boston_features))
 
@@ -120,6 +126,9 @@ def test_stacking_regressor(
         ],
         final_estimator=RidgeCVDF(),
     )
+
+    assert is_regressor(stack_of_pipelines)
+
     stack_of_pipelines.fit(boston_features, boston_target_sr)
 
     pred = stack_of_pipelines.predict(boston_features)
@@ -168,8 +177,10 @@ def test_stacking_classifier(
             ),
         ]
     )
+
+    assert is_classifier(pipeline)
+
     pipeline.fit(iris_features, iris_target_sr)
-    print(pipeline.predict(iris_features))
 
     # Stack of Pipelines doesn't
     stack_of_pipelines = StackingClassifierDF(
@@ -187,6 +198,9 @@ def test_stacking_classifier(
         final_estimator=LogisticRegressionDF(),
         passthrough=True,
     )
+
+    assert is_classifier(pipeline)
+
     stack_of_pipelines.fit(iris_features, iris_target_sr)
 
     pred = stack_of_pipelines.predict_proba(iris_features)

--- a/test/test/sklearndf/test_regression.py
+++ b/test/test/sklearndf/test_regression.py
@@ -2,6 +2,7 @@ from typing import List, Type
 
 import pandas as pd
 import pytest
+from sklearn.base import is_regressor
 from sklearn.multioutput import MultiOutputRegressor, RegressorChain
 
 import sklearndf.regression
@@ -48,6 +49,8 @@ def test_wrapped_fit_predict(
     regressor: RegressorDF = sklearndf_cls(
         **DEFAULT_REGRESSOR_PARAMETERS.get(sklearndf_cls.__name__, {})
     )
+
+    assert is_regressor(regressor)
 
     check_expected_not_fitted_error(estimator=regressor)
 

--- a/test/test/sklearndf/test_regression.py
+++ b/test/test/sklearndf/test_regression.py
@@ -38,14 +38,6 @@ DEFAULT_REGRESSOR_PARAMETERS = {
 
 
 @pytest.mark.parametrize(argnames="sklearndf_cls", argvalues=REGRESSORS_TO_TEST)
-def test_wrapped_constructor(sklearndf_cls: Type) -> None:
-    """ Test standard constructor of wrapped sklearn regressors """
-    _: RegressorDF = sklearndf_cls(
-        **DEFAULT_REGRESSOR_PARAMETERS.get(sklearndf_cls.__name__, {})
-    )
-
-
-@pytest.mark.parametrize(argnames="sklearndf_cls", argvalues=REGRESSORS_TO_TEST)
 def test_wrapped_fit_predict(
     sklearndf_cls: Type,
     boston_features: pd.DataFrame,

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -5,17 +5,24 @@ import pandas as pd
 import pytest
 import sklearn
 from pandas.testing import assert_frame_equal
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, is_classifier, is_regressor
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import Normalizer
 
 import sklearndf.transformation
-from sklearndf import TransformerDF
+from ... import check_sklearn_version
+from ...sklearndf import (
+    check_expected_not_fitted_error,
+    get_sklearndf_wrapper_class,
+    list_classes,
+)
+from sklearndf import ClassifierDF, RegressorDF, TransformerDF
 from sklearndf.classification import RandomForestClassifierDF
 from sklearndf.transformation import (
     RFECVDF,
     RFEDF,
     ColumnTransformerDF,
+    FeatureAgglomerationDF,
     KBinsDiscretizerDF,
     NormalizerDF,
     OneHotEncoderDF,
@@ -23,12 +30,7 @@ from sklearndf.transformation import (
     SparseCoderDF,
 )
 from sklearndf.transformation.extra import OutlierRemoverDF
-from test import check_sklearn_version
-from test.sklearndf import (
-    check_expected_not_fitted_error,
-    get_sklearndf_wrapper_class,
-    list_classes,
-)
+from sklearndf.wrapper import TransformerWrapperDF
 
 TRANSFORMERS_TO_TEST = list_classes(
     from_modules=sklearndf.transformation,
@@ -59,7 +61,22 @@ def test_data() -> pd.DataFrame:
 
 @pytest.mark.parametrize(argnames="sklearndf_cls", argvalues=TRANSFORMERS_TO_TEST)
 def test_wrapped_constructor(sklearndf_cls: Type[TransformerDF]) -> None:
-    sklearndf_cls()
+    transformer_df: TransformerDF = sklearndf_cls()
+
+    if isinstance(transformer_df, RegressorDF):
+        assert is_regressor(transformer_df)
+        assert not is_classifier(transformer_df)
+    elif isinstance(transformer_df, ClassifierDF):
+        assert is_classifier(transformer_df)
+        assert not is_regressor(transformer_df)
+    elif isinstance(transformer_df, TransformerWrapperDF):
+        if isinstance(transformer_df, FeatureAgglomerationDF):
+            assert transformer_df._estimator_type == "clusterer"
+        else:
+            # noinspection PyUnresolvedReferences
+            assert transformer_df._estimator_type is None
+    else:
+        assert getattr(transformer_df, "_estimator_type", None) is None
 
 
 def test_special_wrapped_constructors() -> None:


### PR DESCRIPTION
This PR implements `_estimator_type` as a `@property` of class `EstimatorWrapperDF` to provide the access of the same attribute in the delegate native estimator.

Also, this PR ensures that DF wrapper classes do not subclass more than one of `RegressorDF`, `ClassifierDF`, or `TransformerDF`; for classes that did this in the past this PR instead introduces a hierarchy of subclasses each of which only implements one estimator type. As the only exception, allow `PipelineWrapperDF` still implements `RegressorDF`, `ClassifierDF` and `TransformerDF` all at once, but relies on the `_estimator_type` property to delegate to the native pipeline instance.