### PR TITLE
FIX: wrap extra classifiers using `ClassifierWrapperDF`; add validation to ensure native classes are compatible with wrapper classes

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,6 +12,15 @@ Release Notes
 adds data frame support for clusterers along with additional API enhancements and
 improvements, and is now subject to static type checking with |mypy|.
 
+2.0.1
+~~~~~
+
+- API: when declaring new wrapper classes, validate that their associated native
+  estimators are compatible with the wrapper class
+- FIX: base :class:`.LGBMClassifierDF` and :class:`.XGBClassifierDF` on the
+  the correct wrapper class :class:`.ClassifierWrapperDF`
+
+
 2.0.0
 ~~~~~
 

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -4,6 +4,8 @@ Core implementation of :mod:`sklearndf.classification.extra`
 import logging
 import warnings
 
+from sklearn.base import ClassifierMixin
+
 from pytools.api import AllTracker
 
 from ...wrapper import ClassifierWrapperDF, MissingEstimator
@@ -27,6 +29,7 @@ except ImportError:
 
     class LGBMClassifier(  # type: ignore
         MissingEstimator,
+        ClassifierMixin,  # type: ignore
     ):
         """Mock-up for missing estimator."""
 
@@ -38,6 +41,7 @@ except ImportError:
 
     class XGBClassifier(  # type: ignore
         MissingEstimator,
+        ClassifierMixin,  # type: ignore
     ):
         """Mock-up for missing estimator."""
 

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -2,10 +2,19 @@
 Core implementation of :mod:`sklearndf.classification.extra`
 """
 import logging
+import warnings
 
 from pytools.api import AllTracker
 
-from ...wrapper import MissingEstimator, RegressorWrapperDF
+from ...wrapper import ClassifierWrapperDF, MissingEstimator
+
+# since we install LGBM via conda, the warning about the Clang compiler is irrelevant
+warnings.filterwarnings("ignore", message=r"Starting from version 2\.2\.1")
+# cross-validation will invariably generate sliced subsets, so the following warning
+# is not helpful
+warnings.filterwarnings(
+    "ignore", message=r"Usage of np\.ndarray subset \(sliced data\) is not recommended"
+)
 
 log = logging.getLogger(__name__)
 
@@ -44,10 +53,10 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-if LGBMClassifier:
+if MissingEstimator not in LGBMClassifier.mro():
 
     class LGBMClassifierDF(
-        RegressorWrapperDF[LGBMClassifier],
+        ClassifierWrapperDF[LGBMClassifier],
         native=LGBMClassifier,
     ):
         """Stub for DF wrapper of class ``LGBMClassifierDF``"""
@@ -55,10 +64,10 @@ if LGBMClassifier:
 else:
     __all__.remove("LGBMClassifierDF")
 
-if XGBClassifier:
+if MissingEstimator not in XGBClassifier.mro():
 
     class XGBClassifierDF(
-        RegressorWrapperDF[XGBClassifier],
+        ClassifierWrapperDF[XGBClassifier],
         native=XGBClassifier,
     ):
         """Stub for DF wrapper of class ``XGBClassifierDF``"""

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -53,27 +53,20 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-if MissingEstimator not in LGBMClassifier.mro():
 
-    class LGBMClassifierDF(
-        ClassifierWrapperDF[LGBMClassifier],
-        native=LGBMClassifier,
-    ):
-        """Stub for DF wrapper of class ``LGBMClassifierDF``"""
+class LGBMClassifierDF(
+    ClassifierWrapperDF[LGBMClassifier],
+    native=LGBMClassifier,
+):
+    """Stub for DF wrapper of class ``LGBMClassifierDF``"""
 
-else:
-    __all__.remove("LGBMClassifierDF")
 
-if MissingEstimator not in XGBClassifier.mro():
+class XGBClassifierDF(
+    ClassifierWrapperDF[XGBClassifier],
+    native=XGBClassifier,
+):
+    """Stub for DF wrapper of class ``XGBClassifierDF``"""
 
-    class XGBClassifierDF(
-        ClassifierWrapperDF[XGBClassifier],
-        native=XGBClassifier,
-    ):
-        """Stub for DF wrapper of class ``XGBClassifierDF``"""
-
-else:
-    __all__.remove("XGBClassifierDF")
 
 #
 # validate that __all__

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -2,21 +2,12 @@
 Core implementation of :mod:`sklearndf.classification.extra`
 """
 import logging
