### PR TITLE
API: support sparse data frames

### DIFF
--- a/.idea/sklearndf.iml
+++ b/.idea/sklearndf.iml
@@ -17,7 +17,7 @@
       <excludeFolder url="file://$MODULE_DIR$/sphinx/source/tutorial/.ipynb_checkpoints" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="sklearndf-develop" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="facet-base" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="pytools" />
   </component>

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,8 @@ API.
 
 - API: new property :attr:`.EstimatorDF.output_names_` to get the names of the output
   columns the estimator was fitted with.
+- API: DF estimators now support native estimators using sparse matrices as input or output, and automatically
+  convert them to/from sparse :class:`~pandas.DataFrame` objects
 
 
 *sklearndf* 2.1

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -18,7 +18,11 @@ API.
 ~~~~~
 
 - API: new property :attr:`.EstimatorDF.output_names_` to get the names of the output
-  columns the estimator was fitted with.
+  columns the estimator was fitted with
+- API: new method :attr:`.LearnerPipelineDF.preprocess` to apply the preprocessing step
+  to a data frame
+- API: remove properties ``feature_names_out_`` and ``feature_names_original_`` from
+  class :class:`.LearnerPipelineDF`
 
 
 *sklearndf* 2.1

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,10 @@ ignore_missing_imports = True
 ; TODO remove once PEP 561 is supported
 ignore_missing_imports = True
 
