### PR TITLE
API: move `FeatureAgglomeration` to clusterers

### DIFF
--- a/src/sklearndf/clustering/_clustering.py
+++ b/src/sklearndf/clustering/_clustering.py
@@ -9,6 +9,7 @@ from sklearn.cluster import (
     AffinityPropagation,
     AgglomerativeClustering,
     Birch,
+    FeatureAgglomeration,
     KMeans,
     MeanShift,
     MiniBatchKMeans,
@@ -18,7 +19,7 @@ from sklearn.cluster import (
 from pytools.api import AllTracker
 
 from ..wrapper import make_df_clusterer
-from .wrapper import KMeansBaseWrapperDF
+from .wrapper import FeatureAgglomerationWrapperDF, KMeansBaseWrapperDF
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ __all__ = [
     "AgglomerativeClusteringDF",
     "BirchDF",
     "DBSCANDF",
+    "FeatureAgglomerationDF",
     "KMeansDF",
     "MiniBatchKMeansDF",
     "MeanShiftDF",
@@ -57,7 +59,9 @@ MiniBatchKMeansDF = make_df_clusterer(MiniBatchKMeans, base_wrapper=KMeansBaseWr
 MeanShiftDF = make_df_clusterer(MeanShift)
 OPTICSDF = make_df_clusterer(OPTICS)
 SpectralClusteringDF = make_df_clusterer(SpectralClustering)
-
+FeatureAgglomerationDF = make_df_clusterer(
+    FeatureAgglomeration, base_wrapper=FeatureAgglomerationWrapperDF
+)
 
 #
 # Validate __all__

--- a/src/sklearndf/clustering/wrapper/_wrapper.py
+++ b/src/sklearndf/clustering/wrapper/_wrapper.py
@@ -7,16 +7,18 @@ from abc import ABCMeta
 from typing import Generic, TypeVar
 
 import pandas as pd
-from sklearn.cluster import KMeans, MiniBatchKMeans
+from sklearn.cluster import FeatureAgglomeration, KMeans, MiniBatchKMeans
 
 from pytools.api import AllTracker
 
+from sklearndf.transformation.wrapper import ColumnPreservingTransformerWrapperDF
 from sklearndf.wrapper import ClustererWrapperDF
 
 log = logging.getLogger(__name__)
 
 __all__ = [
     "KMeansBaseWrapperDF",
+    "FeatureAgglomerationWrapperDF",
 ]
 
 #
@@ -66,6 +68,18 @@ class KMeansBaseWrapperDF(
                 len(raw_cluster_centers), name=KMeansBaseWrapperDF.IDX_CLUSTER
             ),
         )
+
+
+class FeatureAgglomerationWrapperDF(
+    ClustererWrapperDF[FeatureAgglomeration],
+    ColumnPreservingTransformerWrapperDF[FeatureAgglomeration],
+    metaclass=ABCMeta,
+):
+    """
+    DF wrapper for FeatureAgglomeration that combines clusterer and transformer.
+    """
+
+    pass
 
 
 #

--- a/src/sklearndf/regression/wrapper/_wrapper.py
+++ b/src/sklearndf/regression/wrapper/_wrapper.py
@@ -44,7 +44,6 @@ __all__ = [
 T_PartialFitRegressorWrapperDF = TypeVar(
     "T_PartialFitRegressorWrapperDF", bound="PartialFitRegressorWrapperDF"
 )
-T_Regressor = TypeVar("T_Regressor", bound=RegressorMixin)
 T_NativeRegressor = TypeVar("T_NativeRegressor", bound=RegressorMixin)
 
 
@@ -171,9 +170,9 @@ class StackingRegressorWrapperDF(
 
 
 class RegressorTransformerWrapperDF(
-    RegressorWrapperDF[T_Regressor],
-    ColumnPreservingTransformerWrapperDF[T_Regressor],
-    Generic[T_Regressor],
+    RegressorWrapperDF[T_NativeRegressor],
+    ColumnPreservingTransformerWrapperDF[T_NativeRegressor],
+    Generic[T_NativeRegressor],
     metaclass=ABCMeta,
 ):
     """

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -4,7 +4,6 @@ Core implementation of :mod:`sklearndf.transformation`
 
 import logging
 
-from sklearn.cluster import FeatureAgglomeration
 from sklearn.compose import ColumnTransformer
 from sklearn.cross_decomposition import PLSSVD
 from sklearn.decomposition import (
@@ -99,7 +98,6 @@ __all__ = [
     "DictionaryLearningDF",
     "FactorAnalysisDF",
     "FastICADF",
-    "FeatureAgglomerationDF",
     "FeatureHasherDF",
     "FunctionTransformerDF",
     "GaussianRandomProjectionDF",
@@ -166,16 +164,6 @@ __tracker = AllTracker(globals(), allow_imported_definitions=True)
 #
 # Class definitions
 #
-
-#
-# cluster
-#
-
-
-FeatureAgglomerationDF = make_df_transformer(
-    FeatureAgglomeration, base_wrapper=ColumnPreservingTransformerWrapperDF
-)
-
 
 #
 # compose

--- a/test/test/sklearndf/__init__.py
+++ b/test/test/sklearndf/__init__.py
@@ -1,7 +1,7 @@
 import re
 import sys
 from distutils import version
-from typing import Any, Dict, Iterable, Optional, Set, Type, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Type, Union
 
 import pandas as pd
 import sklearn
@@ -55,7 +55,7 @@ def iterate_classes(
     from_modules: Union[Module, Iterable[Module]],
     matching: str,
     excluding: Optional[Union[str, Iterable[str]]] = None,
-) -> Iterable[Type[EstimatorWrapperDF]]:
+) -> List[Type[EstimatorWrapperDF]]:
     """ Helper to return all classes with matching name from Python module(s) """
 
     if not isinstance(from_modules, Iterable):
@@ -64,12 +64,12 @@ def iterate_classes(
     if excluding and not isinstance(excluding, str):
         excluding = "|".join(f"({exclude_pattern})" for exclude_pattern in excluding)
 
-    return (
+    return [
         m
         for m in find_all_classes(*from_modules)
         if re.match(matching, m.__name__)
         and not (excluding and re.match(excluding, m.__name__))
-    )
+    ]
 
 
 def get_sklearndf_wrapper_class(

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -5,15 +5,16 @@ import pytest
 
 import sklearndf.clustering
 from sklearndf import ClustererDF
+from sklearndf.clustering import FeatureAgglomerationDF
 from test.sklearndf import iterate_classes
 
-CLUSTERERS_TO_TEST = list(
-    iterate_classes(
-        from_modules=sklearndf.clustering,
-        matching=r".*DF",
-        excluding=[ClustererDF.__name__, r".*WrapperDF"],
-    )
+CLUSTERERS_TO_TEST = iterate_classes(
+    from_modules=sklearndf.clustering,
+    matching=r".*DF",
+    excluding=[ClustererDF.__name__, r".*WrapperDF", FeatureAgglomerationDF.__name__],
 )
+# FeatureAgglomeration doesn't support `fit_predict` method
+CLUSTERERS_WITH_AGGLOMERATION = CLUSTERERS_TO_TEST + [FeatureAgglomerationDF]
 
 
 @pytest.mark.parametrize(argnames="sklearn_clusterer_cls", argvalues=CLUSTERERS_TO_TEST)
@@ -30,7 +31,9 @@ def test_clusterer_fit_predict_call(
     assert clusterer_instance.is_fitted
 
 
-@pytest.mark.parametrize(argnames="sklearn_clusterer_cls", argvalues=CLUSTERERS_TO_TEST)
+@pytest.mark.parametrize(
+    argnames="sklearn_clusterer_cls", argvalues=CLUSTERERS_WITH_AGGLOMERATION
+)
 def test_clusterer_fit_call(
     iris_features: pd.DataFrame, sklearn_clusterer_cls: Type
 ) -> None:

--- a/test/test/sklearndf/test_sklearn_coverage.py
+++ b/test/test/sklearndf/test_sklearn_coverage.py
@@ -70,8 +70,6 @@ PIPELINE_COVERAGE_EXCLUSIONS = GENERAL_COVERAGE_EXCLUSIONS
 
 CLUSTERER_COVERAGE_EXCLUSIONS = {
     *GENERAL_COVERAGE_EXCLUSIONS,
-    # class "FeatureAgglomeration" is already included via Transformers
-    "FeatureAgglomeration",
 }
 
 

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -26,11 +26,11 @@ from sklearndf import (
     __sklearn_version__,
 )
 from sklearndf.classification import RandomForestClassifierDF
+from sklearndf.clustering import FeatureAgglomerationDF
 from sklearndf.transformation import (
     RFECVDF,
     RFEDF,
     ColumnTransformerDF,
-    FeatureAgglomerationDF,
     KBinsDiscretizerDF,
     NormalizerDF,
     OneHotEncoderDF,
@@ -64,6 +64,7 @@ TRANSFORMERS_TO_TEST = iterate_classes(
     matching=r".*DF",
     excluding=TRANSFORMER_EXCLUSIONS,
 )
+TRANSFORMERS_TO_TEST.append(FeatureAgglomerationDF)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR moves `FeatureAgglomeration` to clusterers as it implements both `ClusteringMixin` and `TransformerMixin`.