### PR TITLE
BUILD: drop support for scikit-learn 0.23 and earlier

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,8 @@ API.
 
 *sklearndf* 2.2 adds support for
 `scikit-learn |nbsp| 1.2 <https://scikit-learn.org/1.2>`_.
+It drops support for *scikit-learn* |nbsp| 0.23 and earlier due to incomplete
+support of sparse output (see below).
 
 - API: DF estimators now support native estimators using sparse matrices as input or
   output, and automatically convert them to or from sparse :class:`~pandas.DataFrame`

--- a/src/sklearndf/_sklearn_version.py
+++ b/src/sklearndf/_sklearn_version.py
@@ -7,8 +7,6 @@ from sklearn import __version__ as sklearn_version
 
 __all__ = [
     "__sklearn_version__",
-    "__sklearn_0_22__",
-    "__sklearn_0_23__",
     "__sklearn_0_24__",
     "__sklearn_1_0__",
     "__sklearn_1_1__",
@@ -18,8 +16,6 @@ __all__ = [
 ]
 
 __sklearn_version__ = Version(sklearn_version)
-__sklearn_0_22__ = Version("0.22")
-__sklearn_0_23__ = Version("0.23")
 __sklearn_0_24__ = Version("0.24")
 __sklearn_1_0__ = Version("1.0")
 __sklearn_1_1__ = Version("1.1")

--- a/src/sklearndf/classification/__init__.py
+++ b/src/sklearndf/classification/__init__.py
@@ -2,14 +2,10 @@
 Extended versions of all `scikit-learn` classifiers with enhanced support for data
 frames.
 """
-from .. import __sklearn_0_22__, __sklearn_0_23__, __sklearn_1_0__, __sklearn_version__
+from .. import __sklearn_1_0__, __sklearn_version__
 from ._classification import *
-
-if __sklearn_version__ >= __sklearn_0_22__:
-    from ._classification_v0_22 import *
-
-if __sklearn_version__ >= __sklearn_0_23__:
-    from ._classification_v0_23 import *
+from ._classification_v0_22 import *
+from ._classification_v0_23 import *
 
 if __sklearn_version__ >= __sklearn_1_0__:
     from ._classification_v1_0 import *

--- a/src/sklearndf/regression/__init__.py
+++ b/src/sklearndf/regression/__init__.py
@@ -2,14 +2,10 @@
 Extended versions of all `scikit-learn` regressors with enhanced support for data
 frames.
 """
-from .. import __sklearn_0_22__, __sklearn_0_23__, __sklearn_1_0__, __sklearn_version__
+from .. import __sklearn_1_0__, __sklearn_version__
 from ._regression import *
-
-if __sklearn_version__ >= __sklearn_0_22__:
-    from ._regression_v0_22 import *
-
-if __sklearn_version__ >= __sklearn_0_23__:
-    from ._regression_v0_23 import *
+from ._regression_v0_22 import *
+from ._regression_v0_23 import *
 
 if __sklearn_version__ >= __sklearn_1_0__:
     from ._regression_v1_0 import *

--- a/src/sklearndf/transformation/__init__.py
+++ b/src/sklearndf/transformation/__init__.py
@@ -3,17 +3,9 @@ Extended versions of all `scikit-learn` transformers with enhanced support for d
 frames.
 """
 
-from .. import (
-    __sklearn_0_22__,
-    __sklearn_0_24__,
-    __sklearn_1_0__,
-    __sklearn_1_1__,
-    __sklearn_version__,
-)
+from .. import __sklearn_0_24__, __sklearn_1_0__, __sklearn_1_1__, __sklearn_version__
 from ._transformation import *
-
-if __sklearn_version__ >= __sklearn_0_22__:
-    from ._transformation_v0_22 import *
+from ._transformation_v0_22 import *
 
 if __sklearn_version__ >= __sklearn_0_24__:
     from ._transformation_v0_24 import *

--- a/test/test/sklearndf/__init__.py
+++ b/test/test/sklearndf/__init__.py
@@ -9,13 +9,7 @@ from sklearn.base import BaseEstimator
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import FeatureUnion
 
-from sklearndf import (
-    EstimatorDF,
-    LearnerDF,
-    TransformerDF,
-    __sklearn_0_22__,
-    __sklearn_version__,
-)
+from sklearndf import EstimatorDF, LearnerDF, TransformerDF, __sklearn_version__
 from sklearndf.pipeline.wrapper import FeatureUnionSparseFrames
 from sklearndf.transformation.wrapper import ColumnTransformerSparseFrames
 from sklearndf.wrapper import EstimatorWrapperDF
@@ -106,9 +100,7 @@ def get_sklearndf_wrapper_class(
 
 
 def check_expected_not_fitted_error(estimator: EstimatorDF) -> None:
-    """Check if transformers & learners raise NotFittedError (since sklearn 0.22)"""
-    if __sklearn_version__ < __sklearn_0_22__:
-        return
+    """Check if transformers & learners raise NotFittedError"""
 
     test_x = pd.DataFrame(data=list(range(10)))
 

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -10,7 +10,6 @@ from sklearn.multioutput import ClassifierChain, MultiOutputClassifier
 import sklearndf.classification as classification
 from sklearndf import (
     ClassifierDF,
-    __sklearn_0_22__,
     __sklearn_1_0__,
     __sklearn_1_2__,
     __sklearn_version__,
@@ -28,9 +27,7 @@ def test_classifier_count() -> None:
     n = len(CLASSIFIERS_TO_TEST)
 
     print(f"Testing {n} classifiers.")
-    if __sklearn_version__ < __sklearn_0_22__:
-        assert n == 38
-    elif __sklearn_version__ < __sklearn_1_0__:
+    if __sklearn_version__ < __sklearn_1_0__:
         assert n == 40
     else:
         assert n == 41
@@ -78,9 +75,8 @@ CLASSIFIERS_PARTIAL_FIT = [
     classification.GaussianNBDF,
     classification.ComplementNBDF,
     classification.MultiOutputClassifierDF,
+    classification.CategoricalNBDF,
 ]
-if __sklearn_version__ >= __sklearn_0_22__:
-    CLASSIFIERS_PARTIAL_FIT.append(classification.CategoricalNBDF)
 
 
 @pytest.mark.parametrize(  # type: ignore

--- a/test/test/sklearndf/test_meta_estimators.py
+++ b/test/test/sklearndf/test_meta_estimators.py
@@ -5,7 +5,6 @@ import pytest
 from sklearn.base import is_classifier, is_regressor
 from sklearn.impute import SimpleImputer
 
-from sklearndf import __sklearn_0_22__, __sklearn_version__
 from sklearndf.classification import (
     ClassifierChainDF,
     LogisticRegressionCVDF,
@@ -69,10 +68,6 @@ def test_meta_estimators() -> None:
         ClassifierChainDF(base_estimator=SimpleImputer())
 
 
-@pytest.mark.skipif(  # type: ignore
-    condition=__sklearn_version__ < __sklearn_0_22__,
-    reason="stacking estimators are not implemented by current version of sklearn",
-)
 def test_stacking_regressor(
     diabetes_features: pd.DataFrame, diabetes_target_sr: pd.Series
 ) -> None:
@@ -142,10 +137,6 @@ def test_stacking_regressor(
     ]
 
 
-@pytest.mark.skipif(  # type: ignore
-    condition=__sklearn_version__ < __sklearn_0_22__,
-    reason="stacking estimators are not implemented by current version of sklearn",
-)
 def test_stacking_classifier(
     iris_features: pd.DataFrame, iris_target_sr: pd.Series
 ) -> None:

--- a/test/test/sklearndf/test_regression.py
+++ b/test/test/sklearndf/test_regression.py
@@ -6,14 +6,7 @@ from sklearn.base import BaseEstimator, is_regressor
 from sklearn.multioutput import MultiOutputRegressor, RegressorChain
 
 import sklearndf.regression
-from sklearndf import (
-    RegressorDF,
-    TransformerDF,
-    __sklearn_0_22__,
-    __sklearn_0_23__,
-    __sklearn_1_0__,
-    __sklearn_version__,
-)
+from sklearndf import RegressorDF, TransformerDF, __sklearn_1_0__, __sklearn_version__
 from sklearndf.regression import (
     SVRDF,
     IsotonicRegressionDF,
@@ -40,11 +33,7 @@ def test_regressor_count() -> None:
     n = len(REGRESSORS_TO_TEST)
 
     print(f"Testing {n} regressors.")
-    if __sklearn_version__ < __sklearn_0_22__:
-        assert n == 49
-    elif __sklearn_version__ < __sklearn_0_23__:
-        assert n == 50
-    elif __sklearn_version__ < __sklearn_1_0__:
+    if __sklearn_version__ < __sklearn_1_0__:
         assert n == 53
     else:
         assert n == 55

--- a/test/test/sklearndf/test_sklearn_coverage.py
+++ b/test/test/sklearndf/test_sklearn_coverage.py
@@ -20,8 +20,8 @@ import sklearndf.pipeline
 import sklearndf.regression
 import sklearndf.transformation
 from ..conftest import UNSUPPORTED_SKLEARN_PACKAGES
-from ..sklearndf import find_all_submodules, iterate_classes, sklearn_delegate_classes
-from sklearndf import EstimatorDF, __sklearn_0_23__, __sklearn_version__
+from . import find_all_submodules, iterate_classes, sklearn_delegate_classes
+from sklearndf import EstimatorDF
 
 T = TypeVar("T")
 
@@ -39,11 +39,9 @@ CLASSIFIER_COVERAGE_EXCLUSIONS = {
     *GENERAL_COVERAGE_EXCLUSIONS,
     # Base classes and Mixins not following the convention
     "ForestClassifier",
+    "_IdentityClassifier",
 }
 
-if __sklearn_version__ >= __sklearn_0_23__:
-    added_in_v023 = ("_IdentityClassifier",)
-    CLASSIFIER_COVERAGE_EXCLUSIONS.update(added_in_v023)
 
 REGRESSOR_COVERAGE_EXCLUSIONS = {
     *GENERAL_COVERAGE_EXCLUSIONS,

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -21,8 +21,6 @@ from sklearndf import (
     ClassifierDF,
     RegressorDF,
     TransformerDF,
-    __sklearn_0_22__,
-    __sklearn_0_23__,
     __sklearn_0_24__,
     __sklearn_1_0__,
     __sklearn_1_1__,
@@ -74,9 +72,7 @@ def test_transformer_count() -> None:
     n = len(TRANSFORMERS_TO_TEST)
 
     print(f"Testing {n} transformers.")
-    if __sklearn_version__ < __sklearn_0_22__:
-        assert n == 55
-    elif __sklearn_version__ < __sklearn_0_24__:
+    if __sklearn_version__ < __sklearn_0_24__:
         assert n == 56
     elif __sklearn_version__ < __sklearn_1_0__:
         assert n == 57
@@ -483,23 +479,22 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
         ),
     )
 
-    if __sklearn_version__ >= __sklearn_0_23__:
-        assert_frame_equal(
-            OneHotEncoderDF(drop="if_binary", sparse=sparse).fit_transform(
-                test_data_categorical
-            ),
-            _make_frame(
-                {
-                    "a_yes": [1.0, 1.0, 0.0],
-                    "b_blue": [0.0, 1.0, 0.0],
-                    "b_green": [0.0, 0.0, 1.0],
-                    "b_red": [1.0, 0.0, 0.0],
-                    "c_child": [1.0, 0.0, 0.0],
-                    "c_father": [0.0, 1.0, 0.0],
-                    "c_mother": [0.0, 0.0, 1.0],
-                }
-            ),
-        )
+    assert_frame_equal(
+        OneHotEncoderDF(drop="if_binary", sparse=sparse).fit_transform(
+            test_data_categorical
+        ),
+        _make_frame(
+            {
+                "a_yes": [1.0, 1.0, 0.0],
+                "b_blue": [0.0, 1.0, 0.0],
+                "b_green": [0.0, 0.0, 1.0],
+                "b_red": [1.0, 0.0, 0.0],
+                "c_child": [1.0, 0.0, 0.0],
+                "c_father": [0.0, 1.0, 0.0],
+                "c_mother": [0.0, 0.0, 1.0],
+            }
+        ),
+    )
 
     if __sklearn_version__ >= __sklearn_1_1__:
 


### PR DESCRIPTION
This PR drops support for *scikit-learn* versions 0.23 and earlier due to their incomplete support of sparse output.