+[mypy-scipy.*]
+; TODO remove once PEP 561 is supported
+ignore_missing_imports = True
+
 [mypy-sklearn.*]
 ; TODO remove once PEP 561 is supported
 ignore_missing_imports = True

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -95,7 +95,7 @@ class EstimatorDF(
     @abstractmethod
     def fit(
         self: T_EstimatorDF,
-        X: pd.DataFrame,
+        X: Union[pd.DataFrame, pd.Series],
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params: Any,
     ) -> T_EstimatorDF:
@@ -292,7 +292,7 @@ class LearnerDF(EstimatorDF, metaclass=ABCMeta):
     # noinspection PyPep8Naming
     @abstractmethod
     def predict(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.Series, pd.DataFrame]:
         """
         Predict outputs for the given inputs.
@@ -321,7 +321,10 @@ class SupervisedLearnerDF(LearnerDF, metaclass=ABCMeta):
     # noinspection PyPep8Naming
     @abstractmethod
     def score(
-        self, X: pd.DataFrame, y: pd.Series, sample_weight: Optional[pd.Series] = None
+        self,
+        X: Union[pd.Series, pd.DataFrame],
+        y: pd.Series,
+        sample_weight: Optional[pd.Series] = None,
     ) -> float:
         """
         Score this learner using the given inputs and outputs.
@@ -407,7 +410,7 @@ class TransformerDF(
 
     # noinspection PyPep8Naming
     @abstractmethod
-    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+    def transform(self, X: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
         """
         Transform the given inputs.
 
@@ -424,7 +427,7 @@ class TransformerDF(
     # noinspection PyPep8Naming
     def fit_transform(
         self,
-        X: pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params: Any,
     ) -> pd.DataFrame:
@@ -441,7 +444,7 @@ class TransformerDF(
 
     # noinspection PyPep8Naming
     @abstractmethod
-    def inverse_transform(self, X: pd.DataFrame) -> pd.DataFrame:
+    def inverse_transform(self, X: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
         """
         Inverse-transform the given inputs.
 
@@ -481,7 +484,10 @@ class RegressorDF(
     # noinspection PyPep8Naming
     @abstractmethod
     def score(
-        self, X: pd.DataFrame, y: pd.Series, sample_weight: Optional[pd.Series] = None
+        self,
+        X: Union[pd.Series, pd.DataFrame],
+        y: pd.Series,
+        sample_weight: Optional[pd.Series] = None,
     ) -> float:
         """[see SupervisedLearnerDF]"""
 
@@ -515,7 +521,7 @@ class ClassifierDF(
     # noinspection PyPep8Naming
     @abstractmethod
     def predict_proba(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
         """
         Predict class probabilities for the given inputs.
@@ -537,7 +543,7 @@ class ClassifierDF(
     # noinspection PyPep8Naming
     @abstractmethod
     def predict_log_proba(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
         """
         Predict class log-probabilities for the given inputs.
@@ -559,7 +565,7 @@ class ClassifierDF(
     # noinspection PyPep8Naming
     @abstractmethod
     def decision_function(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.Series, pd.DataFrame]:
         """
         Compute the decision function for the given inputs.
@@ -581,7 +587,10 @@ class ClassifierDF(
     # noinspection PyPep8Naming
     @abstractmethod
     def score(
-        self, X: pd.DataFrame, y: pd.Series, sample_weight: Optional[pd.Series] = None
+        self,
+        X: Union[pd.Series, pd.DataFrame],
+        y: pd.Series,
+        sample_weight: Optional[pd.Series] = None,
     ) -> float:
         """[see SupervisedLearnerDF]"""
 
@@ -620,7 +629,7 @@ class ClusterDF(
     @abstractmethod
     def fit_predict(
         self,
-        X: pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_predict_params: Any,
     ) -> Union[pd.Series, pd.DataFrame]:

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -471,7 +471,7 @@ class TransformerDF(
     def _get_features_out(self) -> pd.Index:
         # return a pandas index with this transformer's output columns
         # default behaviour: get index returned by feature_names_original_
-        return self.feature_names_original_.index
+        return self._get_features_original().index
 
 
 class RegressorDF(

--- a/src/sklearndf/_util.py
+++ b/src/sklearndf/_util.py
@@ -1,0 +1,58 @@
+"""
+Auxiliary functions for internal use.
+"""
+
+from typing import Any, List, Optional, Union, cast
+
+import numpy.typing as npt
+import pandas as pd
+from scipy import sparse
+
+
+def hstack_frames(
+    frames: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]]
+) -> Optional[pd.DataFrame]:
+    """
+    If only data frames are passed, stack them horizontally.
+
+    :param frames: a list of array-likes
+    :return: the stacked data frame if all elements of ``frames`` are data frames;
+        ``None`` otherwise
+    """
+    if all(isinstance(X, pd.DataFrame) for X in frames):
+        return pd.concat(frames, axis=1)
+    else:
+        return None
+
+
+def is_sparse_frame(frame: pd.DataFrame) -> bool:
+    """
+    Check if a data frame contains sparse columns.
+
+    :param frame: the data frame to check
+    :return: ``True`` if the data frame contains sparse columns; ``False`` otherwise
+    """
+
+    return any(isinstance(dtype, pd.SparseDtype) for dtype in frame.dtypes)
+
+
+def sparse_frame_density(frame: pd.DataFrame) -> float:
+    """
+    Compute the density of a data frame.
+
+    The density of a data frame is the average density of its columns.
+    The density of a sparse column is the ratio of non-sparse points to total (dense)
+    data points.
+    The density of a dense column is 1.
+
+    :param frame: a data frame
+    :return: the density of the data frame
+    """
+
+    def _density(sr: pd.Series) -> float:
+        if isinstance(sr.dtype, pd.SparseDtype):
+            return cast(float, sr.sparse.density)
+        else:
+            return 1.0
+
+    return sum(_density(sr) for _, sr in frame.items()) / len(frame.columns)

--- a/src/sklearndf/_util.py
+++ b/src/sklearndf/_util.py
@@ -10,16 +10,30 @@ from scipy import sparse
 
 
 def hstack_frames(
-    frames: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]]
+    frames: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]],
+    *,
+    prefixes: Optional[List[str]] = None,
 ) -> Optional[pd.DataFrame]:
     """
     If only data frames are passed, stack them horizontally.
 
     :param frames: a list of array-likes
+    :param prefixes: an optional list of prefixes to use for the columns of each data
+        frame in arg ``frames``; must have the same length as arg ``frames``
     :return: the stacked data frame if all elements of ``frames`` are data frames;
         ``None`` otherwise
     """
-    if all(isinstance(X, pd.DataFrame) for X in frames):
+    if all(isinstance(frame, pd.DataFrame) for frame in frames):
+        # all frames are data frames
+        frames = cast(List[pd.DataFrame], frames)
+        if prefixes is not None:
+            assert len(prefixes) == len(
+                frames
+            ), "number of prefixes must match number of frames"
+            frames = [
+                frame.add_prefix(f"{prefix}__")
+                for frame, prefix in zip(frames, prefixes)
+            ]
         return pd.concat(frames, axis=1)
     else:
         return None

--- a/src/sklearndf/classification/wrapper/_wrapper.py
+++ b/src/sklearndf/classification/wrapper/_wrapper.py
@@ -90,7 +90,7 @@ class PartialFitClassifierWrapperDF(
     # noinspection PyPep8Naming
     def partial_fit(
         self: T_PartialFitClassifierWrapperDF,
-        X: pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: Union[pd.Series, pd.DataFrame],
         classes: Optional[Sequence[Any]] = None,
         sample_weight: Optional[pd.Series] = None,
@@ -109,7 +109,7 @@ class PartialFitClassifierWrapperDF(
         :param sample_weight: optional weights applied to individual samples
         :return: ``self``
         """
-        self._check_parameter_types(X, y)
+        X, y = self._validate_parameter_types(X, y)
         self._partial_fit(X, y, classes=classes, sample_weight=sample_weight)
 
         return self

--- a/src/sklearndf/pipeline/_learner_pipeline.py
+++ b/src/sklearndf/pipeline/_learner_pipeline.py
@@ -139,7 +139,7 @@ class _EstimatorPipelineDF(EstimatorDF, Generic[T_FinalEstimatorDF], metaclass=A
     # noinspection PyPep8Naming
     def fit(
         self: T_EstimatorPipelineDF,
-        X: pd.DataFrame,
+        X: Union[pd.DataFrame, pd.Series],
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         *,
         sample_weight: Optional[pd.Series] = None,
@@ -230,7 +230,7 @@ class LearnerPipelineDF(
 
     # noinspection PyPep8Naming
     def predict(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.Series, pd.DataFrame]:
         """[see superclass]"""
         return self.final_estimator.predict(self._pre_transform(X), **predict_params)
@@ -251,7 +251,7 @@ class SupervisedLearnerPipelineDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: Optional[pd.Series] = None,
         sample_weight: Optional[Any] = None,
     ) -> float:
@@ -353,14 +353,14 @@ class ClassifierPipelineDF(
 
     # noinspection PyPep8Naming
     def predict_proba(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
         """[see superclass]"""
         return self.classifier.predict_proba(self._pre_transform(X), **predict_params)
 
     # noinspection PyPep8Naming
     def predict_log_proba(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
         """[see superclass]"""
         return self.classifier.predict_log_proba(
@@ -369,7 +369,7 @@ class ClassifierPipelineDF(
 
     # noinspection PyPep8Naming
     def decision_function(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.Series, pd.DataFrame]:
         """[see superclass]"""
         return self.classifier.decision_function(
@@ -426,7 +426,7 @@ class ClusterPipelineDF(
     # noinspection PyPep8Naming
     def fit_predict(
         self,
-        X: pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_predict_params: Any,
     ) -> Union[pd.Series, pd.DataFrame]:

--- a/src/sklearndf/pipeline/_pipeline.py
+++ b/src/sklearndf/pipeline/_pipeline.py
@@ -4,11 +4,11 @@ Core implementation of :mod:`sklearndf.pipeline`
 
 import logging
 
-from sklearn.pipeline import FeatureUnion, Pipeline
+from sklearn.pipeline import Pipeline
 
 from pytools.api import AllTracker
 
-from .wrapper import FeatureUnionWrapperDF, PipelineWrapperDF
+from .wrapper import FeatureUnionSparseFrames, FeatureUnionWrapperDF, PipelineWrapperDF
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class PipelineDF(PipelineWrapperDF, native=Pipeline):
     """Stub for DF wrapper of class ``Pipeline``"""
 
 
-class FeatureUnionDF(FeatureUnionWrapperDF, native=FeatureUnion):
+class FeatureUnionDF(FeatureUnionWrapperDF, native=FeatureUnionSparseFrames):
     """Stub for DF wrapper of class ``FeatureUnion``"""
 
 

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -232,7 +232,7 @@ class FeatureUnionSparseFrames(
         self, Xs: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]]
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
         stacked = hstack_frames(Xs)
-        return stacked if stacked is None else super()._hstack(Xs)
+        return stacked if stacked is not None else super()._hstack(Xs)
 
 
 class FeatureUnionWrapperDF(

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -231,8 +231,13 @@ class FeatureUnionSparseFrames(
     def _hstack(
         self, Xs: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]]
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
-        stacked = hstack_frames(Xs)
-        return stacked if stacked is not None else super()._hstack(Xs)
+        stacked_frames = hstack_frames(
+            Xs, prefixes=[name for name, _ in self.transformer_list]
+        )
+        if stacked_frames is None:
+            return super()._hstack(Xs)
+        else:
+            return stacked_frames
 
 
 class FeatureUnionWrapperDF(

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -245,6 +245,8 @@ class FeatureUnionWrapperDF(
     DROP = "drop"
     PASSTHROUGH = "passthrough"
 
+    __native_base_class__ = FeatureUnionSparseFrames
+
     @staticmethod
     def _prepend_features_out(features_out: pd.Index, name_prefix: str) -> pd.Index:
         return pd.Index(data=f"{name_prefix}__" + features_out.astype(str))

--- a/src/sklearndf/regression/wrapper/_wrapper.py
+++ b/src/sklearndf/regression/wrapper/_wrapper.py
@@ -14,9 +14,11 @@ from sklearn.multioutput import MultiOutputRegressor
 
 from pytools.api import AllTracker
 
+from ... import __sklearn_0_24__, __sklearn_version__
 from ...transformation.wrapper import (
     ColumnPreservingTransformerWrapperDF,
     NumpyTransformerWrapperDF,
+    SingleColumnTransformerWrapperDF,
 )
 from ...wrapper import MetaEstimatorWrapperDF, RegressorWrapperDF
 
@@ -149,6 +151,7 @@ class RegressorTransformerWrapperDF(
 
 class IsotonicRegressionWrapperDF(
     RegressorTransformerWrapperDF[IsotonicRegression],
+    SingleColumnTransformerWrapperDF[IsotonicRegression],
     NumpyTransformerWrapperDF[IsotonicRegression],
     metaclass=ABCMeta,
 ):
@@ -157,22 +160,13 @@ class IsotonicRegressionWrapperDF(
     """
 
     # noinspection PyPep8Naming
-    def _check_parameter_types(
-        self,
-        X: pd.DataFrame,
-        y: Optional[pd.Series],
-        *,
-        expected_columns: pd.Index = None,
-    ) -> None:
-        super()._check_parameter_types(X, y, expected_columns=expected_columns)
-        if X.shape[1] != 1:
-            raise ValueError(
-                f"arg X expected to have exactly 1 column but has {X.shape[1]} columns"
-            )
-
-    # noinspection PyPep8Naming
     def _adjust_X_type_for_delegate(self, X: pd.DataFrame) -> npt.NDArray[Any]:
-        return super()._adjust_X_type_for_delegate(X).ravel()
+        arr = super()._adjust_X_type_for_delegate(X)
+        if __sklearn_version__ >= __sklearn_0_24__:
+            # we can return a 1D array as of sklearn 0.24
+            return arr.ravel()
+        else:
+            return arr
 
 
 #

--- a/src/sklearndf/regression/wrapper/_wrapper.py
+++ b/src/sklearndf/regression/wrapper/_wrapper.py
@@ -81,7 +81,7 @@ class PartialFitRegressorWrapperDF(
     # noinspection PyPep8Naming
     def partial_fit(
         self: T_PartialFitRegressorWrapperDF,
-        X: pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: Union[pd.Series, pd.DataFrame],
         sample_weight: Optional[pd.Series] = None,
     ) -> T_PartialFitRegressorWrapperDF:
@@ -97,7 +97,7 @@ class PartialFitRegressorWrapperDF(
         :param sample_weight: optional weights applied to individual samples
         :return: ``self``
         """
-        self._check_parameter_types(X, y)
+        X, y = self._validate_parameter_types(X, y)
         self._partial_fit(X, y, sample_weight=sample_weight)
 
         return self

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -84,6 +84,7 @@ from .wrapper import (
     NComponentsDimensionalityReductionWrapperDF,
     OneHotEncoderWrapperDF,
     PolynomialTransformerWrapperDF,
+    VectorizerWrapperDF,
 )
 
 log = logging.getLogger(__name__)
@@ -190,14 +191,12 @@ class FeatureHasherDF(
     """Stub for DF wrapper of class ``FeatureHasher``"""
 
 
-class DictVectorizerDF(
-    ColumnPreservingTransformerWrapperDF[DictVectorizer], native=DictVectorizer
-):
+class DictVectorizerDF(VectorizerWrapperDF[DictVectorizer], native=DictVectorizer):
     """Stub for DF wrapper of class ``DictVectorizer``"""
 
 
 class HashingVectorizerDF(
-    ColumnPreservingTransformerWrapperDF[HashingVectorizer], native=HashingVectorizer
+    VectorizerWrapperDF[HashingVectorizer], native=HashingVectorizer
 ):
     """Stub for DF wrapper of class ``HashingVectorizer``"""
 

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -4,7 +4,6 @@ Core implementation of :mod:`sklearndf.transformation`
 
 import logging
 
-from sklearn.compose import ColumnTransformer
 from sklearn.cross_decomposition import PLSSVD
 from sklearn.decomposition import (
     NMF,
@@ -74,6 +73,7 @@ from pytools.api import AllTracker
 from .wrapper import (
     AdditiveChi2SamplerWrapperDF,
     ColumnPreservingTransformerWrapperDF,
+    ColumnTransformerSparseFrames,
     ColumnTransformerWrapperDF,
     ComponentsDimensionalityReductionWrapperDF,
     FeatureSelectionWrapperDF,
@@ -169,7 +169,9 @@ __tracker = AllTracker(globals())
 #
 
 
-class ColumnTransformerDF(ColumnTransformerWrapperDF, native=ColumnTransformer):
+class ColumnTransformerDF(
+    ColumnTransformerWrapperDF, native=ColumnTransformerSparseFrames
+):
     """Stub for DF wrapper of class ``ColumnTransformer``"""
 
 

--- a/src/sklearndf/transformation/_transformation.py
+++ b/src/sklearndf/transformation/_transformation.py
@@ -4,6 +4,7 @@ Core implementation of :mod:`sklearndf.transformation`
 
 import logging
 
+from sklearn.base import TransformerMixin
 from sklearn.cross_decomposition import PLSSVD
 from sklearn.decomposition import (
     NMF,
@@ -21,7 +22,12 @@ from sklearn.decomposition import (
     TruncatedSVD,
 )
 from sklearn.feature_extraction import DictVectorizer, FeatureHasher
-from sklearn.feature_extraction.text import HashingVectorizer, TfidfTransformer
+from sklearn.feature_extraction.text import (
+    CountVectorizer,
+    HashingVectorizer,
+    TfidfTransformer,
+    TfidfVectorizer,
+)
 from sklearn.feature_selection import (
     RFE,
     RFECV,
@@ -94,6 +100,8 @@ __all__ = [
     "BernoulliRBMDF",
     "BinarizerDF",
     "ColumnTransformerDF",
+    "CountVectorizerDF",
+    "CountVectorizerTx",
     "DictVectorizerDF",
     "DictionaryLearningDF",
     "FactorAnalysisDF",
@@ -147,9 +155,12 @@ __all__ = [
     "SparseRandomProjectionDF",
     "StandardScalerDF",
     "TfidfTransformerDF",
+    "TfidfVectorizerDF",
+    "TfidfVectorizerTx",
     "TruncatedSVDDF",
     "VarianceThresholdDF",
 ]
+
 
 __imported_estimators = {name for name in globals().keys() if name.endswith("DF")}
 
@@ -185,6 +196,11 @@ class PLSSVDDF(ColumnPreservingTransformerWrapperDF[PLSSVD], native=PLSSVD):
     """Stub for DF wrapper of class ``PLSSVD``"""
 
 
+#
+# feature_extraction
+#
+
+
 class FeatureHasherDF(
     ColumnPreservingTransformerWrapperDF[FeatureHasher], native=FeatureHasher
 ):
@@ -199,6 +215,36 @@ class HashingVectorizerDF(
     VectorizerWrapperDF[HashingVectorizer], native=HashingVectorizer
 ):
     """Stub for DF wrapper of class ``HashingVectorizer``"""
+
+
+class CountVectorizerTx(
+    CountVectorizer,  # type: ignore
+    TransformerMixin,  # type: ignore
+):
+    """
+    Subclass of ``CountVectorizer`` that makes it a transformer.
+    """
+
+
+class CountVectorizerDF(
+    VectorizerWrapperDF[CountVectorizerTx], native=CountVectorizerTx
+):
+    """Stub for DF wrapper of class ``CountVectorizer``"""
+
+
+class TfidfVectorizerTx(
+    TfidfVectorizer,  # type: ignore
+    TransformerMixin,  # type: ignore
+):
+    """
+    Subclass of ``CountVectorizer`` that makes it a transformer.
+    """
+
+
+class TfidfVectorizerDF(
+    VectorizerWrapperDF[TfidfVectorizerTx], native=TfidfVectorizerTx
+):
+    """Stub for DF wrapper of class ``TfidfVectorizer``"""
 
 
 class TfidfTransformerDF(
@@ -554,7 +600,7 @@ __estimators = {
     if sym.endswith("DF")
     and sym not in __imported_estimators
     and not sym.startswith("_")
-}
+} | {CountVectorizerTx.__name__, TfidfVectorizerTx.__name__}
 
 if __estimators != set(__all__):
     raise RuntimeError(

--- a/src/sklearndf/transformation/extra/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/extra/wrapper/_wrapper.py
@@ -46,6 +46,10 @@ if BorutaPy:
         def _get_features_out(self) -> pd.Index:
             return self.feature_names_in_[self.native_estimator.support_]
 
+        def _get_sparse_threshold(self) -> float:
+            # don't allow sparse input
+            return 0.0
+
 else:
     __all__.remove("BorutaPyWrapperDF")
 

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -73,19 +73,14 @@ __all__ = [
 # Type variables
 #
 
-T_Transformer = TypeVar("T_Transformer", bound=TransformerMixin)
-
-# T_Imputer is needed because scikit-learn's _BaseImputer only exists from v0.22
-# onwards.
-# Once we drop support for sklearn 0.21, _BaseImputer can be used instead.
-# The following TypeVar helps to annotate availability of "add_indicator" and
-# "missing_values" attributes on an imputer instance for ImputerWrapperDF below.
 
 # noinspection PyProtectedMember
 from sklearn.impute._iterative import IterativeImputer
 
+# Once we drop support for sklearn 0.21, T_Imputer can be bound to _BaseImputer
 T_Imputer = TypeVar("T_Imputer", SimpleImputer, IterativeImputer)
 T_Polynomial = TypeVar("T_Polynomial", bound=TransformerMixin)
+T_Transformer = TypeVar("T_Transformer", bound=TransformerMixin)
 T_Vectorizer = TypeVar("T_Vectorizer", bound=TransformerMixin)
 
 #
@@ -502,7 +497,9 @@ class ColumnTransformerWrapperDF(
         )
 
 
-class ImputerWrapperDF(TransformerWrapperDF[T_Imputer], metaclass=ABCMeta):
+class ImputerWrapperDF(
+    TransformerWrapperDF[T_Imputer], Generic[T_Imputer], metaclass=ABCMeta
+):
     """
     DF wrapper for imputation transformers, e.g., :class:`sklearn.impute.SimpleImputer`.
     """

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -475,7 +475,10 @@ class ColumnTransformerWrapperDF(
         columns: pd.Index,
     ) -> pd.DataFrame:
         if isinstance(transformed, pd.DataFrame):
-            transformed = transformed.set_axis(columns, axis=1, inplace=False)
+            # Our overloaded version of method _hstack in ColumnTransformerSparseFrames
+            # returns a DataFrame if all transformers return a DataFrame, but does not
+            # update the column names. We do that here.
+            transformed = transformed.set_axis(columns, axis=1)
         return super(
             ColumnTransformerWrapperDF, ColumnTransformerWrapperDF
         )._transformed_to_df(transformed, index, columns)

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -80,6 +80,7 @@ from sklearn.impute._iterative import IterativeImputer
 # Once we drop support for sklearn 0.21, T_Imputer can be bound to _BaseImputer
 T_Imputer = TypeVar("T_Imputer", SimpleImputer, IterativeImputer)
 T_Polynomial = TypeVar("T_Polynomial", bound=TransformerMixin)
+T_Target = TypeVar("T_Target", bound=Union[pd.Series, pd.DataFrame, None])
 T_Transformer = TypeVar("T_Transformer", bound=TransformerMixin)
 T_Vectorizer = TypeVar("T_Vectorizer", bound=TransformerMixin)
 
@@ -159,10 +160,10 @@ class SingleColumnTransformerWrapperDF(
     def _validate_parameter_types(
         self,
         X: Union[pd.Series, pd.DataFrame],
-        y: Optional[pd.Series],
+        y: T_Target,
         *,
         expected_columns: pd.Index = None,
-    ) -> Tuple[pd.DataFrame, Union[pd.Series, pd.DataFrame]]:
+    ) -> Tuple[pd.DataFrame, T_Target]:
         X, y = super()._validate_parameter_types(
             X, y, expected_columns=expected_columns
         )

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -805,14 +805,14 @@ class VectorizerWrapperDF(
 
     def _get_features_out(self) -> pd.Index:
         try:
-            feature_names = self.native_estimator.get_feature_names()
+            feature_names = self.native_estimator.get_feature_names_out()
         except AttributeError:
             try:
                 n_features = self.native_estimator.n_features
             except AttributeError:
                 raise TypeError(
                     f"native vectorizer {type(self.native_estimator).__name__} "
-                    "has no method get_feature_names() or attribute n_features"
+                    "has no method get_feature_names_out() or attribute n_features"
                 )
             else:
                 return pd.RangeIndex(n_features)

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -805,14 +805,17 @@ class VectorizerWrapperDF(
 
     def _get_features_out(self) -> pd.Index:
         try:
-            feature_names = self.native_estimator.get_feature_names()
+            if __sklearn_version__ >= __sklearn_1_0__:
+                feature_names = self.native_estimator.get_feature_names_out()
+            else:
+                feature_names = self.native_estimator.get_feature_names()
         except AttributeError:
             try:
                 n_features = self.native_estimator.n_features
             except AttributeError:
                 raise TypeError(
                     f"native vectorizer {type(self.native_estimator).__name__} "
-                    "has no method get_feature_names() or attribute n_features"
+                    "has no method get_feature_names_out() or attribute n_features"
                 )
             else:
                 return pd.RangeIndex(n_features)

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
     cast,
@@ -61,11 +62,12 @@ __all__ = [
     "NumpyTransformerWrapperDF",
     "OneHotEncoderWrapperDF",
     "PolynomialTransformerWrapperDF",
+    "SingleColumnTransformerWrapperDF",
 ]
 
 
 #
-# type variables
+# Type variables
 #
 
 T_Transformer = TypeVar("T_Transformer", bound=TransformerMixin)
@@ -144,6 +146,32 @@ class NumpyTransformerWrapperDF(
         # convert series and data frames to sparse matrices instead of
         # dense arrays
         return 0.3
+
+
+class SingleColumnTransformerWrapperDF(
+    TransformerWrapperDF[T_Transformer], Generic[T_Transformer], metaclass=ABCMeta
+):
+    """
+    Abstract base class of DF wrappers for transformers that only accept single-column
+    inputs.
+    """
+
+    # noinspection PyPep8Naming
+    def _validate_parameter_types(
+        self,
+        X: Union[pd.Series, pd.DataFrame],
+        y: Optional[pd.Series],
+        *,
+        expected_columns: pd.Index = None,
+    ) -> Tuple[pd.DataFrame, Union[pd.Series, pd.DataFrame]]:
+        X, y = super()._validate_parameter_types(
+            X, y, expected_columns=expected_columns
+        )
+        if X.shape[1] != 1:
+            raise ValueError(
+                f"arg X expected to have exactly 1 column but has {X.shape[1]} columns"
+            )
+        return X, y
 
 
 class ColumnSubsetTransformerWrapperDF(

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -35,7 +35,6 @@ from ... import (
     __sklearn_1_0__,
     __sklearn_1_1__,
     __sklearn_1_2__,
-    __sklearn_1_4__,
     __sklearn_version__,
 )
 from ...wrapper import TransformerWrapperDF
@@ -574,26 +573,6 @@ class OneHotEncoderWrapperDF(TransformerWrapperDF[OneHotEncoder], metaclass=ABCM
     """
     DF wrapper for :class:`sklearn.preprocessing.OneHotEncoder`.
     """
-
-    def _validate_delegate_estimator(self) -> None:
-        sparse: bool
-        attr_sparse: str
-
-        if __sklearn_version__ < __sklearn_1_2__:
-            sparse = self.native_estimator.sparse
-            attr_sparse = "sparse"
-        else:
-            attr_sparse = "sparse_output"
-            sparse = self.native_estimator.sparse_output
-            if __sklearn_version__ < __sklearn_1_4__ and isinstance(
-                self.native_estimator.sparse, bool
-            ):
-                sparse = self.native_estimator.sparse
-
-        if sparse:
-            raise NotImplementedError(
-                f"sparse matrices not supported; use {attr_sparse}=False"
-            )
 
     def _get_features_original(self) -> pd.Series:
         # Return the series mapping output column names to original column names.

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -471,7 +471,7 @@ class EstimatorWrapperDF(
                 )
             X = X.to_frame()
         elif not isinstance(X, pd.DataFrame):
-            raise TypeError("arg X must be a DataFrame")
+            raise TypeError("arg X must be a DataFrame or a Series")
 
         if self.is_fitted:
             EstimatorWrapperDF._verify_df(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -644,7 +644,7 @@ class TransformerWrapperDF(
     # noinspection PyPep8Naming
     def transform(self, X: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
         """[see superclass]"""
-        X, y = self._validate_parameter_types(X, None)
+        X, _ = self._validate_parameter_types(X, None)
 
         transformed = self._transform(X)
 
@@ -680,7 +680,7 @@ class TransformerWrapperDF(
     # noinspection PyPep8Naming
     def inverse_transform(self, X: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
         """[see superclass]"""
-        X, y = self._validate_parameter_types(
+        X, _ = self._validate_parameter_types(
             X, None, expected_columns=self.feature_names_out_
         )
 
@@ -833,7 +833,7 @@ class LearnerWrapperDF(
         self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[pd.Series, pd.DataFrame]:
         """[see superclass]"""
-        X, y = self._validate_parameter_types(X, None)
+        X, _ = self._validate_parameter_types(X, None)
 
         # noinspection PyUnresolvedReferences
         return self._prediction_to_series_or_frame(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -85,6 +85,7 @@ __all__ = [
 
 T = TypeVar("T")
 T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
+T_Target = TypeVar("T_Target", bound=Union[pd.Series, pd.DataFrame, None])
 
 T_NativeEstimator = TypeVar("T_NativeEstimator", bound=BaseEstimator)
 T_NativeTransformer = TypeVar("T_NativeTransformer", bound=TransformerMixin)
@@ -452,10 +453,10 @@ class EstimatorWrapperDF(
     def _validate_parameter_types(
         self,
         X: Union[pd.Series, pd.DataFrame],
-        y: Optional[Union[pd.Series, pd.DataFrame]],
+        y: T_Target,
         *,
         expected_columns: pd.Index = None,
-    ) -> Tuple[pd.DataFrame, Union[pd.Series, pd.DataFrame]]:
+    ) -> Tuple[pd.DataFrame, T_Target]:
         # Check that the X and y parameters are valid data frames and series,
         # and return X as a data frame and y as a series or data frame.
         #
@@ -1213,40 +1214,43 @@ class MetaEstimatorWrapperDF(
     """
 
     def _validate_delegate_estimator(self) -> None:
-        def _unwrap_estimator(estimator: BaseEstimator) -> BaseEstimator:
-            native_estimator = (
-                estimator.native_estimator
-                if isinstance(estimator, EstimatorWrapperDF)
-                else estimator
-            )
-            # noinspection PyProtectedMember
-            if isinstance(
-                native_estimator, (EstimatorDF, sklearn_meta._BaseComposition)
-            ) or not isinstance(native_estimator, (RegressorMixin, ClassifierMixin)):
-                raise TypeError(
-                    "sklearndf meta-estimators only accept simple regressors and "
-                    f"classifiers, but got: {type(estimator).__name__}"
-                )
-            return cast(BaseEstimator, native_estimator)
+        meta_estimator = self.native_estimator
 
-        delegate_estimator = self.native_estimator
-
-        estimator = getattr(delegate_estimator, "estimator", None)
+        estimator = getattr(meta_estimator, "estimator", None)
         if estimator is not None:
-            delegate_estimator.estimator = _unwrap_estimator(estimator)
+            meta_estimator.estimator = self._native_learner(estimator)
 
-        base_estimator = getattr(delegate_estimator, "base_estimator", None)
+        base_estimator = getattr(meta_estimator, "base_estimator", None)
         # attribute base_estimator is deprecated as of scikit-learn 1.2, with the
         # default value of "deprecated"
-
         if base_estimator is not None and base_estimator != "deprecated":
-            delegate_estimator.base_estimator = _unwrap_estimator(base_estimator)
+            meta_estimator.base_estimator = self._native_learner(base_estimator)
 
-        estimators = getattr(delegate_estimator, "estimators", None)
+        estimators = getattr(meta_estimator, "estimators", None)
         if estimators is not None:
-            delegate_estimator.estimators = [
-                (name, _unwrap_estimator(estimator)) for name, estimator in estimators
+            meta_estimator.estimators = [
+                (name, self._native_learner(estimator))
+                for name, estimator in estimators
             ]
+
+    @staticmethod
+    def _native_learner(
+        estimator_wrapper: BaseEstimator,
+    ) -> Union[RegressorMixin, ClassifierMixin]:
+        native_estimator: BaseEstimator = (
+            estimator_wrapper.native_estimator
+            if isinstance(estimator_wrapper, EstimatorWrapperDF)
+            else estimator_wrapper
+        )
+        # noinspection PyProtectedMember
+        if isinstance(
+            native_estimator, (EstimatorDF, sklearn_meta._BaseComposition)
+        ) or not isinstance(native_estimator, (RegressorMixin, ClassifierMixin)):
+            raise TypeError(
+                "sklearndf meta-estimators only accept simple regressors and "
+                f"classifiers, but got: {type(estimator_wrapper).__name__}"
+            )
+        return native_estimator
 
 
 #

--- a/src/sklearndf/wrapper/numpy/_numpy.py
+++ b/src/sklearndf/wrapper/numpy/_numpy.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Generic, List, Optional, Sequence, TypeVar, Un
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from scipy import sparse
 
 from pytools.api import AllTracker, inheritdoc, subsdoc
 
@@ -101,7 +102,7 @@ class EstimatorNPDF(
 
     def fit(
         self: T_EstimatorNPDF,
-        X: Union[npt.NDArray[Any], pd.DataFrame],
+        X: Union[npt.NDArray[Any], sparse.spmatrix, pd.Series, pd.DataFrame],
         y: Optional[Union[npt.NDArray[Any], pd.Series, pd.DataFrame]] = None,
         **fit_params: Any,
     ) -> T_EstimatorNPDF:
@@ -123,31 +124,47 @@ class EstimatorNPDF(
     def _get_n_outputs(self) -> int:
         return self.delegate._get_n_outputs()
 
-    def _ensure_X_frame(self, X: Union[npt.NDArray[Any], pd.DataFrame]) -> pd.DataFrame:
+    def _ensure_X_frame(
+        self, X: Union[npt.NDArray[Any], sparse.spmatrix, pd.Series, pd.DataFrame]
+    ) -> pd.DataFrame:
         column_names = self.column_names
         if callable(column_names):
             column_names = column_names()
 
-        if isinstance(X, np.ndarray):
-            if X.ndim != 2:
-                raise TypeError(
-                    f"expected 2-dimensional array but got {X.ndim} dimensions"
+        if isinstance(X, pd.Series):
+            if column_names and (len(column_names) != 1 or column_names[0] != X.name):
+                raise ValueError(
+                    f"expected column name {column_names[0]} but got {X.name}"
                 )
-            if column_names:
-                if X.shape[1] != len(column_names):
-                    raise ValueError(
-                        f"expected {len(column_names)} columns but got {X.shape[1]}"
-                    )
-                return pd.DataFrame(X, columns=column_names)
-            else:
-                return pd.DataFrame(X)
-        else:
+            return X.to_frame()
+        elif isinstance(X, pd.DataFrame):
             if column_names and X.columns.to_list() != column_names:
                 raise ValueError(
                     f"expected column names {column_names} "
                     f"but got {X.columns.to_list()}"
                 )
             return X
+        else:
+            try:
+                ndim = X.ndim
+            except AttributeError:
+                raise TypeError(
+                    f"expected numpy array, sparse matrix, pandas series or data frame "
+                    f"but got a {type(X).__name__}"
+                )
+            if ndim != 2:
+                raise TypeError(
+                    f"expected 2-dimensional array but got {ndim} dimensions"
+                )
+            if column_names is not None:
+                if X.shape[1] != len(column_names):
+                    raise ValueError(
+                        f"expected {len(column_names)} columns but got {X.shape[1]}"
+                    )
+            if isinstance(X, sparse.spmatrix):
+                return pd.DataFrame.sparse.from_spmatrix(X, columns=column_names)
+            else:
+                return pd.DataFrame(X, columns=column_names)
 
     @staticmethod
     def _ensure_y_series_or_frame(

--- a/src/sklearndf/wrapper/stacking/_stacking.py
+++ b/src/sklearndf/wrapper/stacking/_stacking.py
@@ -98,7 +98,7 @@ class StackingEstimatorWrapperDF(
 
     def fit(
         self: T_StackingEstimatorWrapperDF,
-        X: pd.DataFrame,
+        X: Union[pd.DataFrame, pd.Series],
         y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params: Any,
     ) -> T_StackingEstimatorWrapperDF:
@@ -256,7 +256,7 @@ class _StackableSupervisedLearnerDF(
     @subsdoc(pattern="", replacement="", using=SupervisedLearnerDF.fit)
     def fit(
         self: T_StackableSupervisedLearnerDF,
-        X: pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: Optional[npt.NDArray[Any]] = None,
         **fit_params: Any,
     ) -> T_StackableSupervisedLearnerDF:
@@ -270,7 +270,9 @@ class _StackableSupervisedLearnerDF(
         replacement="predictions as a numpy array",
         using=SupervisedLearnerDF.predict,
     )
-    def predict(self, X: pd.DataFrame, **predict_params: Any) -> npt.NDArray[Any]:
+    def predict(
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+    ) -> npt.NDArray[Any]:
         """[see SupervisedLearnerDF.predict]"""
         return cast(
             npt.NDArray[Any],
@@ -278,15 +280,16 @@ class _StackableSupervisedLearnerDF(
         )
 
     # noinspection PyPep8Naming
-    @subsdoc(pattern="", replacement="", using=SupervisedLearnerDF.score)
     def score(
         self,
-        X: pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: npt.NDArray["np.floating[Any]"],
         sample_weight: Optional[pd.Series] = None,
     ) -> float:
         """[see SupervisedLearnerDF.score]"""
         return self.delegate.score(X, self._convert_y_to_series(X, y), sample_weight)
+
+    score.__doc__ = SupervisedLearnerDF.score.__doc__
 
     def _get_features_in(self) -> pd.Index:
         # noinspection PyProtectedMember
@@ -345,7 +348,7 @@ class _StackableClassifierDF(_StackableSupervisedLearnerDF[ClassifierDF], Classi
         return self.delegate._get_classes()
 
     def predict_proba(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
         """[see superclass]"""
         return self._convert_prediction_to_numpy(
@@ -353,7 +356,7 @@ class _StackableClassifierDF(_StackableSupervisedLearnerDF[ClassifierDF], Classi
         )
 
     def predict_log_proba(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
         """[see superclass]"""
         return self._convert_prediction_to_numpy(
@@ -361,7 +364,7 @@ class _StackableClassifierDF(_StackableSupervisedLearnerDF[ClassifierDF], Classi
         )
 
     def decision_function(
-        self, X: pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> npt.NDArray[np.floating[Any]]:
         """[see superclass]"""
         return cast(

--- a/test/test/sklearndf/__init__.py
+++ b/test/test/sklearndf/__init__.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, List, Optional, Set, Type, Union
 import pandas as pd
 import sklearn
 from sklearn.base import BaseEstimator
+from sklearn.compose import ColumnTransformer
 
 from sklearndf import (
     EstimatorDF,
@@ -14,7 +15,12 @@ from sklearndf import (
     __sklearn_0_22__,
     __sklearn_version__,
 )
+from sklearndf.transformation.wrapper import ColumnTransformerSparseFrames
 from sklearndf.wrapper import EstimatorWrapperDF
+
+OVERRIDDEN_SKLEARN_CLASSES = {
+    ColumnTransformerSparseFrames: ColumnTransformer,
+}
 
 
 def find_all_classes(
@@ -53,7 +59,9 @@ def sklearn_delegate_classes(
     classes.
     """
     return {
-        df_class.__wrapped__: df_class
+        OVERRIDDEN_SKLEARN_CLASSES.get(
+            df_class.__wrapped__, df_class.__wrapped__
+        ): df_class
         for df_class in find_all_classes(module)
         # we only consider non-abstract wrapper classes wrapping a specific native class
         if issubclass(df_class, EstimatorWrapperDF) and hasattr(df_class, "__wrapped__")

--- a/test/test/sklearndf/__init__.py
+++ b/test/test/sklearndf/__init__.py
@@ -7,6 +7,7 @@ import pandas as pd
 import sklearn
 from sklearn.base import BaseEstimator
 from sklearn.compose import ColumnTransformer
+from sklearn.pipeline import FeatureUnion
 
 from sklearndf import (
     EstimatorDF,
@@ -15,11 +16,13 @@ from sklearndf import (
     __sklearn_0_22__,
     __sklearn_version__,
 )
+from sklearndf.pipeline.wrapper import FeatureUnionSparseFrames
 from sklearndf.transformation.wrapper import ColumnTransformerSparseFrames
 from sklearndf.wrapper import EstimatorWrapperDF
 
 OVERRIDDEN_SKLEARN_CLASSES = {
     ColumnTransformerSparseFrames: ColumnTransformer,
+    FeatureUnionSparseFrames: FeatureUnion,
 }
 
 

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -356,7 +356,7 @@ def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> Non
                 one_hot__c_father=[0.0, 1.0, 0.0],
                 one_hot__c_mother=[0.0, 0.0, 1.0],
             ),
-        ).rename_axis(columns="feature"),
+        ).rename_axis(columns="feature_out"),
     )
 
     if __sklearn_version__ >= __sklearn_1_1__:
@@ -397,5 +397,5 @@ def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> Non
                     test_data_categorical.add_prefix("pass_again__"),
                 ],
                 axis=1,
-            ).rename_axis(columns="feature_out"),
+            ),
         )

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -135,7 +135,7 @@ def test_pipeline_df_memory(
         pipe = PipelineDF([("tx", clone(tx)), ("svc", clf)])
         cached_pipe = PipelineDF([("tx", tx), ("svc", clf)], memory=memory)
 
-        # Memoize the transformer at the first fit
+        # Memorize the transformer at the first fit
         cached_pipe.fit(iris_features, iris_target_sr)
         pipe.fit(iris_features, iris_target_sr)
         # Get the time stamp of the transformer in the cached pipeline
@@ -323,48 +323,75 @@ def test_pipeline_df_raise_set_params_error() -> None:
         pipe.set_params(fake__estimator="nope")
 
 
-def test_feature_union(test_data_categorical: pd.DataFrame) -> None:
+@pytest.mark.parametrize(argnames="sparse", argvalues=[True, False])  # type: ignore
+def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> None:
+    # the expected column dtype, depending on arg sparse
+    dtype_expected = pd.SparseDtype(np.float_, fill_value=0) if sparse else np.float_
+
+    # apply the test data to a simple feature union
     feature_union = FeatureUnionDF(
         [
-            ("oh", OneHotEncoderDF(drop="first", sparse=False)),
+            ("one_hot", OneHotEncoderDF(drop="first", sparse=sparse)),
         ]
     )
+    transformed = feature_union.fit_transform(test_data_categorical)
 
+    # assert that all columns of the data frame are sparse
+    assert all(
+        col_dtype == dtype_expected for col_dtype in transformed.dtypes
+    ), f"all columns should be of type {dtype_expected}: {transformed.dtypes}"
+
+    # if the output is sparse, make it dense
+    if sparse:
+        transformed = transformed.sparse.to_dense()
+
+    # assert that the one-hot encoding is as expected
     assert_frame_equal(
-        feature_union.fit_transform(test_data_categorical),
+        transformed,
         pd.DataFrame(
             dict(
-                oh__a_yes=[1.0, 1.0, 0.0],
-                oh__b_green=[0.0, 0.0, 1.0],
-                oh__b_red=[1.0, 0.0, 0.0],
-                oh__c_father=[0.0, 1.0, 0.0],
-                oh__c_mother=[0.0, 0.0, 1.0],
+                one_hot__a_yes=[1.0, 1.0, 0.0],
+                one_hot__b_green=[0.0, 0.0, 1.0],
+                one_hot__b_red=[1.0, 0.0, 0.0],
+                one_hot__c_father=[0.0, 1.0, 0.0],
+                one_hot__c_mother=[0.0, 0.0, 1.0],
             ),
-        ).rename_axis(columns="feature_out"),
+        ).rename_axis(columns="feature"),
     )
 
     if __sklearn_version__ >= __sklearn_1_1__:
+        # test the passthrough option introduced in sklearn 1.1
+
+        # apply the test data to a simple feature union
         feature_union = FeatureUnionDF(
             [
-                ("oh", OneHotEncoderDF(drop="first", sparse=False)),
+                ("one_hot", OneHotEncoderDF(drop="first", sparse=sparse)),
                 ("pass", "passthrough"),
                 ("pass_again", "passthrough"),
-            ]
+            ],
+        )
+        transformed = feature_union.fit_transform(test_data_categorical)
+
+        # assert that all one-hot-encoded columns of the data frame are sparse
+        assert all(
+            dtype == (dtype_expected if column.startswith("one_hot__") else np.object_)
+            for column, dtype in zip(transformed.columns, transformed.dtypes)
         )
 
+        # assert that the one-hot encoding is as expected
         assert_frame_equal(
-            feature_union.fit_transform(test_data_categorical),
+            transformed,
             pd.concat(
                 [
                     pd.DataFrame(
                         dict(
-                            oh__a_yes=[1.0, 1.0, 0.0],
-                            oh__b_green=[0.0, 0.0, 1.0],
-                            oh__b_red=[1.0, 0.0, 0.0],
-                            oh__c_father=[0.0, 1.0, 0.0],
-                            oh__c_mother=[0.0, 0.0, 1.0],
+                            one_hot__a_yes=[1.0, 1.0, 0.0],
+                            one_hot__b_green=[0.0, 0.0, 1.0],
+                            one_hot__b_red=[1.0, 0.0, 0.0],
+                            one_hot__c_father=[0.0, 1.0, 0.0],
+                            one_hot__c_mother=[0.0, 0.0, 1.0],
                         ),
-                        dtype=object,
+                        dtype=dtype_expected,
                     ),
                     test_data_categorical.add_prefix("pass__"),
                     test_data_categorical.add_prefix("pass_again__"),

--- a/test/test/sklearndf/test_base.py
+++ b/test/test/sklearndf/test_base.py
@@ -18,8 +18,8 @@ from pytools.expression.atomic import Id
 from sklearndf.classification import SVCDF, DecisionTreeClassifierDF
 from sklearndf.clustering.wrapper import KMeansBaseWrapperDF
 from sklearndf.pipeline import PipelineDF
-from sklearndf.pipeline.wrapper import FeatureUnionWrapperDF
 from sklearndf.transformation import OneHotEncoderDF
+from sklearndf.transformation.wrapper import ImputerWrapperDF
 from sklearndf.wrapper import (
     ClassifierWrapperDF,
     EstimatorWrapperDF,
@@ -254,7 +254,7 @@ def test_native_class_validation() -> None:
     ):
 
         class MismatchedNativeClass4(
-            FeatureUnionWrapperDF, native=RandomForestRegressor
+            ImputerWrapperDF[Any], native=RandomForestRegressor
         ):
             pass
 

--- a/test/test/sklearndf/test_sklearn_coverage.py
+++ b/test/test/sklearndf/test_sklearn_coverage.py
@@ -161,9 +161,9 @@ def sklearn_clusterer_classes() -> List[type]:
 def _check_unexpected_sklearn_class(cls: type) -> None:
     f_cls_name = f"{cls.__module__}.{cls.__name__}"
     if cls.__name__ in UNSUPPORTED_SKLEARN_CLASSES:
-        pytest.skip(f"Class '{f_cls_name} is not wrapped but marked as unsupported' ")
+        pytest.skip(f"Class {f_cls_name} is not wrapped but marked as unsupported")
     else:
-        raise ValueError(f"Class '{f_cls_name}' is not wrapped")
+        raise ValueError(f"Class {f_cls_name} is not wrapped")
 
 
 @pytest.mark.parametrize(  # type: ignore

--- a/test/test/sklearndf/transformation/test_extra.py
+++ b/test/test/sklearndf/transformation/test_extra.py
@@ -4,7 +4,11 @@ from sklearn.ensemble import RandomForestRegressor
 
 from sklearndf.pipeline import PipelineDF
 from sklearndf.regression import RandomForestRegressorDF
-from sklearndf.transformation import SimpleImputerDF
+from sklearndf.transformation import (
+    ColumnTransformerDF,
+    OneHotEncoderDF,
+    SimpleImputerDF,
+)
 from sklearndf.transformation.extra import BorutaDF
 
 
@@ -26,7 +30,27 @@ def test_boruta_pipeline(boston_df: pd.DataFrame, boston_target: str) -> None:
 
     boruta_selector = PipelineDF(
         steps=[
-            ("preprocess", SimpleImputerDF(strategy="median")),
+            (
+                "preprocess",
+                PipelineDF(
+                    steps=[
+                        ("imputer", SimpleImputerDF()),
+                        (
+                            "onehot",
+                            ColumnTransformerDF(
+                                [
+                                    (
+                                        "onehot",
+                                        OneHotEncoderDF(drop="if_binary"),
+                                        ["CHAS"],
+                                    ),
+                                ],
+                                remainder="passthrough",
+                            ),
+                        ),
+                    ]
+                ),
+            ),
             (
                 "boruta",
                 BorutaDF(

--- a/test/test/sklearndf/transformation/test_extra.py
+++ b/test/test/sklearndf/transformation/test_extra.py
@@ -42,7 +42,7 @@ def test_boruta_pipeline(diabetes_df: pd.DataFrame, diabetes_target: str) -> Non
                                     (
                                         "onehot",
                                         OneHotEncoderDF(drop="if_binary"),
-                                        ["CHAS"],
+                                        ["sex"],
                                     ),
                                 ],
                                 remainder="passthrough",

--- a/test/test/sklearndf/transformation/test_sparse.py
+++ b/test/test/sklearndf/transformation/test_sparse.py
@@ -1,0 +1,103 @@
+import pandas as pd
+import pytest
+from pandas.testing import assert_index_equal, assert_series_equal
+
+from sklearndf._util import sparse_frame_density
+from sklearndf.pipeline import FeatureUnionDF, PipelineDF
+from sklearndf.transformation import CountVectorizerDF, TfidfTransformerDF
+
+
+def test_tfidf() -> None:
+
+    # expected results
+
+    word_feature_names = (
+        ["and", "document", "first", "here", "is", "it"]
+        + ["last", "one", "or", "second", "the", "third", "this"]
+        # single-word features
+    )
+    bigram_feature_names = (
+        ["and the", "first document", "here is", "is it", "is the", "is this", "it the"]
+        + ["last document", "or is", "second document", "the first", "the last"]
+        + ["the second", "the third", "third one", "this the"]
+    )
+
+    # create a simple toy corpus, inspired by scikit-learn's documentation
+
+    corpus = pd.Series(
+        [
+            "Here is the first document.",
+            "Here is the second document.",
+            "And the third one.",
+            "Is this the first document?",
+            "The last document?",
+            "Or is it the second document?",
+        ]
+    )
+    corpus_named = corpus.rename("document")
+
+    # count the words for every document in the corpus
+
+    word_counter = CountVectorizerDF()
+
+    with pytest.raises(
+        ValueError, match="the name of the series passed as arg X must not be None$"
+    ):
+        word_counter.fit_transform(corpus)
+
+    word_counts_sparse_df = word_counter.fit_transform(corpus_named)
+
+    assert word_counter.get_feature_names() == word_feature_names
+    assert all(
+        isinstance(dtype, pd.SparseDtype) for dtype in word_counts_sparse_df.dtypes
+    )
+
+    # compute the tf-idf values for every word in every document
+
+    tfidf = TfidfTransformerDF()
+    x_tfidf = tfidf.fit_transform(word_counts_sparse_df)
+
+    assert all(isinstance(dtype, pd.SparseDtype) for dtype in x_tfidf.dtypes)
+    assert_index_equal(tfidf.feature_names_out_, word_counts_sparse_df.columns)
+    assert_index_equal(tfidf.feature_names_out_, x_tfidf.columns)
+    assert sparse_frame_density(x_tfidf) == pytest.approx(0.3589744)
+
+    # count the bigrams for every document in the corpus
+
+    bigram_counter = CountVectorizerDF(analyzer="word", ngram_range=(2, 2))
+    x2 = bigram_counter.fit_transform(corpus_named)
+    assert bigram_counter.get_feature_names() == bigram_feature_names
+    assert all(isinstance(dtype, pd.SparseDtype) for dtype in x2.dtypes)
+
+    # create a pipeline that combines the word and bigram counter
+    # and computes the tf-idf values for every word and bigram
+
+    pipe = PipelineDF(
+        [
+            (
+                "vectorize",
+                FeatureUnionDF(
+                    [
+                        ("words", word_counter),
+                        ("bigrams", bigram_counter),
+                    ]
+                ),
+            ),
+            ("tfidf", tfidf),
+        ]
+    )
+
+    tfidf = pipe.fit_transform(corpus_named)
+    assert all(isinstance(dtype, pd.SparseDtype) for dtype in tfidf.dtypes)
+    assert_series_equal(
+        pipe.feature_names_original_,
+        pd.Series(
+            index=pd.Index(
+                [f"words__{name}" for name in word_feature_names]
+                + [f"bigrams__{name}" for name in bigram_feature_names],
+                name="feature_out",
+            ),
+            data="document",  # all features share the same input column, "document"
+            name="feature_in",
+        ),
+    )

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -75,15 +75,15 @@ def test_transformer_count() -> None:
 
     print(f"Testing {n} transformers.")
     if __sklearn_version__ < __sklearn_0_22__:
-        assert n == 53
-    elif __sklearn_version__ < __sklearn_0_24__:
-        assert n == 54
-    elif __sklearn_version__ < __sklearn_1_0__:
         assert n == 55
-    elif __sklearn_version__ < __sklearn_1_1__:
+    elif __sklearn_version__ < __sklearn_0_24__:
         assert n == 56
-    else:
+    elif __sklearn_version__ < __sklearn_1_0__:
+        assert n == 57
+    elif __sklearn_version__ < __sklearn_1_1__:
         assert n == 58
+    else:
+        assert n == 60
 
 
 @pytest.fixture  # type: ignore

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -455,10 +455,10 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
     )
 
     assert_frame_equal(
-        OneHotEncoderDF(drop="first", sparse=False).fit_transform(
+        OneHotEncoderDF(drop="first", sparse=sparse).fit_transform(
             test_data_categorical
         ),
-        pd.DataFrame(
+        _make_frame(
             {
                 "a_yes": [1.0, 1.0, 0.0],
                 "b_green": [0.0, 0.0, 1.0],
@@ -466,14 +466,14 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
                 "c_father": [0.0, 1.0, 0.0],
                 "c_mother": [0.0, 0.0, 1.0],
             }
-        ).rename_axis(columns="feature_out"),
+        ),
     )
 
     assert_frame_equal(
-        OneHotEncoderDF(drop=["yes", "red", "mother"], sparse=False).fit_transform(
+        OneHotEncoderDF(drop=["yes", "red", "mother"], sparse=sparse).fit_transform(
             test_data_categorical
         ),
-        pd.DataFrame(
+        _make_frame(
             {
                 "a_no": [0.0, 0.0, 1.0],
                 "b_blue": [0.0, 1.0, 0.0],
@@ -481,7 +481,7 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
                 "c_child": [1.0, 0.0, 0.0],
                 "c_father": [0.0, 1.0, 0.0],
             }
-        ).rename_axis(columns="feature_out"),
+        ),
     )
 
     if __sklearn_version__ >= __sklearn_0_23__:
@@ -505,17 +505,17 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
     if __sklearn_version__ >= __sklearn_1_1__:
 
         assert_frame_equal(
-            OneHotEncoderDF(min_frequency=2, sparse=False).fit_transform(
+            OneHotEncoderDF(min_frequency=2, sparse=sparse).fit_transform(
                 test_data_categorical
             ),
-            pd.DataFrame(
+            _make_frame(
                 {
                     "a_yes": [1.0, 1.0, 0.0],
                     "a_infrequent_sklearn": [0.0, 0.0, 1.0],
                     "b_infrequent_sklearn": [1.0, 1.0, 1.0],
                     "c_infrequent_sklearn": [1.0, 1.0, 1.0],
                 }
-            ).rename_axis(columns="feature_out"),
+            ),
         )
 
         assert_frame_equal(
@@ -549,14 +549,14 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
                     "c_father": [0.0, 1.0, 0.0],
                     "c_mother": [0.0, 0.0, 1.0],
                 }
-            ).rename_axis(columns="feature_out"),
+            ),
         )
 
         assert_frame_equal(
             OneHotEncoderDF(
-                drop="if_binary", max_categories=10, sparse=False
+                drop="if_binary", max_categories=10, sparse=sparse
             ).fit_transform(test_data_categorical),
-            pd.DataFrame(
+            _make_frame(
                 {
                     "a_yes": [1.0, 1.0, 0.0],
                     "b_blue": [0.0, 1.0, 0.0],
@@ -566,27 +566,27 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
                     "c_father": [0.0, 1.0, 0.0],
                     "c_mother": [0.0, 0.0, 1.0],
                 }
-            ).rename_axis(columns="feature_out"),
+            ),
         )
 
         assert_frame_equal(
-            OneHotEncoderDF(drop="first", max_categories=2, sparse=False).fit_transform(
-                test_data_categorical
-            ),
-            pd.DataFrame(
+            OneHotEncoderDF(
+                drop="first", max_categories=2, sparse=sparse
+            ).fit_transform(test_data_categorical),
+            _make_frame(
                 {
                     "a_infrequent_sklearn": [0.0, 0.0, 1.0],
                     "b_infrequent_sklearn": [0.0, 1.0, 1.0],
                     "c_infrequent_sklearn": [1.0, 1.0, 0.0],
                 }
-            ).rename_axis(columns="feature_out"),
+            ),
         )
 
         assert_frame_equal(
             OneHotEncoderDF(
-                drop="if_binary", max_categories=2, sparse=False
+                drop="if_binary", max_categories=2, sparse=sparse
             ).fit_transform(test_data_categorical),
-            pd.DataFrame(
+            _make_frame(
                 {
                     "a_infrequent_sklearn": [0.0, 0.0, 1.0],
                     "b_infrequent_sklearn": [0.0, 1.0, 1.0],

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -252,7 +252,7 @@ def test_column_transformer(test_data: pd.DataFrame) -> None:
             **transformer_args,
         )
         transformed_native = pd.DataFrame(
-            col_tx_native.fit_transform(X=data), columns=feature_names_out_expected
+            col_tx_native.fit_transform(X=data), columns=names_out
         )
 
         assert_frame_equal(transformed_df, transformed_native, check_dtype=False)

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -255,12 +255,11 @@ def test_column_transformer(test_data: pd.DataFrame) -> None:
             remainder=remainder,
             **transformer_args,
         )
-        transformed_native = col_tx_native.fit_transform(X=data)
-
-        assert_frame_equal(
-            transformed_df,
-            pd.DataFrame(transformed_native, columns=feature_names_out_expected),
+        transformed_native = pd.DataFrame(
+            col_tx_native.fit_transform(X=data), columns=feature_names_out_expected
         )
+
+        assert_frame_equal(transformed_df, transformed_native, check_dtype=False)
 
         assert col_tx_df.feature_names_in_.equals(feature_names_in_expected)
         assert col_tx_df.feature_names_out_.equals(feature_names_out_expected)

--- a/test/test/test_docs.py
+++ b/test/test/test_docs.py
@@ -21,9 +21,11 @@ def test_doc() -> None:
                     # XGBoost estimators in the '.extra' packages
                     r"(?:classification|regression)\.extra\.XGB.*",
                     # BorutaDF
-                    r"transformation\.extra\.BorutaDF.*",
+                    r"transformation\.extra\.BorutaDF",
                     # scikit-learn pipeline classes
                     r"pipeline\.(PipelineDF|FeatureUnionDF).*",
+                    # sparse frames version of FeatureUnion
+                    r"pipeline\.wrapper\.FeatureUnion\.",
                 )
             )
             + ")"


### PR DESCRIPTION
- allow `OneHotEncoderDF` to produce sparse data frames
- accept pandas series as the `X` argument of all estimators, as an alternative to data frames
- add `CountVectorizerDF` and `TfidfVectorizerDF` (both of which expect a series or a single-column data frame as the `X` argument)
- preserve sparse dataframes in `ColumnTransformerDF` and `FeatureUnionDF`