-import warnings
 
 from sklearn.base import ClassifierMixin
 
 from pytools.api import AllTracker
 
 from ...wrapper import ClassifierWrapperDF, MissingEstimator
-
-# since we install LGBM via conda, the warning about the Clang compiler is irrelevant
-warnings.filterwarnings("ignore", message=r"Starting from version 2\.2\.1")
-# cross-validation will invariably generate sliced subsets, so the following warning
-# is not helpful
-warnings.filterwarnings(
-    "ignore", message=r"Usage of np\.ndarray subset \(sliced data\) is not recommended"
-)
 
 log = logging.getLogger(__name__)
 

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -47,6 +47,8 @@ class PipelineWrapperDF(
     DF wrapper for `scikit-learn` class :class:`~sklearn.pipeline.Pipeline`.
     """
 
+    __native_base_class__ = Pipeline
+
     #: Placeholder that can be used in place of an estimator to designate a pipeline
     #: step that preserves the original ingoing data.
     PASSTHROUGH = "passthrough"

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -2,21 +2,12 @@
 Core implementation of :mod:`sklearndf.regression.extra`
 """
 import logging
-import warnings
 
 from sklearn.base import RegressorMixin
 
 from pytools.api import AllTracker
 
 from ...wrapper import MissingEstimator, RegressorWrapperDF
-
-# since we install LGBM via conda, the warning about the Clang compiler is irrelevant
-warnings.filterwarnings("ignore", message=r"Starting from version 2\.2\.1")
-# cross-validation will invariably generate sliced subsets, so the following warning
-# is not helpful
-warnings.filterwarnings(
-    "ignore", message=r"Usage of np\.ndarray subset \(sliced data\) is not recommended"
-)
 
 log = logging.getLogger(__name__)
 

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -4,6 +4,8 @@ Core implementation of :mod:`sklearndf.regression.extra`
 import logging
 import warnings
 
+from sklearn.base import RegressorMixin
+
 from pytools.api import AllTracker
 
 from ...wrapper import MissingEstimator, RegressorWrapperDF
@@ -28,6 +30,7 @@ except ImportError:
 
     class LGBMRegressor(  # type: ignore
         MissingEstimator,
+        RegressorMixin,  # type: ignore
     ):
         """Mock-up for missing estimator."""
 
@@ -40,6 +43,7 @@ except ImportError:
 
     class XGBRegressor(  # type: ignore
         MissingEstimator,
+        RegressorMixin,  # type: ignore
     ):
         """Mock-up for missing estimator."""
 

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -55,20 +55,27 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
+if MissingEstimator not in LGBMRegressor.mro():
 
-class LGBMRegressorDF(
-    RegressorWrapperDF[LGBMRegressor],
-    native=LGBMRegressor,
-):
-    """Stub for DF wrapper of class ``LGBMRegressorDF``"""
+    class LGBMRegressorDF(
+        RegressorWrapperDF[LGBMRegressor],
+        native=LGBMRegressor,
+    ):
+        """Stub for DF wrapper of class ``LGBMRegressorDF``"""
 
+else:
+    __all__.remove("LGBMRegressorDF")
 
-class XGBRegressorDF(
-    RegressorWrapperDF[XGBRegressor],
-    native=XGBRegressor,
-):
-    """Stub for DF wrapper of class ``XGBRegressorDF``"""
+if MissingEstimator not in XGBRegressor.mro():
 
+    class XGBRegressorDF(
+        RegressorWrapperDF[XGBRegressor],
+        native=XGBRegressor,
+    ):
+        """Stub for DF wrapper of class ``XGBRegressorDF``"""
+
+else:
+    __all__.remove("XGBClassifierDF")
 
 #
 # validate __all__

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -55,27 +55,20 @@ __tracker = AllTracker(globals())
 # Class definitions
 #
 
-if MissingEstimator not in LGBMRegressor.mro():
 
-    class LGBMRegressorDF(
-        RegressorWrapperDF[LGBMRegressor],
-        native=LGBMRegressor,
-    ):
-        """Stub for DF wrapper of class ``LGBMRegressorDF``"""
+class LGBMRegressorDF(
+    RegressorWrapperDF[LGBMRegressor],
+    native=LGBMRegressor,
+):
+    """Stub for DF wrapper of class ``LGBMRegressorDF``"""
 
-else:
-    __all__.remove("LGBMRegressorDF")
 
-if MissingEstimator not in XGBRegressor.mro():
+class XGBRegressorDF(
+    RegressorWrapperDF[XGBRegressor],
+    native=XGBRegressor,
+):
+    """Stub for DF wrapper of class ``XGBRegressorDF``"""
 
-    class XGBRegressorDF(
-        RegressorWrapperDF[XGBRegressor],
-        native=XGBRegressor,
-    ):
-        """Stub for DF wrapper of class ``XGBRegressorDF``"""
-
-else:
-    __all__.remove("XGBClassifierDF")
 
 #
 # validate __all__

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import logging
 
+from sklearn.base import TransformerMixin
+
 from pytools.api import AllTracker
 
 from ...wrapper import MissingEstimator
@@ -21,6 +23,7 @@ except ImportError:
 
     class BorutaPy(  # type: ignore
         MissingEstimator,
+        TransformerMixin,  # type: ignore
     ):
         """Mock-up for missing estimator."""
 

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -144,6 +144,15 @@ class EstimatorWrapperDFMeta(ABCMeta, Generic[T_NativeEstimator]):
             return cls
 
         wrapper_cls = cast(Type[EstimatorWrapperDF[T_NativeEstimator]], cls)
+
+        if not issubclass(native, wrapper_cls.__native_base_class__):
+            raise TypeError(
+                f"native class {native.__name__} "
+                f"cannot be used with wrapper class {wrapper_cls.__name__} "
+                f"because it does not implement "
+                f"{wrapper_cls.__native_base_class__.__name__}"
+            )
+
         wrapper_cls.__wrapped__ = native
         wrapper_cls.__signature__ = inspect.signature(native)
         wrapper_init = _make_init(wrapper_cls)
@@ -198,6 +207,7 @@ class EstimatorWrapperDF(
     API.
     """
 
+    __native_base_class__ = BaseEstimator
     __ARG_FITTED_DELEGATE_CONTEXT = "__EstimatorWrapperDF_fitted"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -555,6 +565,8 @@ class TransformerWrapperDF(
     API.
     """
 
+    __native_base_class__ = TransformerMixin
+
     @property
     def feature_names_out_(self) -> pd.Index:
         """[see superclass]"""
@@ -827,6 +839,8 @@ class RegressorWrapperDF(
     API.
     """
 
+    __native_base_class__ = RegressorMixin
+
     # noinspection PyPep8Naming
     def score(
         self, X: pd.DataFrame, y: pd.Series, sample_weight: Optional[pd.Series] = None
@@ -849,6 +863,8 @@ class ClassifierWrapperDF(
     Base class of DF wrappers for native classifiers conforming with the `scikit-learn`
     API.
     """
+
+    __native_base_class__ = ClassifierMixin
 
     @property
     def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
@@ -984,6 +1000,8 @@ class ClusterWrapperDF(
     Base class of DF wrappers for native clusterers conforming with the scikit-learn
     API.
     """
+
+    __native_base_class__ = ClusterMixin
 
     COL_LABELS = "labels"
 

--- a/test/test/sklearndf/pipeline/test_classification_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_classification_pipeline_df.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -5,17 +7,25 @@ from sklearn.base import is_classifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.preprocessing import OneHotEncoder
 
+from sklearndf import ClassifierDF
 from sklearndf.classification import RandomForestClassifierDF
+from sklearndf.classification.extra import LGBMClassifierDF
 from sklearndf.pipeline import ClassifierPipelineDF
 from test.sklearndf.pipeline import make_simple_transformer
 
 
+@pytest.mark.parametrize(  # type: ignore
+    argnames="classifier_df_cls",
+    argvalues=[RandomForestClassifierDF, LGBMClassifierDF],
+)
 def test_classification_pipeline_df(
-    iris_features: pd.DataFrame, iris_target_sr: pd.DataFrame
+    iris_features: pd.DataFrame,
+    iris_target_sr: pd.DataFrame,
+    classifier_df_cls: Type[ClassifierDF],
 ) -> None:
 
     cls_p_df = ClassifierPipelineDF(
-        classifier=RandomForestClassifierDF(),
+        classifier=classifier_df_cls(),
         preprocessing=make_simple_transformer(
             impute_median_columns=iris_features.select_dtypes(
                 include=np.number

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -52,7 +52,10 @@ class NoFit(
         self.b = b
 
 
-class NoTransformer(NoFit):
+class NoTransformer(
+    NoFit,
+    TransformerMixin,  # type: ignore
+):
     """
     Not a transformer
     """
@@ -70,8 +73,8 @@ class NoTransformer(NoFit):
 
 
 class NoInvTransformer(
-    TransformerMixin,  # type: ignore
     NoTransformer,
+    TransformerMixin,  # type: ignore
 ):
     # noinspection PyPep8Naming
     def transform(self, X: npt.NDArray[Any]) -> npt.NDArray[Any]:

--- a/test/test/sklearndf/pipeline/test_regression_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_regression_pipeline_df.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -5,17 +7,24 @@ from lightgbm import LGBMRegressor
 from sklearn.base import is_regressor
 from sklearn.preprocessing import OneHotEncoder
 
+from sklearndf import RegressorDF
 from sklearndf.pipeline import RegressorPipelineDF
+from sklearndf.regression import RandomForestRegressorDF
 from sklearndf.regression.extra import LGBMRegressorDF
 from test.sklearndf.pipeline import make_simple_transformer
 
 
+@pytest.mark.parametrize(  # type: ignore
+    argnames="regressor_df_cls", argvalues=[RandomForestRegressorDF, LGBMRegressorDF]
+)
 def test_regression_pipeline_df(
-    boston_features: pd.DataFrame, boston_target_sr: pd.Series
+    boston_features: pd.DataFrame,
+    boston_target_sr: pd.Series,
+    regressor_df_cls: Type[RegressorDF],
 ) -> None:
 
     rpdf = RegressorPipelineDF(
-        regressor=LGBMRegressorDF(),
+        regressor=regressor_df_cls(),
         preprocessing=make_simple_transformer(
             impute_median_columns=boston_features.select_dtypes(
                 include=np.number


### PR DESCRIPTION
Hi @j-ittner!

As I started updating docs I found that that `LGBMClassifierDF` has incorrect base class in `sklearndf` version `2.0.x`:

```python3
from sklearndf.classification.extra import LGBMClassifierDF
print(LGBMClassifierDF.mro())
# [..., <class 'sklearndf._sklearndf.RegressorDF'>, ...] <-- incorrect base
```
Also PR contains changes for extra learners when imported with lack of underlying 3rd party library: Class is now always created but otherwise it's created with base class `MissingEstimator` so in `if` I check if such class is in `mro` as simple `if LGBMClassifierDF:` always evaluates to true if I'm not mistaken (it could be also done with `issubclass` check).

What do you think?