### PR TITLE
FIX: back-port column transformer passthrough fix from 1.2.x branch

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,15 @@ Release Notes
 *sklearndf* 1.1
 ---------------
 
+1.1.2
+~~~~~
+
+This release comprises bugfixes and minor code tweaks.
+
+- FIX: accept `"passthrough"` as value for arg `remainder` of
+  :class:`.ColumnTransformerDF`
+
+
 1.1.1
 ~~~~~
 

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -4,7 +4,6 @@ Core implementation of :mod:`sklearndf.transformation.wrapper`
 
 import logging
 from abc import ABCMeta, abstractmethod
-from functools import reduce
 from typing import Any, Generic, List, Optional, TypeVar, Union
 
 import numpy as np
@@ -259,7 +258,10 @@ class ColumnTransformerWrapperDF(
     def _validate_delegate_estimator(self) -> None:
         column_transformer: ColumnTransformer = self.native_estimator
 
-        if column_transformer.remainder != ColumnTransformerWrapperDF.__DROP:
+        if (
+            column_transformer.remainder
+            not in ColumnTransformerWrapperDF.__SPECIAL_TRANSFORMERS
+        ):
             raise ValueError(
                 f"unsupported value for arg remainder: ({column_transformer.remainder})"
             )
@@ -291,20 +293,29 @@ class ColumnTransformerWrapperDF(
         values the corresponding input column names.
         """
 
-        return reduce(
-            lambda x, y: x.append(y),
-            (
-                (
-                    pd.Series(index=columns, data=columns)
-                    if df_transformer == ColumnTransformerWrapperDF.__PASSTHROUGH
-                    else df_transformer.feature_names_original_
-                )
+        def _features_original(df_transformer: TransformerDF, columns: List[Any]):
+            if df_transformer == ColumnTransformerWrapperDF.__PASSTHROUGH:
+                # we may get positional indices for columns selected by the
+                # 'passthrough' transformer, and in that case so need to look up the
+                # associated column names
+                if all(isinstance(column, int) for column in columns):
+                    column_names = self._get_features_in()[columns]
+                else:
+                    column_names = columns
+                return pd.Series(index=column_names, data=column_names)
+
+            else:
+                return df_transformer.feature_names_original_
+
+        return pd.concat(
+            [
+                _features_original(df_transformer, columns)
                 for _, df_transformer, columns in self.native_estimator.transformers_
                 if (
                     len(columns) > 0
                     and df_transformer != ColumnTransformerWrapperDF.__DROP
                 )
-            ),
+            ]
         )
 
 


### PR DESCRIPTION
Apply fix #184 to the 1.1.x branch. Fixes #183.