### PR TITLE
API: make boruta_py an optional package; move wrapper class to submodule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,4 @@ repos:
         language_version: python38
         additional_dependencies:
           - numpy~=1.22
-          - gamma-pytools~=2.0,>=2.0.1
+          - gamma-pytools~=2.0,!=2.0.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
               versionSpec: '3.8'
             displayName: 'use Python 3.8'
           - script: |
-              python -m pip install mypy~=0.961 numpy~=1.22 gamma-pytools~=2.0
+              python -m pip install mypy~=0.971 numpy~=1.22 gamma-pytools~=2.0,!=2.0.0
               python -m mypy src
             displayName: 'Run mypy'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dist-name = "sklearndf"
 license = "Apache Software License v2.0"
 
 requires = [
-    "boruta         ~=0.3",
     "gamma-pytools  ~=2.0,>=2.0.1",
     "numpy          >=1.21,<2a",  # cannot use ~= due to conda bug
     "packaging      >=20",
@@ -43,9 +42,10 @@ classifiers = [
 
 [tool.flit.metadata.requires-extra]
 testing = [
+    "boruta ~=0.3",
+    "lightgbm ~= 3.3",
     "pytest ~= 7.1",
     "pytest-cov ~= 2.8",
-    "lightgbm ~= 3.3",
     "xgboost ~= 1.5",
 ]
 

--- a/src/sklearndf/classification/extra/__init__.py
+++ b/src/sklearndf/classification/extra/__init__.py
@@ -1,4 +1,8 @@
 """
 Additional 3rd party classifiers that implement the `scikit-learn` interface.
+
+Note that 3rd party packages implementing the associated native estimators must be
+installed explicitly: they are not included in `sklearndf`'s package requirements to
+achieve a lean package footprint for default installs of `sklearndf`.
 """
 from ._extra import *

--- a/src/sklearndf/regression/extra/__init__.py
+++ b/src/sklearndf/regression/extra/__init__.py
@@ -1,4 +1,8 @@
 """
 Additional 3rd party regressors that implement the `scikit-learn` interface.
+
+Note that 3rd party packages implementing the associated native estimators must be
+installed explicitly: they are not included in `sklearndf`'s package requirements to
+achieve a lean package footprint for default installs of `sklearndf`.
 """
 from ._extra import *

--- a/src/sklearndf/transformation/extra/__init__.py
+++ b/src/sklearndf/transformation/extra/__init__.py
@@ -1,4 +1,8 @@
 """
 Additional 3rd party transformers that implement the `scikit-learn` interface.
+
+Note that 3rd party packages implementing the associated native estimators must be
+installed explicitly: they are not included in `sklearndf`'s package requirements to
+achieve a lean package footprint for default installs of `sklearndf`.
 """
 from ._extra import *

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -5,17 +5,19 @@ from __future__ import annotations
 
 import logging
 
-import pandas as pd
-from boruta import BorutaPy
-
 from pytools.api import AllTracker
-
-from ...wrapper import MetaEstimatorWrapperDF
-from ..wrapper import ColumnSubsetTransformerWrapperDF, NumpyTransformerWrapperDF
 
 log = logging.getLogger(__name__)
 
-__all__ = ["BorutaPyWrapperDF", "BorutaDF"]
+__all__ = ["BorutaDF"]
+
+
+try:
+    # import boruta classes only if installed
+    from boruta import BorutaPy
+
+except ImportError:
+    BorutaPy = None
 
 
 #
@@ -29,24 +31,20 @@ __tracker = AllTracker(globals(), allow_imported_definitions=True)
 # Class definitions
 #
 
+if BorutaPy:
 
-class BorutaPyWrapperDF(
-    MetaEstimatorWrapperDF[BorutaPy],
-    NumpyTransformerWrapperDF[BorutaPy],
-    ColumnSubsetTransformerWrapperDF[BorutaPy],
-):
-    """
-    DF wrapper for :class:`~boruta.BorutaPy`.
-    """
+    from .wrapper import BorutaPyWrapperDF
 
-    def _get_features_out(self) -> pd.Index:
-        return self.feature_names_in_[self.native_estimator.support_]
+    class BorutaDF(BorutaPyWrapperDF, native=BorutaPy):
+        """
+        DF version of :class:`~boruta.BorutaPy`.
+        """
 
+    # remove the wrapper class from the global namespace to pass AllTracker validation
+    del BorutaPyWrapperDF
 
-class BorutaDF(BorutaPyWrapperDF, native=BorutaPy):
-    """
-    DF version of :class:`~boruta.BorutaPy`.
-    """
+else:
+    __all__.remove("BorutaDF")
 
 
 __tracker.validate()

--- a/src/sklearndf/transformation/extra/wrapper/__init__.py
+++ b/src/sklearndf/transformation/extra/wrapper/__init__.py
@@ -1,0 +1,6 @@
+"""
+DF wrapper classes for additional 3rd party transformers that implement the
+`scikit-learn` interface.
+"""
+
+from ._wrapper import *

--- a/src/sklearndf/transformation/extra/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/extra/wrapper/_wrapper.py
@@ -1,0 +1,52 @@
+"""
+Core implementation of :mod:`sklearndf.transformation.extra.wrapper`
+"""
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+from pytools.api import AllTracker
+
+from ....wrapper import MetaEstimatorWrapperDF
+from ...wrapper import ColumnSubsetTransformerWrapperDF, NumpyTransformerWrapperDF
+
+log = logging.getLogger(__name__)
+
+__all__ = ["BorutaPyWrapperDF"]
+
+try:
+    # import boruta classes only if installed
+    from boruta import BorutaPy
+except ImportError:
+    BorutaPy = None
+
+#
+# Ensure all symbols introduced below are included in __all__
+#
+
+__tracker = AllTracker(globals())
+
+#
+# Class definitions
+#
+
+if BorutaPy:
+
+    class BorutaPyWrapperDF(
+        MetaEstimatorWrapperDF[BorutaPy],
+        NumpyTransformerWrapperDF[BorutaPy],
+        ColumnSubsetTransformerWrapperDF[BorutaPy],
+    ):
+        """
+        DF wrapper for :class:`~boruta.BorutaPy`.
+        """
+
+        def _get_features_out(self) -> pd.Index:
+            return self.feature_names_in_[self.native_estimator.support_]
+
+else:
+    __all__.remove("BorutaPyWrapperDF")
+
+__tracker.validate()

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -389,7 +389,7 @@ class ImputerWrapperDF(TransformerWrapperDF[T_Imputer], metaclass=ABCMeta):
             stats: npt.NDArray[Any],
         ) -> Union[List[bool], npt.NDArray[np.bool_]]:
             if issubclass(stats.dtype.type, float):
-                return np.isnan(stats)
+                return cast(npt.NDArray[np.bool_], np.isnan(stats))
             else:
                 return [
                     x is None or (isinstance(x, float) and np.isnan(x)) for x in stats


### PR DESCRIPTION
We have made 3rd party packages _lgbm_ and _xgboost_ optional to achieve a leaner footprint of the basic _sklearndf_ installation. Consequentially, this PR does the same with _boruta_: now any DF estimator offered through a `sklearndf.*.extra` package will require a 3rd party package to be installed.