### PR TITLE
FIX: use fitted attribute n_components_ to get PCA component count

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -14,6 +14,12 @@ Release Notes
 adds data frame support for clusterers along with additional API enhancements and
 improvements, and is now subject to static type checking with |mypy|.
 
+2.0.2
+~~~~~
+
+- FIX: property :attr:`.PCADF.n_components_` now returns the value of :attr:`~sklearndf.decomposition.PCA.n_components_`, not :attr:`~sklearndf.decomposition.PCA.n_components`
+
+
 2.0.1
 ~~~~~
 

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -85,6 +85,7 @@ from .wrapper import (
     OneHotEncoderWrapperDF,
     PolynomialTransformerWrapperDF,
 )
+from .wrapper._wrapper import PCAWrapperDF
 
 log = logging.getLogger(__name__)
 
@@ -461,7 +462,7 @@ class NMFDF(ComponentsDimensionalityReductionWrapperDF[NMF], native=NMF):
     """Stub for DF wrapper of class ``NMF``"""
 
 
-class PCADF(NComponentsDimensionalityReductionWrapperDF[PCA], native=PCA):
+class PCADF(PCAWrapperDF, native=PCA):
     """Stub for DF wrapper of class ``PCA``"""
 
 

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -22,6 +22,7 @@ import numpy.typing as npt
 import pandas as pd
 from sklearn.base import TransformerMixin
 from sklearn.compose import ColumnTransformer
+from sklearn.decomposition import PCA
 from sklearn.impute import MissingIndicator, SimpleImputer
 from sklearn.kernel_approximation import AdditiveChi2Sampler
 from sklearn.manifold import Isomap
@@ -35,24 +36,24 @@ from ...wrapper import TransformerWrapperDF
 log = logging.getLogger(__name__)
 
 __all__ = [
+    "AdditiveChi2SamplerWrapperDF",
     "BaseDimensionalityReductionWrapperDF",
     "BaseMultipleInputsPerOutputTransformerWrapperDF",
     "ColumnPreservingTransformerWrapperDF",
     "ColumnSubsetTransformerWrapperDF",
+    "ColumnTransformerWrapperDF",
     "ComponentsDimensionalityReductionWrapperDF",
     "FeatureSelectionWrapperDF",
+    "ImputerWrapperDF",
+    "IsomapWrapperDF",
+    "KBinsDiscretizerWrapperDF",
+    "MissingIndicatorWrapperDF",
     "NComponentsDimensionalityReductionWrapperDF",
     "NumpyTransformerWrapperDF",
-    "ColumnTransformerWrapperDF",
-    "IsomapWrapperDF",
-    "ImputerWrapperDF",
-    "MissingIndicatorWrapperDF",
-    "AdditiveChi2SamplerWrapperDF",
-    "KBinsDiscretizerWrapperDF",
-    "PolynomialTransformerWrapperDF",
     "OneHotEncoderWrapperDF",
+    "PCAWrapperDF",
+    "PolynomialTransformerWrapperDF",
 ]
-
 
 #
 # type variables
@@ -206,6 +207,18 @@ class NComponentsDimensionalityReductionWrapperDF(
     @property
     def _n_components_(self) -> int:
         return cast(int, getattr(self.native_estimator, self._ATTR_N_COMPONENTS))
+
+
+class PCAWrapperDF(NComponentsDimensionalityReductionWrapperDF[PCA]):
+    """
+    DF wrapper for :class:`sklearn.decomposition.PCA`.
+
+    Uses attribute :attr:`~sklearn.decomposition.PCA.n_components_` to get the number
+    of components, which may be determined by the estimator during fitting.
+    """
+
+    # overrides "n_components" defined in NComponentsDimensionalityReductionWrapperDF
+    _ATTR_N_COMPONENTS = "n_components_"
 
 
 class ComponentsDimensionalityReductionWrapperDF(

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -202,11 +202,21 @@ class NComponentsDimensionalityReductionWrapperDF(
     _ATTR_N_COMPONENTS = "n_components"
 
     def _validate_delegate_estimator(self) -> None:
-        self._validate_delegate_attribute(attribute_name=self._ATTR_N_COMPONENTS)
+        self._validate_delegate_attribute(
+            attribute_name=(
+                NComponentsDimensionalityReductionWrapperDF._ATTR_N_COMPONENTS
+            )
+        )
 
     @property
     def _n_components_(self) -> int:
-        return cast(int, getattr(self.native_estimator, self._ATTR_N_COMPONENTS))
+        return cast(
+            int,
+            getattr(
+                self.native_estimator,
+                NComponentsDimensionalityReductionWrapperDF._ATTR_N_COMPONENTS,
+            ),
+        )
 
 
 class PCAWrapperDF(NComponentsDimensionalityReductionWrapperDF[PCA]):
@@ -217,8 +227,9 @@ class PCAWrapperDF(NComponentsDimensionalityReductionWrapperDF[PCA]):
     of components, which may be determined by the estimator during fitting.
     """
 
-    # overrides "n_components" defined in NComponentsDimensionalityReductionWrapperDF
-    _ATTR_N_COMPONENTS = "n_components_"
+    @property
+    def _n_components_(self) -> int:
+        return cast(int, self._native_estimator.n_components_)
 
 
 class ComponentsDimensionalityReductionWrapperDF(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -212,6 +212,9 @@ class EstimatorWrapperDF(
     __native_base_class__ = BaseEstimator
     __ARG_FITTED_DELEGATE_CONTEXT = "__EstimatorWrapperDF_fitted"
 
+    #: The native estimator that this wrapper delegates to.
+    _native_estimator: T_NativeEstimator
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """
         :param args: positional arguments to use when initializing a new new delegate
@@ -227,6 +230,8 @@ class EstimatorWrapperDF(
         fitted_delegate_context: Tuple[T_NativeEstimator, pd.Index, int] = kwargs.get(
             EstimatorWrapperDF.__ARG_FITTED_DELEGATE_CONTEXT, None
         )
+
+        _native_estimator: T_NativeEstimator
 
         if fitted_delegate_context is None:
             # create a new delegate estimator with the given parameters


### PR DESCRIPTION
This PR introduces a dedicated DF wrapper for class `sklearn.decomposition.PCA`.

The wrapper uses attribute `PCA.n_components_` to get the number of components, which may be determined by the estimator only during fitting.