### PR TITLE
REFACTOR: replace `EstimatorDF.ensure_fitted()` with pytools `@fitted_only`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install mypy~=0.981 numpy~=1.22 gamma-pytools~=2.0,!=2.0.0
+              python -m pip install mypy~=0.981 numpy~=1.22 gamma-pytools~=2.1rc
               python -m mypy src
             displayName: 'Run mypy'
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # run
   - boruta_py ~= 0.3
-  - gamma-pytools ~= 2.0, != 2.0.0
+  - gamma-pytools ~= 2.1
   - joblib ~= 1.1
   - lightgbm ~= 3.3
   - matplotlib ~= 3.5

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # run
   - boruta_py ~= 0.3
-  - gamma-pytools ~= 2.1
+  - gamma-pytools ~= 2.1rc
   - joblib ~= 1.1
   - lightgbm ~= 3.3
   - matplotlib ~= 3.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dist-name = "sklearndf"
 license = "Apache Software License v2.0"
 
 requires = [
-    "gamma-pytools  ~=2.1",
+    "gamma-pytools  ~=2.1rc",
     "numpy          >=1.21,<2a",  # cannot use ~= due to conda bug
     "packaging      >=20",
     "pandas         >=1,<2a",  # cannot use ~= due to conda bug
@@ -71,7 +71,7 @@ no-binary.min = ["matplotlib"]
 [build.matrix.min]
 # direct requirements of sklearndf
 boruta         = "~=0.3.0"
-gamma-pytools  = "~=2.1.0"
+gamma-pytools  = "~=2.1rc"
 lightgbm       = "~=3.0.0"
 numpy          = "==1.21.6"  # cannot use ~= due to conda bug
 packaging      = "~=20.9"
@@ -88,7 +88,7 @@ typing_inspect = "~=0.4.0"
 [build.matrix.max]
 # direct requirements of sklearndf
 boruta         = "~=0.3"
-gamma-pytools  = "~=2.1"
+gamma-pytools  = "~=2.1rc"
 lightgbm       = "~=3.3"
 numpy          = ">=1.23,<2a"  # cannot use ~= due to conda bug
 packaging      = ">=20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dist-name = "sklearndf"
 license = "Apache Software License v2.0"
 
 requires = [
-    "gamma-pytools  ~=2.0,!=2.0.0",
+    "gamma-pytools  ~=2.1",
     "numpy          >=1.21,<2a",  # cannot use ~= due to conda bug
     "packaging      >=20",
     "pandas         >=1,<2a",  # cannot use ~= due to conda bug
@@ -71,7 +71,7 @@ no-binary.min = ["matplotlib"]
 [build.matrix.min]
 # direct requirements of sklearndf
 boruta         = "~=0.3.0"
-gamma-pytools  = "~=2.0.1"
+gamma-pytools  = "~=2.1.0"
 lightgbm       = "~=3.0.0"
 numpy          = "==1.21.6"  # cannot use ~= due to conda bug
 packaging      = "~=20.9"
@@ -88,7 +88,7 @@ typing_inspect = "~=0.4.0"
 [build.matrix.max]
 # direct requirements of sklearndf
 boruta         = "~=0.3"
-gamma-pytools  = "~=2.0,!=2.0.0"
+gamma-pytools  = "~=2.1"
 lightgbm       = "~=3.3"
 numpy          = ">=1.23,<2a"  # cannot use ~= due to conda bug
 packaging      = ">=20"

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -606,7 +606,7 @@ class ClusterDF(
     """
 
     @property
-    @abstractmethod
+    @fitted_only(not_fitted_error=AttributeError)
     def labels_(self) -> pd.Series:
         # noinspection GrazieInspection
         """
@@ -614,7 +614,7 @@ class ClusterDF(
 
         :raises AttributeError: this clusterer is not fitted
         """
-        pass
+        return self._get_labels()
 
     # noinspection PyPep8Naming
     @abstractmethod
@@ -634,6 +634,10 @@ class ClusterDF(
         :return: predicted cluster labels for all observations as a series,
             or as a data frame in case of multiple outputs
         """
+        pass
+
+    @abstractmethod
+    def _get_labels(self) -> pd.Series:
         pass
 
 

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -502,7 +502,7 @@ class ClassifierDF(
     """
 
     @property
-    @abstractmethod
+    @fitted_only(not_fitted_error=AttributeError)
     def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
         """
         Get the classes predicted by this classifier as a numpy array of class labels
@@ -510,7 +510,7 @@ class ClassifierDF(
 
         :raises AttributeError: this classifier is not fitted
         """
-        pass
+        return self._get_classes()
 
     # noinspection PyPep8Naming
     @abstractmethod
@@ -588,6 +588,10 @@ class ClassifierDF(
     # we cannot get the docstring via the @inheritdoc mechanism because
     # ClassifierMixin precedes SupervisedLearnerDF in the MRO
     score.__doc__ = SupervisedLearnerDF.score.__doc__
+
+    @abstractmethod
+    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        pass
 
 
 class ClusterDF(

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -130,25 +130,24 @@ class EstimatorDF(
         return self._get_features_in().rename(self.COL_FEATURE_IN)
 
     @property
+    @fitted_only(not_fitted_error=AttributeError)
     def output_names_(self) -> Optional[List[str]]:
         """
         The name(s) of the output(s) this estimator was fitted to,
         or ``None`` if this estimator was not fitted to any outputs.
 
-        :raises AttributeError: if this estimator is not fitted
+        :raises AttributeError: this estimator is not fitted
         """
-        self.ensure_fitted()
         return self._get_outputs()
 
     @property
+    @fitted_only(not_fitted_error=AttributeError)
     def n_features_in_(self) -> int:
         """
         The number of features used to fit this estimator.
 
-        :raises AttributeError: if this estimator is not fitted
-        :return: the number of features
+        :raises AttributeError: this estimator is not fitted
         """
-        self.ensure_fitted()
         return self._get_n_features_in()
 
     @property

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -22,6 +22,7 @@ from sklearn.utils import is_scalar_nan
 from pytools.api import AllTracker, inheritdoc
 from pytools.expression import Expression, HasExpressionRepr, make_expression
 from pytools.expression.atomic import Id
+from pytools.fit import fitted_only
 
 log = logging.getLogger(__name__)
 
@@ -118,35 +119,25 @@ class EstimatorDF(
         """
         pass
 
-    def ensure_fitted(self) -> None:
-        """
-        Raise a :class:`~sklearn.exceptions.NotFittedError` if this estimator is not
-        fitted.
-
-        :raise sklearn.exceptions.NotFittedError: this estimator is not fitted
-        """
-        if not self.is_fitted:
-            raise NotFittedError(f"{type(self).__name__} is not fitted")
-
     @property
+    @fitted_only(not_fitted_error=AttributeError)
     def feature_names_in_(self) -> pd.Index:
         """
         The pandas column index with the names of the features used to fit this
         estimator.
 
-        :raises AttributeError: if this estimator is not fitted
+        :raises AttributeError: this estimator is not fitted
         """
-        self.ensure_fitted()
         return self._get_features_in().rename(self.COL_FEATURE_IN)
 
     @property
+    @fitted_only(not_fitted_error=AttributeError)
     def n_outputs_(self) -> int:
         """
         The number of outputs used to fit this estimator.
 
-        :raises AttributeError: if this estimator is not fitted
+        :raises AttributeError: this estimator is not fitted
         """
-        self.ensure_fitted()
         return self._get_n_outputs()
 
     def get_params(self, deep: bool = True) -> Mapping[str, Any]:
@@ -343,6 +334,7 @@ class TransformerDF(
         self._features_original = None
 
     @property
+    @fitted_only(not_fitted_error=AttributeError)
     def feature_names_original_(self) -> pd.Series:
         # noinspection GrazieInspection
         """
@@ -351,8 +343,9 @@ class TransformerDF(
 
         The index of the resulting series consists of the names of the output features;
         the corresponding values are the names of the original input features.
+
+        :raises AttributeError: this transformer is not fitted
         """
-        self.ensure_fitted()
         if self._features_original is None:
             self._features_original = (
                 self._get_features_original()
@@ -362,12 +355,14 @@ class TransformerDF(
         return self._features_original
 
     @property
+    @fitted_only(not_fitted_error=AttributeError)
     def feature_names_out_(self) -> pd.Index:
         """
         A pandas column index with the names of the features produced by this
         transformer
+
+        :raises AttributeError: this transformer is not fitted
         """
-        self.ensure_fitted()
         return self._get_features_out().rename(self.COL_FEATURE_OUT)
 
     # noinspection PyPep8Naming
@@ -470,10 +465,10 @@ class ClassifierDF(
     @abstractmethod
     def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
         """
-        Get the classes predicted by this classifier.
+        Get the classes predicted by this classifier as a numpy array of class labels
+        for single-output problems, or a list of such arrays for multi-output problems
 
-        :return: a numpy array of class labels for single-output problems, or a list
-            of such arrays for multi-output problems
+        :raises AttributeError: this classifier is not fitted
         """
         pass
 
@@ -572,6 +567,8 @@ class ClusterDF(
         # noinspection GrazieInspection
         """
         A pandas series, mapping the index of the input data frame to cluster labels.
+
+        :raises AttributeError: this clusterer is not fitted
         """
         pass
 

--- a/src/sklearndf/clustering/wrapper/_wrapper.py
+++ b/src/sklearndf/clustering/wrapper/_wrapper.py
@@ -10,6 +10,7 @@ import pandas as pd
 from sklearn.cluster import FeatureAgglomeration, KMeans, MiniBatchKMeans
 
 from pytools.api import AllTracker
+from pytools.fit import fitted_only
 
 from sklearndf.transformation.wrapper import ColumnPreservingTransformerWrapperDF
 from sklearndf.wrapper import ClusterWrapperDF
@@ -52,13 +53,14 @@ class KMeansBaseWrapperDF(
     IDX_CLUSTER = "cluster"
 
     @property
+    @fitted_only(not_fitted_error=AttributeError)
     def cluster_centers_(self) -> pd.DataFrame:
         """
         The cluster centers as a data frame, with clusters as rows and feature values
         as columns.
-        """
 
-        self.ensure_fitted()
+        :raises AttributeError: the clusterer is not fitted
+        """
 
         raw_cluster_centers = self._native_estimator.cluster_centers_
         return pd.DataFrame(

--- a/src/sklearndf/pipeline/_learner_pipeline.py
+++ b/src/sklearndf/pipeline/_learner_pipeline.py
@@ -419,9 +419,9 @@ class ClusterPipelineDF(
         return "cluster"
 
     @property
-    def labels_(self) -> pd.Series:
+    def _get_labels(self) -> pd.Series:
         """[see superclass]"""
-        return self.final_estimator.labels_
+        return self.final_estimator._get_labels()
 
     # noinspection PyPep8Naming
     def fit_predict(

--- a/src/sklearndf/pipeline/_learner_pipeline.py
+++ b/src/sklearndf/pipeline/_learner_pipeline.py
@@ -348,10 +348,8 @@ class ClassifierPipelineDF(
         """[see superclass]"""
         return "classifier"
 
-    @property
-    def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
-        """[see superclass]"""
-        return self.final_estimator.classes_
+    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        return self.final_estimator._get_classes()
 
     # noinspection PyPep8Naming
     def predict_proba(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -1085,13 +1085,12 @@ class ClusterWrapperDF(
         super().__init__(*args, **kwargs)
         self._x_index: Optional[pd.Index] = None
 
-    @property
-    def labels_(self) -> pd.Series:
-        """[see superclass]"""
-
-        raw_labels = self._native_estimator.labels_
-
-        return pd.Series(data=raw_labels, name=self.COL_LABELS, index=self._x_index)
+    def _get_labels(self) -> pd.Series:
+        return pd.Series(
+            data=self._native_estimator.labels_,
+            name=self.COL_LABELS,
+            index=self._x_index,
+        )
 
     def fit_predict(
         self,

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -50,7 +50,6 @@ from sklearn.base import (
 )
 
 from pytools.api import AllTracker, inheritdoc, public_module_prefix
-from pytools.fit import fitted_only
 
 from sklearndf import (
     ClassifierDF,
@@ -946,12 +945,7 @@ class ClassifierWrapperDF(
 
     __native_base_class__ = ClassifierMixin
 
-    @property
-    @fitted_only(not_fitted_error=AttributeError)
-    def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
-        """[see superclass]"""
-
-        # noinspection PyUnresolvedReferences
+    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
         return cast(
             Union[npt.NDArray[Any], List[npt.NDArray[Any]]],
             self._native_estimator.classes_,

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -50,6 +50,7 @@ from sklearn.base import (
 )
 
 from pytools.api import AllTracker, inheritdoc, public_module_prefix
+from pytools.fit import fitted_only
 
 from sklearndf import (
     ClassifierDF,
@@ -882,9 +883,10 @@ class ClassifierWrapperDF(
     __native_base_class__ = ClassifierMixin
 
     @property
+    @fitted_only(not_fitted_error=AttributeError)
     def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
         """[see superclass]"""
-        self.ensure_fitted()
+
         # noinspection PyUnresolvedReferences
         return cast(
             Union[npt.NDArray[Any], List[npt.NDArray[Any]]],
@@ -1028,7 +1030,7 @@ class ClusterWrapperDF(
     @property
     def labels_(self) -> pd.Series:
         """[see superclass]"""
-        self.ensure_fitted()
+
         raw_labels = self._native_estimator.labels_
 
         return pd.Series(data=raw_labels, name=self.COL_LABELS, index=self._x_index)

--- a/src/sklearndf/wrapper/numpy/_numpy.py
+++ b/src/sklearndf/wrapper/numpy/_numpy.py
@@ -228,9 +228,8 @@ class ClassifierNPDF(
     column_names: Optional[Union[Sequence[str], Callable[[], Sequence[str]]]]
 
     @property
-    def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
-        """[see superclass]"""
-        return self.delegate.classes_
+    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        return self.delegate._get_classes()
 
     def predict_proba(
         self, X: Union[npt.NDArray[Any], pd.DataFrame], **predict_params: Any

--- a/src/sklearndf/wrapper/stacking/_stacking.py
+++ b/src/sklearndf/wrapper/stacking/_stacking.py
@@ -341,10 +341,8 @@ class _StackableSupervisedLearnerDF(
 class _StackableClassifierDF(_StackableSupervisedLearnerDF[ClassifierDF], ClassifierDF):
     """[see superclass]"""
 
-    @property
-    def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
-        """[see superclass]"""
-        return self.delegate.classes_
+    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        return self.delegate._get_classes()
 
     def predict_proba(
         self, X: pd.DataFrame, **predict_params: Any


### PR DESCRIPTION
This PR removes method `EstimatorDF.ensure_fitted()` and instead uses the `@fitted_only` decorator from *gamma-pytools* to mark properties/methods as only available once the estimator has been fitted.

**DRAFT**: first need to release *pytools 2.1*