### PR TITLE
BUILD: move __version__ to sklearndf.__init__ so flit can pick it up

### DIFF
--- a/src/sklearndf/__init__.py
+++ b/src/sklearndf/__init__.py
@@ -9,9 +9,8 @@ from packaging.version import parse as __parse_version
 from sklearn import __version__ as __sklearn_version__
 
 from ._sklearndf import *
-from ._version import __version__
 
-__version__: str  # noqa: F811
+__version__ = "1.1.4"
 
 __sklearn_version__ = __parse_version(__sklearn_version__)
 __sklearn_0_22__ = __parse_version("0.22")

--- a/src/sklearndf/_version.py
+++ b/src/sklearndf/_version.py
@@ -1,5 +1,0 @@
-"""
-Define the package version for gamma-sklearndf – done here so that it can be used
-without external dependencies (pandas, sklearn, ...).
-"""
-__version__ = "1.1.4"


### PR DESCRIPTION
This is to address a [new issue with flit](https://github.com/pypa/flit/issues/530).

This PR moves the `__version__` declaration to the top-level `__init__` file, where flit can pick it up without actually importing the module.

Enabled by BCG-Gamma/pytools#297