### PR TITLE
API: introduce SupervisedLearnerDF

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,11 @@ Release Notes
 2.0.0
 ~~~~~
 
+- API: :class:`.ClassifierDF` and :class:`.RegressorDF` get a new base class
+  :class:`.SupervisedLearnerDF`, which in turn is based on :class:`.LearnerDF`;
+  :class:`.SupervisedLearnerDF` implements method :meth:`~.SupervisedLearnerDF.score`,
+  which is no longer implemented by :class:`.LearnerDF`
+- API: new class :class:`.ClustererDF`, based on :class:`.LearnerDF`
 - API: class :class:`.EstimatorDF` now implements the :class:`.HasExpressionRepr`
   mix-in, rendering estimator representations as :class:`.Expression` objects
   to enable better formatting

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -23,7 +23,14 @@ from pytools.fit import FittableMixin
 
 log = logging.getLogger(__name__)
 
-__all__ = ["EstimatorDF", "LearnerDF", "ClassifierDF", "RegressorDF", "TransformerDF"]
+__all__ = [
+    "EstimatorDF",
+    "LearnerDF",
+    "ClassifierDF",
+    "RegressorDF",
+    "SupervisedLearnerDF",
+    "TransformerDF",
+]
 
 #
 # type variables
@@ -272,6 +279,14 @@ class LearnerDF(EstimatorDF, metaclass=ABCMeta):
         """
         pass
 
+
+class SupervisedLearnerDF(LearnerDF, metaclass=ABCMeta):
+    """
+    Base class for augmented scikit-learn `supervised learners`.
+
+    Provides enhanced support for data frames.
+    """
+
     # noinspection PyPep8Naming
     @abstractmethod
     def score(
@@ -401,7 +416,7 @@ class TransformerDF(EstimatorDF, TransformerMixin, metaclass=ABCMeta):
         return self.feature_names_original_.index
 
 
-class RegressorDF(LearnerDF, RegressorMixin, metaclass=ABCMeta):
+class RegressorDF(SupervisedLearnerDF, RegressorMixin, metaclass=ABCMeta):
     """
     Base class for augmented scikit-learn `regressors`.
 
@@ -409,7 +424,7 @@ class RegressorDF(LearnerDF, RegressorMixin, metaclass=ABCMeta):
     """
 
 
-class ClassifierDF(LearnerDF, ClassifierMixin, metaclass=ABCMeta):
+class ClassifierDF(SupervisedLearnerDF, ClassifierMixin, metaclass=ABCMeta):
     """
     Base class for augmented scikit-learn `classifiers`.
 

--- a/src/sklearndf/pipeline/_learner_pipeline.py
+++ b/src/sklearndf/pipeline/_learner_pipeline.py
@@ -10,15 +10,30 @@ import pandas as pd
 
 from pytools.api import AllTracker, inheritdoc
 
-from .. import ClassifierDF, EstimatorDF, LearnerDF, RegressorDF, TransformerDF
+from .. import (
+    ClassifierDF,
+    EstimatorDF,
+    LearnerDF,
+    RegressorDF,
+    SupervisedLearnerDF,
+    TransformerDF,
+)
 
 log = logging.getLogger(__name__)
 
-__all__ = ["LearnerPipelineDF", "RegressorPipelineDF", "ClassifierPipelineDF"]
+__all__ = [
+    "LearnerPipelineDF",
+    "SupervisedLearnerPipelineDF",
+    "RegressorPipelineDF",
+    "ClassifierPipelineDF",
+]
 
 T_Self = TypeVar("T_Self")
 T_FinalEstimatorDF = TypeVar("T_FinalEstimatorDF", bound=EstimatorDF)
 T_FinalLearnerDF = TypeVar("T_FinalLearnerDF", bound=LearnerDF)
+T_FinalSupervisedLearnerDF = TypeVar(
+    "T_FinalSupervisedLearnerDF", bound=SupervisedLearnerDF
+)
 T_FinalRegressorDF = TypeVar("T_FinalRegressorDF", bound=RegressorDF)
 T_FinalClassifierDF = TypeVar("T_FinalClassifierDF", bound=ClassifierDF)
 
@@ -212,6 +227,19 @@ class LearnerPipelineDF(
             self._pre_fit_transform(X, y, **fit_params), y, **fit_params
         )
 
