### PR TITLE
API: add `_EstimatorPipelineDF.preprocess()`; remove attributes `feature_names_out_` and `feature_names_original_`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -18,7 +18,11 @@ API.
 ~~~~~
 
 - API: new property :attr:`.EstimatorDF.output_names_` to get the names of the output
-  columns the estimator was fitted with.
+  columns the estimator was fitted with
+- API: new method :attr:`.LearnerPipelineDF.preprocess` to apply the preprocessing step
+  to a data frame
+- API: remove properties ``feature_names_out_`` and ``feature_names_original_`` from
+  class :class:`.LearnerPipelineDF`
 
 
 *sklearndf* 2.1


### PR DESCRIPTION
- add `preprocess()` as a convenience method to invoke the preprocessing step of the two-step learner pipeline
- remove `feature_names_out_` and `feature_names_original_` properties as these can be invoked directly on the preprocessing step