### PR TITLE
API: add sub-packages to sklearndf.wrapper

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -31,6 +31,11 @@ improvements, and is now subject to static type checking with :mod:`mypy`.
   for details
 - API: remove functions ``make_df_estimator``, ``make_df_classifier``,
   ``make_df_regressor``, and ``make_df_transformer`` which are now obsolete
+- API: move some classes in :mod:`sklearndf.wrapper` to sub-packages
+  :mod:`sklearndf.wrapper.stacking` and :mod:`sklearndf.wrapper.numpy` to improve
+  package navigability and to achieve better de-coupling of the underlying code;
+  this change also moves :class:`~.StackingClassifierWrapperDF` and
+  :class:`~.StackingRegressorWrapperDF` to package :mod:`sklearndf.wrapper.stacking`
 
 
 *sklearndf* 1.2

--- a/src/sklearndf/__init__.py
+++ b/src/sklearndf/__init__.py
@@ -5,17 +5,7 @@ Data frame support and feature traceability for `scikit-learn`.
 native support of data frames, while leaving the original API intact.
 """
 
-from packaging.version import Version as __Version
-from sklearn import __version__ as __sklearn_version_str
-
+from ._sklearn_version import *
 from ._sklearndf import *
 
 __version__ = "2.0.dev4"
-
-__sklearn_version__ = __Version(__sklearn_version_str)
-__sklearn_0_22__ = __Version("0.22")
-__sklearn_0_23__ = __Version("0.23")
-__sklearn_0_24__ = __Version("0.24")
-__sklearn_1_0__ = __Version("1.0")
-
-del __Version, __sklearn_version_str

--- a/src/sklearndf/_sklearn_version.py
+++ b/src/sklearndf/_sklearn_version.py
@@ -1,0 +1,20 @@
+"""
+Special constants for version checks for scikit-learn.
+"""
+
+from packaging.version import Version
+from sklearn import __version__ as sklearn_version
+
+__all__ = [
+    "__sklearn_version__",
+    "__sklearn_0_22__",
+    "__sklearn_0_23__",
+    "__sklearn_0_24__",
+    "__sklearn_1_0__",
+]
+
+__sklearn_version__ = Version(sklearn_version)
+__sklearn_0_22__ = Version("0.22")
+__sklearn_0_23__ = Version("0.23")
+__sklearn_0_24__ = Version("0.24")
+__sklearn_1_0__ = Version("1.0")

--- a/src/sklearndf/classification/_classification_v0_22.py
+++ b/src/sklearndf/classification/_classification_v0_22.py
@@ -9,7 +9,8 @@ from sklearn.naive_bayes import CategoricalNB
 
 from pytools.api import AllTracker
 
-from .wrapper import PartialFitClassifierWrapperDF, StackingClassifierWrapperDF
+from ..wrapper.stacking import StackingClassifierWrapperDF
+from .wrapper import PartialFitClassifierWrapperDF
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +30,6 @@ __tracker = AllTracker(globals(), allow_imported_definitions=True)
 # Class definitions
 #
 
-# todo: add other classification implementations for sklearn 0.22
 
 #
 # naive bayes

--- a/src/sklearndf/classification/wrapper/_wrapper.py
+++ b/src/sklearndf/classification/wrapper/_wrapper.py
@@ -4,17 +4,7 @@ Core implementation of :mod:`sklearndf.classification.wrapper`
 
 import logging
 from abc import ABCMeta
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    List,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Generic, List, Optional, Sequence, TypeVar, Union, cast
 
 import numpy.typing as npt
 import pandas as pd
@@ -24,13 +14,8 @@ from sklearn.multioutput import ClassifierChain, MultiOutputClassifier
 
 from pytools.api import AllTracker
 
-from sklearndf import ClassifierDF, LearnerDF
-from sklearndf.transformation.wrapper import NComponentsDimensionalityReductionWrapperDF
-from sklearndf.wrapper import (
-    ClassifierWrapperDF,
-    MetaEstimatorWrapperDF,
-    StackingEstimatorWrapperDF,
-)
+from ...transformation.wrapper import NComponentsDimensionalityReductionWrapperDF
+from ...wrapper import ClassifierWrapperDF, MetaEstimatorWrapperDF
 
 log = logging.getLogger(__name__)
 
@@ -39,7 +24,6 @@ __all__ = [
     "LinearDiscriminantAnalysisWrapperDF",
     "MetaClassifierWrapperDF",
     "MultiOutputClassifierWrapperDF",
-    "StackingClassifierWrapperDF",
     "PartialFitClassifierWrapperDF",
 ]
 
@@ -47,7 +31,6 @@ __all__ = [
 # Type variables
 #
 
-T_DelegateClassifierDF = TypeVar("T_DelegateClassifierDF", bound=ClassifierDF)
 T_PartialFitClassifierWrapperDF = TypeVar(
     "T_PartialFitClassifierWrapperDF",
     bound="PartialFitClassifierWrapperDF[ClassifierMixin]",
@@ -226,51 +209,6 @@ class ClassifierChainWrapperDF(
         return super()._prediction_with_class_labels(
             X, prediction, classes=range(self.n_outputs_)
         )
-
-
-# noinspection PyProtectedMember
-from ...wrapper._adapter import ClassifierNPDF as _ClassifierNPDF
-
-# noinspection PyProtectedMember
-from ...wrapper._wrapper import _StackableClassifierDF
-
-
-class StackingClassifierWrapperDF(
-    ClassifierWrapperDF[T_NativeClassifier],
-    StackingEstimatorWrapperDF[T_NativeClassifier],
-    Generic[T_NativeClassifier],
-    metaclass=ABCMeta,
-):
-    """
-    Abstract base class of DF wrappers for classifiers implementing
-    :class:`sklearn.ensemble._stacking._BaseStacking`.
-    """
-
-    @staticmethod
-    def _make_default_final_estimator() -> LearnerDF:
-        from sklearndf.classification import LogisticRegressionDF
-
-        return LogisticRegressionDF()
-
-    def _get_estimators_features_out(self) -> List[str]:
-        classes = self.native_estimator.classes_
-        names = super()._get_estimators_features_out()
-        if len(classes) > 2:
-            return [f"{name}_{c}" for name in names for c in classes]
-        else:
-            return names
-
-    def _make_stackable_learner_df(
-        self, learner: ClassifierDF
-    ) -> _StackableClassifierDF:
-        return _StackableClassifierDF(learner)
-
-    def _make_learner_np_df(
-        self,
-        delegate: T_DelegateClassifierDF,
-        column_names: Callable[[], Sequence[str]],
-    ) -> _ClassifierNPDF[T_DelegateClassifierDF]:
-        return _ClassifierNPDF(delegate, column_names)
 
 
 #

--- a/src/sklearndf/regression/_regression_v0_22.py
+++ b/src/sklearndf/regression/_regression_v0_22.py
@@ -8,7 +8,7 @@ from sklearn.ensemble import StackingRegressor
 
 from pytools.api import AllTracker
 
-from .wrapper import StackingRegressorWrapperDF
+from ..wrapper.stacking import StackingRegressorWrapperDF
 
 log = logging.getLogger(__name__)
 

--- a/src/sklearndf/regression/wrapper/_wrapper.py
+++ b/src/sklearndf/regression/wrapper/_wrapper.py
@@ -4,7 +4,7 @@ Core implementation of :mod:`sklearndf.regression.wrapper`
 
 import logging
 from abc import ABCMeta
-from typing import Any, Callable, Generic, Optional, Sequence, TypeVar, Union, cast
+from typing import Any, Generic, Optional, TypeVar, Union, cast
 
 import numpy.typing as npt
 import pandas as pd
@@ -14,16 +14,11 @@ from sklearn.multioutput import MultiOutputRegressor
 
 from pytools.api import AllTracker
 
-from sklearndf import RegressorDF, SupervisedLearnerDF
-from sklearndf.transformation.wrapper import (
+from ...transformation.wrapper import (
     ColumnPreservingTransformerWrapperDF,
     NumpyTransformerWrapperDF,
 )
-from sklearndf.wrapper import (
-    MetaEstimatorWrapperDF,
-    RegressorWrapperDF,
-    StackingEstimatorWrapperDF,
-)
+from ...wrapper import MetaEstimatorWrapperDF, RegressorWrapperDF
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +26,6 @@ __all__ = [
     "IsotonicRegressionWrapperDF",
     "MetaRegressorWrapperDF",
     "RegressorTransformerWrapperDF",
-    "StackingRegressorWrapperDF",
     "PartialFitRegressorWrapperDF",
     "MultiOutputRegressorWrapperDF",
 ]
@@ -41,7 +35,6 @@ __all__ = [
 # type variables
 #
 
-T_DelegateRegressorDF = TypeVar("T_DelegateRegressorDF", bound=RegressorDF)
 T_PartialFitRegressorWrapperDF = TypeVar(
     "T_PartialFitRegressorWrapperDF",
     bound="PartialFitRegressorWrapperDF[RegressorMixin]",
@@ -139,39 +132,6 @@ class MultiOutputRegressorWrapperDF(
     """
 
     pass