+
+@inheritdoc(match="[see superclass]")
+class SupervisedLearnerPipelineDF(
+    LearnerPipelineDF[T_FinalSupervisedLearnerDF],
+    SupervisedLearnerDF,
+    Generic[T_FinalSupervisedLearnerDF],
+    metaclass=ABCMeta,
+):
+    """
+    A data frame enabled pipeline with an optional preprocessing step and a
+    mandatory supervised learner step.
+    """
+
     # noinspection PyPep8Naming
     def score(
         self,
@@ -230,7 +258,9 @@ class LearnerPipelineDF(
 
 @inheritdoc(match="[see superclass]")
 class RegressorPipelineDF(
-    LearnerPipelineDF[T_FinalRegressorDF], RegressorDF, Generic[T_FinalRegressorDF]
+    SupervisedLearnerPipelineDF[T_FinalRegressorDF],
+    RegressorDF,
+    Generic[T_FinalRegressorDF],
 ):
     """
     A data frame enabled pipeline with an optional preprocessing step and a
@@ -271,7 +301,9 @@ class RegressorPipelineDF(
 
 @inheritdoc(match="[see superclass]")
 class ClassifierPipelineDF(
-    LearnerPipelineDF[T_FinalClassifierDF], ClassifierDF, Generic[T_FinalClassifierDF]
+    SupervisedLearnerPipelineDF[T_FinalClassifierDF],
+    ClassifierDF,
+    Generic[T_FinalClassifierDF],
 ):
     """
     A data frame enabled pipeline with an optional preprocessing step and a

--- a/src/sklearndf/regression/wrapper/_wrapper.py
+++ b/src/sklearndf/regression/wrapper/_wrapper.py
@@ -13,7 +13,7 @@ from sklearn.isotonic import IsotonicRegression
 
 from pytools.api import AllTracker
 
-from sklearndf import LearnerDF, RegressorDF
+from sklearndf import RegressorDF, SupervisedLearnerDF
 from sklearndf.transformation.wrapper import (
     ColumnPreservingTransformerWrapperDF,
     NumpyTransformerWrapperDF,
@@ -87,12 +87,14 @@ class StackingRegressorWrapperDF(
     """
 
     @staticmethod
-    def _make_default_final_estimator() -> LearnerDF:
+    def _make_default_final_estimator() -> SupervisedLearnerDF:
         from sklearndf.regression import RidgeCVDF
 
         return RidgeCVDF()
 
-    def _make_stackable_learner_df(self, learner: LearnerDF) -> _StackableRegressorDF:
+    def _make_stackable_learner_df(
+        self, learner: SupervisedLearnerDF
+    ) -> _StackableRegressorDF:
         return _StackableRegressorDF(learner)
 
     def _make_learner_np_df(

--- a/src/sklearndf/wrapper/_adapter.py
+++ b/src/sklearndf/wrapper/_adapter.py
@@ -10,7 +10,14 @@ import pandas as pd
 
 from pytools.api import AllTracker, inheritdoc
 
-from sklearndf import ClassifierDF, EstimatorDF, LearnerDF, RegressorDF, TransformerDF
+from sklearndf import (
+    ClassifierDF,
+    EstimatorDF,
+    LearnerDF,
+    RegressorDF,
+    SupervisedLearnerDF,
+    TransformerDF,
+)
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +25,7 @@ __all__ = [
     "ClassifierNPDF",
     "EstimatorNPDF",
     "LearnerNPDF",
+    "SupervisedLearnerNPDF",
     "RegressorNPDF",
     "TransformerNPDF",
 ]
@@ -29,6 +37,9 @@ __all__ = [
 T_Self = TypeVar("T_Self")
 T_DelegateEstimatorDF = TypeVar("T_DelegateEstimatorDF", bound=EstimatorDF)
 T_DelegateLearnerDF = TypeVar("T_DelegateLearnerDF", bound=LearnerDF)
+T_DelegateSupervisedLearnerDF = TypeVar(
+    "T_DelegateSupervisedLearnerDF", bound=SupervisedLearnerDF
+)
 T_DelegateClassifierDF = TypeVar("T_DelegateClassifierDF", bound=ClassifierDF)
 T_DelegateRegressorDF = TypeVar("T_DelegateRegressorDF", bound=RegressorDF)
 T_DelegateTransformerDF = TypeVar("T_DelegateTransformerDF", bound=TransformerDF)
@@ -169,6 +180,16 @@ class LearnerNPDF(
             self._ensure_X_frame(X), self._ensure_y_series_or_frame(y), **fit_params
         )
 
+
+# noinspection PyPep8Naming
+@inheritdoc(match="""[see superclass]""")
+class SupervisedLearnerNPDF(
+    LearnerNPDF[T_DelegateSupervisedLearnerDF],
+    SupervisedLearnerDF,
+    Generic[T_DelegateSupervisedLearnerDF],
+):
+    """[see superclass]"""
+
     def score(
         self,
         X: Union[np.ndarray, pd.DataFrame],
@@ -186,7 +207,7 @@ class LearnerNPDF(
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
 class ClassifierNPDF(
-    LearnerNPDF[T_DelegateClassifierDF],
+    SupervisedLearnerNPDF[T_DelegateClassifierDF],
     ClassifierDF,
     Generic[T_DelegateClassifierDF],
 ):
@@ -229,7 +250,7 @@ class ClassifierNPDF(
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
 class RegressorNPDF(
-    LearnerNPDF[T_DelegateRegressorDF],
+    SupervisedLearnerNPDF[T_DelegateRegressorDF],
     RegressorDF,
     Generic[T_DelegateRegressorDF],
 ):


### PR DESCRIPTION
Hi @j-ittner @joerg-schneider!

Here's a PR based on Friday's discussion: a separation of `LearnerDF` into `LearnerDF` and `SupervisedLearnerDF` for easy incorporation of clustering algorithms (introduced in the other PR).

And here's new inheritance hierarchy:
```
                 ┌───────────┐
            ┌───►│EstimatorDF│  # introduces `fit`
            │    └───────────┘
            │          ▲
            │          │
 ┌──────────┴──┐  ┌────┴────┐
 │TransformerDF│  │LearnerDF│  # introduces `predict` and `fit_predict`
 └─────────────┘  └─────────┘
                   ▲      ▲
         ┌─────────┘      │
         │                │
┌────────┴──┐   ┌─────────┴─────────┐
│ClustererDF│   │SupervisedLearnerDF│ # introduces `score`
└───────────┘   └───────────────────┘
                 ▲               ▲
                 │               │
                 │               │
      ┌──────────┴─┐    ┌────────┴──┐
      │ClassifierDF│    │RegressorDF│
      └────────────┘    └───────────┘
```
What do you think?