-
-
-# noinspection PyProtectedMember
-from ...wrapper._adapter import RegressorNPDF as _RegressorNPDF
-
-# noinspection PyProtectedMember
-from ...wrapper._wrapper import _StackableRegressorDF
-
-
-class StackingRegressorWrapperDF(
-    StackingEstimatorWrapperDF[T_NativeRegressor],
-    RegressorWrapperDF[T_NativeRegressor],
-    Generic[T_NativeRegressor],
-    metaclass=ABCMeta,
-):
-    """
-    Abstract base class of DF wrappers for regressors implementing
-    :class:`sklearn.ensemble._stacking._BaseStacking`.
-    """
-
-    @staticmethod
-    def _make_default_final_estimator() -> SupervisedLearnerDF:
-        from sklearndf.regression import RidgeCVDF
-
-        return RidgeCVDF()
-
-    def _make_stackable_learner_df(self, learner: RegressorDF) -> _StackableRegressorDF:
-        return _StackableRegressorDF(learner)
-
-    def _make_learner_np_df(
-        self, delegate: T_DelegateRegressorDF, column_names: Callable[[], Sequence[str]]
-    ) -> _RegressorNPDF[T_DelegateRegressorDF]:
-        return _RegressorNPDF(delegate, column_names)
 
 
 class RegressorTransformerWrapperDF(

--- a/src/sklearndf/wrapper/_adapter.py
+++ b/src/sklearndf/wrapper/_adapter.py
@@ -168,6 +168,10 @@ class LearnerNPDF(
 ):
     """[see superclass]"""
 
+    # repeating attribute declarations of base classes for Sphinx documentation
+    delegate: T_DelegateLearnerDF
+    column_names: Optional[Union[Sequence[str], Callable[[], Sequence[str]]]]
+
     def predict(
         self, X: Union[npt.NDArray[Any], pd.DataFrame], **predict_params: Any
     ) -> Union[pd.Series, pd.DataFrame]:
@@ -183,6 +187,10 @@ class SupervisedLearnerNPDF(
     Generic[T_DelegateSupervisedLearnerDF],
 ):
     """[see superclass]"""
+
+    # repeating attribute declarations of base classes for Sphinx documentation
+    delegate: T_DelegateSupervisedLearnerDF
+    column_names: Optional[Union[Sequence[str], Callable[[], Sequence[str]]]]
 
     def score(
         self,
@@ -206,6 +214,10 @@ class ClassifierNPDF(
     Generic[T_DelegateClassifierDF],
 ):
     """[see superclass]"""
+
+    # repeating attribute declarations of base classes for Sphinx documentation
+    delegate: T_DelegateClassifierDF
+    column_names: Optional[Union[Sequence[str], Callable[[], Sequence[str]]]]
 
     @property
     def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
@@ -250,6 +262,10 @@ class RegressorNPDF(
 ):
     """[see superclass]"""
 
+    # repeating attribute declarations of base classes for Sphinx documentation
+    delegate: T_DelegateRegressorDF
+    column_names: Optional[Union[Sequence[str], Callable[[], Sequence[str]]]]
+
 
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
@@ -259,6 +275,10 @@ class TransformerNPDF(
     Generic[T_DelegateTransformerDF],
 ):
     """[see superclass]"""
+
+    # repeating attribute declarations of base classes for Sphinx documentation
+    delegate: T_DelegateTransformerDF
+    column_names: Optional[Union[Sequence[str], Callable[[], Sequence[str]]]]
 
     def transform(self, X: Union[npt.NDArray[Any], pd.DataFrame]) -> pd.DataFrame:
         """[see superclass]"""

--- a/src/sklearndf/wrapper/numpy/__init__.py
+++ b/src/sklearndf/wrapper/numpy/__init__.py
@@ -1,0 +1,8 @@
+"""
+Adapter classes that wrap DF estimators and accept numpy arrays for all DF estimator
+methods that would usually only accept pandas data frames or series.
+
+For use in meta-estimators that internally pass on numpy arrays to sub-estimators.
+"""
+
+from ._numpy import *

--- a/src/sklearndf/wrapper/numpy/_numpy.py
+++ b/src/sklearndf/wrapper/numpy/_numpy.py
@@ -9,7 +9,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
-from pytools.api import AllTracker, inheritdoc
+from pytools.api import AllTracker, inheritdoc, subsdoc
 
 from sklearndf import (
     ClassifierDF,
@@ -59,9 +59,8 @@ class EstimatorNPDF(
     Generic[T_DelegateEstimatorDF],
 ):
     """
-    An adapter class that wraps around a :class:`.EstimatorDF` and accepts numpy arrays
-    for all DF estimator methods that would usually only accept pandas data frames or
-    series.
+    Adapter class that delegates to :class:`.EstimatorDF` and accepts numpy arrays
+    in addition to :mod:`pandas` data frames and series.
 
     Converts all numpy arrays to pandas series or data frames before deferring to the
     delegate estimator, and passes through pandas objects unchanged.
@@ -163,6 +162,7 @@ class EstimatorNPDF(
 
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
+@subsdoc(pattern="EstimatorDF", replacement="LearnerDF", using=EstimatorNPDF)
 class LearnerNPDF(
     EstimatorNPDF[T_DelegateLearnerDF], LearnerDF, Generic[T_DelegateLearnerDF]
 ):
@@ -181,6 +181,7 @@ class LearnerNPDF(
 
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
+@subsdoc(pattern="EstimatorDF", replacement="SupervisedLearnerDF", using=EstimatorNPDF)
 class SupervisedLearnerNPDF(
     LearnerNPDF[T_DelegateSupervisedLearnerDF],
     SupervisedLearnerDF,
@@ -208,6 +209,7 @@ class SupervisedLearnerNPDF(
 
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
+@subsdoc(pattern="EstimatorDF", replacement="ClassifierDF", using=EstimatorNPDF)
 class ClassifierNPDF(
     SupervisedLearnerNPDF[T_DelegateClassifierDF],
     ClassifierDF,
@@ -255,6 +257,7 @@ class ClassifierNPDF(
 
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
+@subsdoc(pattern="EstimatorDF", replacement="RegressorDF", using=EstimatorNPDF)
 class RegressorNPDF(
     SupervisedLearnerNPDF[T_DelegateRegressorDF],
     RegressorDF,
@@ -269,6 +272,7 @@ class RegressorNPDF(
 
 # noinspection PyPep8Naming
 @inheritdoc(match="""[see superclass]""")
+@subsdoc(pattern="EstimatorDF", replacement="TransformerDF", using=EstimatorNPDF)
 class TransformerNPDF(
     EstimatorNPDF[T_DelegateTransformerDF],
     TransformerDF,

--- a/src/sklearndf/wrapper/numpy/_numpy.py
+++ b/src/sklearndf/wrapper/numpy/_numpy.py
@@ -1,5 +1,5 @@
 """
-Estimator adapter classes to handle numpy arrays in meta-estimators
+Estimator adapter classes to handle numpy arrays in meta-estimators.
 """
 
 import logging

--- a/src/sklearndf/wrapper/stacking/__init__.py
+++ b/src/sklearndf/wrapper/stacking/__init__.py
@@ -1,0 +1,5 @@
+"""
+DF wrapper classes for stacking estimators.
+"""
+
+from ._stacking import *

--- a/src/sklearndf/wrapper/stacking/_stacking.py
+++ b/src/sklearndf/wrapper/stacking/_stacking.py
@@ -1,0 +1,378 @@
+"""
+DF wrapper classes for stacking estimators.
+"""
+from __future__ import annotations
+
+import logging
+from abc import ABCMeta, abstractmethod
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from sklearn.base import (
+    BaseEstimator,
+    ClassifierMixin,
+    MetaEstimatorMixin,
+    RegressorMixin,
+)
+
+from pytools.api import AllTracker, inheritdoc, subsdoc
+
+from ... import ClassifierDF, LearnerDF, RegressorDF, SupervisedLearnerDF
+from .. import ClassifierWrapperDF, RegressorWrapperDF, SupervisedLearnerWrapperDF
+from ..numpy import ClassifierNPDF, RegressorNPDF, SupervisedLearnerNPDF
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "StackingEstimatorWrapperDF",
+    "StackingClassifierWrapperDF",
+    "StackingRegressorWrapperDF",
+]
+
+
+#
+# Type variables
+#
+
+T_DelegateClassifierDF = TypeVar("T_DelegateClassifierDF", bound=ClassifierDF)
+T_DelegateRegressorDF = TypeVar("T_DelegateRegressorDF", bound=RegressorDF)
+
+T_NativeSupervisedLearner = TypeVar(
+    "T_NativeSupervisedLearner", bound=Union[RegressorMixin, ClassifierMixin]
+)
+T_NativeRegressor = TypeVar("T_NativeRegressor", bound=RegressorMixin)
+T_NativeClassifier = TypeVar("T_NativeClassifier", bound=ClassifierMixin)
+
+T_SupervisedLearnerDF = TypeVar("T_SupervisedLearnerDF", bound="SupervisedLearnerDF")
+T_StackableSupervisedLearnerDF = TypeVar(
+    "T_StackableSupervisedLearnerDF",
+    bound="_StackableSupervisedLearnerDF[SupervisedLearnerDF]",
+)
+T_StackingEstimatorWrapperDF = TypeVar(
+    "T_StackingEstimatorWrapperDF",
+    bound="StackingEstimatorWrapperDF[Union[RegressorMixin, ClassifierMixin]]",
+)
+
+#
+# Ensure all symbols introduced below are included in __all__
+#
+
+__tracker = AllTracker(globals())
+
+
+#
+# Stacking Estimator wrappers
+#
+
+# noinspection PyPep8Naming
+@inheritdoc(match="""[see superclass]""")
+class StackingEstimatorWrapperDF(
+    # note: MetaEstimatorMixin is the first public class in the mro of _BaseStacking
+    # MetaEstimatorMixin <-- _BaseHeterogeneousEnsemble <-- _BaseStacking
+    MetaEstimatorMixin,  # type: ignore
+    SupervisedLearnerWrapperDF[T_NativeSupervisedLearner],
+    Generic[T_NativeSupervisedLearner],
+    metaclass=ABCMeta,
+):
+    """
+    Abstract base class of wrappers for estimators implementing
+    :class:`sklearn.ensemble._stacking._BaseStacking`.
+
+    The stacking estimator will delegate to embedded estimators; this wrapper ensures
+    the required conversions from and to numpy arrays as the native stacking estimator
+    invokes the embedded estimators.
+    """
+
+    def fit(
+        self: T_StackingEstimatorWrapperDF,
+        X: pd.DataFrame,
+        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
+        **fit_params: Any,
+    ) -> T_StackingEstimatorWrapperDF:
+        """[see superclass]"""
+
+        class _ColumnNameFn:
+            # noinspection PyMethodParameters
+            def __call__(self_) -> Sequence[str]:
+                return self._get_final_estimator_features_in()
+
+            def __deepcopy__(self, memo: Any = None) -> Any:
+                # prevent a deep copy of this callable, to preserve reference to
+                # stacking estimator being fitted
+                return self
+
+        native: T_NativeSupervisedLearner = self.native_estimator
+        estimators: Sequence[Tuple[str, BaseEstimator]] = native.estimators
+        final_estimator: BaseEstimator = native.final_estimator
+
+        try:
+            native.estimators = [
+                (
+                    name,
+                    self._make_stackable_learner_df(estimator)
+                    if isinstance(estimator, SupervisedLearnerDF)
+                    else estimator,
+                )
+                for name, estimator in native.estimators
+            ]
+            native.final_estimator = self._make_learner_np_df(
+                delegate=native.final_estimator or self._make_default_final_estimator(),
+                column_names=_ColumnNameFn(),
+            )
+
+            # suppress a false warning from PyCharm's type checker
+            # noinspection PyTypeChecker
+            return super().fit(X, y, **fit_params)
+
+        finally:
+            native.estimators = estimators
+            native.final_estimator = final_estimator
+
+    @abstractmethod
+    def _make_stackable_learner_df(
+        self, learner: T_SupervisedLearnerDF
+    ) -> _StackableSupervisedLearnerDF[T_SupervisedLearnerDF]:
+        pass
+
+    @abstractmethod
+    def _make_learner_np_df(
+        self, delegate: T_SupervisedLearnerDF, column_names: Callable[[], Sequence[str]]
+    ) -> SupervisedLearnerNPDF[T_SupervisedLearnerDF]:
+        pass
+
+    def _get_estimators_features_out(self) -> List[str]:
+        return [name for name, estimator in self.estimators if estimator != "drop"]
+
+    def _get_final_estimator_features_in(self) -> List[str]:
+        names = self._get_estimators_features_out()
+        if self.passthrough:
+            return [*names, *self.estimators_[0].feature_names_in_]
+        else:
+            return names
+
+
+class StackingClassifierWrapperDF(
+    ClassifierWrapperDF[T_NativeClassifier],
+    StackingEstimatorWrapperDF[T_NativeClassifier],
+    Generic[T_NativeClassifier],
+    metaclass=ABCMeta,
+):
+    """
+    Abstract base class of DF wrappers for classifiers implementing
+    :class:`sklearn.ensemble._stacking._BaseStacking`.
+    """
+
+    @staticmethod
+    def _make_default_final_estimator() -> LearnerDF:
+        from sklearndf.classification import LogisticRegressionDF
+
+        return LogisticRegressionDF()
+
+    def _get_estimators_features_out(self) -> List[str]:
+        classes = self.native_estimator.classes_
+        names = super()._get_estimators_features_out()
+        if len(classes) > 2:
+            return [f"{name}_{c}" for name in names for c in classes]
+        else:
+            return names
+
+    def _make_stackable_learner_df(
+        self, learner: ClassifierDF
+    ) -> _StackableClassifierDF:
+        return _StackableClassifierDF(learner)
+
+    def _make_learner_np_df(
+        self,
+        delegate: T_DelegateClassifierDF,
+        column_names: Callable[[], Sequence[str]],
+    ) -> ClassifierNPDF[T_DelegateClassifierDF]:
+        return ClassifierNPDF(delegate, column_names)
+
+
+class StackingRegressorWrapperDF(
+    StackingEstimatorWrapperDF[T_NativeRegressor],
+    RegressorWrapperDF[T_NativeRegressor],
+    Generic[T_NativeRegressor],
+    metaclass=ABCMeta,
+):
+    """
+    Abstract base class of DF wrappers for regressors implementing
+    :class:`sklearn.ensemble._stacking._BaseStacking`.
+    """
+
+    @staticmethod
+    def _make_default_final_estimator() -> SupervisedLearnerDF:
+        from sklearndf.regression import RidgeCVDF
+
+        return RidgeCVDF()
+
+    def _make_stackable_learner_df(self, learner: RegressorDF) -> _StackableRegressorDF:
+        return _StackableRegressorDF(learner)
+
+    def _make_learner_np_df(
+        self, delegate: T_DelegateRegressorDF, column_names: Callable[[], Sequence[str]]
+    ) -> RegressorNPDF[T_DelegateRegressorDF]:
+        return RegressorNPDF(delegate, column_names)
+
+
+#
+# Supporting classes
+#
+
+
+class _StackableSupervisedLearnerDF(
+    BaseEstimator,  # type: ignore
+    Generic[T_SupervisedLearnerDF],
+):
+    """
+    Returns numpy arrays from all prediction functions, instead of pandas series or
+    data frames.
+
+    For use in stacking estimators that forward the predictions of multiple learners to
+    one final learner.
+    """
+
+    def __init__(self, delegate: T_SupervisedLearnerDF) -> None:
+        super().__init__()
+        self.delegate = delegate
+
+    @property
+    def is_fitted(self) -> bool:
+        """[see superclass]"""
+        return self.delegate.is_fitted
+
+    # noinspection PyPep8Naming
+    @subsdoc(pattern="", replacement="", using=SupervisedLearnerDF.fit)
+    def fit(
+        self: T_StackableSupervisedLearnerDF,
+        X: pd.DataFrame,
+        y: Optional[npt.NDArray[Any]] = None,
+        **fit_params: Any,
+    ) -> T_StackableSupervisedLearnerDF:
+        """[see SupervisedLearnerDF.fit]"""
+        self.delegate.fit(X, self._convert_y_to_series(X, y), **fit_params)
+        return self
+
+    # noinspection PyPep8Naming
+    @subsdoc(
+        pattern="predictions per observation as a series, or as a data frame",
+        replacement="predictions as a numpy array",
+        using=SupervisedLearnerDF.predict,
+    )
+    def predict(self, X: pd.DataFrame, **predict_params: Any) -> npt.NDArray[Any]:
+        """[see SupervisedLearnerDF.predict]"""
+        return cast(
+            npt.NDArray[Any],
+            self.delegate.predict(X, **predict_params).values,
+        )
+
+    # noinspection PyPep8Naming
+    @subsdoc(pattern="", replacement="", using=SupervisedLearnerDF.score)
+    def score(
+        self,
+        X: pd.DataFrame,
+        y: npt.NDArray["np.floating[Any]"],
+        sample_weight: Optional[pd.Series] = None,
+    ) -> float:
+        """[see SupervisedLearnerDF.score]"""
+        return self.delegate.score(X, self._convert_y_to_series(X, y), sample_weight)
+
+    def _get_features_in(self) -> pd.Index:
+        # noinspection PyProtectedMember
+        return self.delegate._get_features_in()
+
+    def _get_n_outputs(self) -> int:
+        # noinspection PyProtectedMember
+        return self.delegate._get_n_outputs()
+
+    # noinspection PyPep8Naming
+    @staticmethod
+    def _convert_y_to_series(
+        X: pd.DataFrame, y: Optional[npt.NDArray[Any]]
+    ) -> Optional[pd.Series]:
+        if y is None:
+            return y
+        if not isinstance(y, np.ndarray):
+            raise TypeError(
+                f"expected numpy array for arg y but got a {type(y).__name__}"
+            )
+        if y.ndim != 1:
+            raise TypeError(
+                f"expected 1-d numpy array for arg y but got a {y.ndim}-d array"
+            )
+        if len(y) != len(X):
+            raise ValueError(
+                "args X and y have different lengths: "
+                f"len(X)={len(X)} and len(y)={len(y)}"
+            )
+        return pd.Series(y, index=X.index)
+
+    @staticmethod
+    def _convert_prediction_to_numpy(
+        prediction: Union[pd.DataFrame, List[pd.DataFrame]]
+    ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        if isinstance(prediction, list):
+            return [proba.values for proba in prediction]
+        else:
+            return cast(npt.NDArray[Any], prediction.values)
+
+
+# noinspection PyPep8Naming
+@inheritdoc(match="""[see superclass]""")
+class _StackableClassifierDF(_StackableSupervisedLearnerDF[ClassifierDF], ClassifierDF):
+    """[see superclass]"""
+
+    @property
+    def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        """[see superclass]"""
+        return self.delegate.classes_
+
+    def predict_proba(
+        self, X: pd.DataFrame, **predict_params: Any
+    ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        """[see superclass]"""
+        return self._convert_prediction_to_numpy(
+            self.delegate.predict_proba(X, **predict_params)
+        )
+
+    def predict_log_proba(
+        self, X: pd.DataFrame, **predict_params: Any
+    ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        """[see superclass]"""
+        return self._convert_prediction_to_numpy(
+            self.delegate.predict_log_proba(X, **predict_params)
+        )
+
+    def decision_function(
+        self, X: pd.DataFrame, **predict_params: Any
+    ) -> npt.NDArray[np.floating[Any]]:
+        """[see superclass]"""
+        return cast(
+            npt.NDArray[np.floating[Any]],
+            self.delegate.decision_function(X, **predict_params).values,
+        )
+
+
+@inheritdoc(match="""[see superclass]""")
+class _StackableRegressorDF(_StackableSupervisedLearnerDF[RegressorDF], RegressorDF):
+    """[see superclass]"""
+
+
+#
+# validate __all__
+#
+
+__tracker.validate()

--- a/src/sklearndf/wrapper/stacking/_stacking.py
+++ b/src/sklearndf/wrapper/stacking/_stacking.py
@@ -171,8 +171,7 @@ class StackingClassifierWrapperDF(
     metaclass=ABCMeta,
 ):
     """
-    Abstract base class of DF wrappers for classifiers implementing
-    :class:`sklearn.ensemble._stacking._BaseStacking`.
+    DF wrapper class for :class:`sklearn.classifier.StackingClassifierDF`.
     """
 
     @staticmethod
@@ -209,8 +208,7 @@ class StackingRegressorWrapperDF(
     metaclass=ABCMeta,
 ):
     """
-    Abstract base class of DF wrappers for regressors implementing
-    :class:`sklearn.ensemble._stacking._BaseStacking`.
+    DF wrapper class for :class:`sklearn.regression.StackingRegressorDF`.
     """
 
     @staticmethod


### PR DESCRIPTION
This PR makes package `sklearndf.wrapper` easier to navigate, and increases de-coupling of the stackable learners implementation. 

- moves some classes in module `sklearndf.wrapper` to sub-packages `sklearndf.wrapper.stacking` and `sklearndf.wrapper.numpy`
- this improves package navigability and achieves better de-coupling of the underlying code, esp. for stacking
- moves classes `StackingClassifierWrapperDF` and `StackingRegressorWrapperDF` to package `sklearndf.wrapper.stacking`