### PR TITLE
API: replace BorutaPy with ARFS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,7 +155,8 @@ stages:
                 set -eux
                 eval "$(conda shell.bash hook)"
 
-                conda env create --verbose
+                conda install -c conda-forge mamba~=1.4.1
+                mamba env create
                 conda activate $(project_name)-develop
 
                 export PYTHONPATH=$(System.DefaultWorkingDirectory)/src/
@@ -647,7 +648,8 @@ stages:
                 echo "Checking out $(branchName)"
                 git checkout $(branchName)
 
-                conda env create
+                conda install -c conda-forge mamba~=1.4.1
+                mamba env create
                 conda activate $(project_name)-develop
 
                 export PYTHONPATH=$(System.DefaultWorkingDirectory)/src/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install isort~=5.10
+              python -m pip install isort~=5.12
               python -m isort --check --diff .
             displayName: 'Run isort'
       - job:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,8 +141,8 @@ stages:
         steps:
           - task: UsePythonVersion@0
             inputs:
-              versionSpec: '3.8'
-            displayName: 'use Python 3.8'
+              versionSpec: '3.9'
+            displayName: 'use Python 3.9'
 
           - checkout: self
 
@@ -155,7 +155,7 @@ stages:
                 set -eux
                 eval "$(conda shell.bash hook)"
 
-                conda env create
+                conda env create --verbose
                 conda activate $(project_name)-develop
 
                 export PYTHONPATH=$(System.DefaultWorkingDirectory)/src/

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
   - bcg_gamma
 dependencies:
   # run
-  - boruta_py ~= 0.3
   - gamma-pytools ~= 2.1rc, <3a
   - joblib ~= 1.2
   - lightgbm ~= 3.3.4
@@ -15,6 +14,9 @@ dependencies:
   - scikit-learn ~= 1.2.0
   - scipy ~= 1.10.0
   - xgboost ~= 1.7.1
+  - pip ~= 23.0
+  - pip:
+    - arfs ~= 1.0.5
   # build/test
   - conda-build ~= 3.23.3
   - conda-verify ~= 3.1.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # run
   - gamma-pytools ~= 2.1rc1, <3a
-  - joblib ~= 1.2
+  - joblib ~= 1.2.0
   - lightgbm ~= 3.3.5
   - matplotlib ~= 3.6.3
   - numpy ~= 1.23.5
@@ -14,9 +14,10 @@ dependencies:
   - scikit-learn ~= 1.2.2
   - scipy ~= 1.10.1
   - xgboost ~= 1.7.1
-  - pip ~= 23.0
+  - pip ~= 23.0.1
   - pip:
     - arfs ~= 1.0.5
+    - shap ~= 0.41.0
   # build/test
   - conda-build ~= 3.23.3
   - conda-verify ~= 3.1.1
@@ -34,7 +35,7 @@ dependencies:
   - tox ~= 3.27.1
   - yaml ~= 0.2.5
   # sphinx
-  - nbsphinx ~= 0.8.9
+  - nbsphinx ~= 0.8.12
   - sphinx ~= 4.5.0
   - sphinx-autodoc-typehints ~= 1.19.2
   - pydata-sphinx-theme ~= 0.8.1

--- a/environment.yml
+++ b/environment.yml
@@ -4,15 +4,15 @@ channels:
   - bcg_gamma
 dependencies:
   # run
-  - gamma-pytools ~= 2.1rc, <3a
+  - gamma-pytools ~= 2.1rc1, <3a
   - joblib ~= 1.2
-  - lightgbm ~= 3.3.4
+  - lightgbm ~= 3.3.5
   - matplotlib ~= 3.6.3
   - numpy ~= 1.23.5
   - pandas ~= 1.5.3
-  - python ~= 3.9.15
-  - scikit-learn ~= 1.2.0
-  - scipy ~= 1.10.0
+  - python ~= 3.9.16
+  - scikit-learn ~= 1.2.2
+  - scipy ~= 1.10.1
   - xgboost ~= 1.7.1
   - pip ~= 23.0
   - pip:
@@ -27,7 +27,7 @@ dependencies:
   - m2r ~= 0.3.1
   - pluggy ~= 0.13.1
   - pre-commit ~= 2.21.0
-  - pytest ~= 7.2.1
+  - pytest ~= 7.2.2
   - pytest-cov ~= 2.12.1
   - pyyaml ~= 5.4.1
   - toml ~= 0.10.2
@@ -39,6 +39,6 @@ dependencies:
   - sphinx-autodoc-typehints ~= 1.19.2
   - pydata-sphinx-theme ~= 0.8.1
   # notebooks
-  - jupyterlab ~= 3.5.2
+  - jupyterlab ~= 3.5.3
   - openpyxl ~= 3.0.10
   - seaborn ~= 0.12.2

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,10 @@
 strict = True
 show_error_codes = True
 
+[mypy-arfs.*]
+; TODO remove once PEP 561 is supported
+ignore_missing_imports = True
+
 [mypy-boruta.*]
 ; TODO remove once PEP 561 is supported
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dist-name = "sklearndf"
 license = "Apache Software License v2.0"
 
 requires = [
-    "gamma-pytools  ~=2.1rc",
+    "gamma-pytools  >=2.1rc2,<3a",
     "numpy          >=1.21,<1.24a",  # cannot use ~= due to conda bug
     "packaging      >=20",
     "pandas         >=1",
@@ -71,7 +71,7 @@ no-binary.min = ["matplotlib"]
 [build.matrix.min]
 # direct requirements of sklearndf
 boruta         = "~=0.3.0"
-gamma-pytools  = "~=2.1rc"
+gamma-pytools  = "~=2.1rc2"
 lightgbm       = "~=3.0.0"
 numpy          = "==1.21.6"  # cannot use ~= due to conda bug
 packaging      = "~=20.9"
@@ -88,7 +88,7 @@ typing_inspect = "~=0.4.0"
 [build.matrix.max]
 # direct requirements of sklearndf
 boruta         = "~=0.3"
-gamma-pytools  = "~=2.1rc"
+gamma-pytools  = ">=2.1rc2,<3a"
 lightgbm       = "~=3.3"
 numpy          = ">=1.23,<1.24a"  # cannot use ~= due to conda bug
 packaging      = ">=20"

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 
-from sklearn.base import TransformerMixin
+from sklearn.base import BaseEstimator, TransformerMixin
 
 from pytools.api import AllTracker
 
@@ -13,7 +13,7 @@ from ...wrapper import MissingEstimator
 
 log = logging.getLogger(__name__)
 
-__all__ = ["BorutaDF"]
+__all__ = ["BoostAGrootaDF", "BorutaDF", "GrootCVDF", "LeshyDF"]
 
 try:
     # import boruta classes only if installed
@@ -22,6 +22,31 @@ try:
 except ImportError:
 
     class BorutaPy(  # type: ignore
+        MissingEstimator,
+        TransformerMixin,  # type: ignore
+    ):
+        """Mock-up for missing estimator."""
+
+
+try:
+    # import boruta classes only if installed
+    from arfs.feature_selection.allrelevant import BoostAGroota, GrootCV, Leshy
+
+except ImportError:
+
+    class BoostAGroota(  # type: ignore
+        MissingEstimator,
+        TransformerMixin,  # type: ignore
+    ):
+        """Mock-up for missing estimator."""
+
+    class GrootCV(  # type: ignore
+        MissingEstimator,
+        TransformerMixin,  # type: ignore
+    ):
+        """Mock-up for missing estimator."""
+
+    class Leshy(  # type: ignore
         MissingEstimator,
         TransformerMixin,  # type: ignore
     ):
@@ -40,12 +65,59 @@ __tracker = AllTracker(globals())
 #
 
 
+from .wrapper import ARFSWrapperDF as _ARFSWrapperDF
 from .wrapper import BorutaPyWrapperDF as _BorutaPyWrapperDF
 
 
 class BorutaDF(_BorutaPyWrapperDF, native=BorutaPy):
     """
     DF version of :class:`~boruta.BorutaPy`.
+    """
+
+
+class LeshyDF(_ARFSWrapperDF[Leshy], native=Leshy):
+    """
+    DF version of :class:`~arfs.feature_selection.allrelevant.Leshy`.
+    """
+
+
+class BoostAGrootaDF(_ARFSWrapperDF[BoostAGroota], native=BoostAGroota):
+    """
+    DF version of :class:`~arfs.feature_selection.allrelevant.BoostAGroota`.
+    """
+
+    @property
+    def estimator(self) -> BaseEstimator:
+        """
+        Alias for the native estimator's :attr:`.est` attribute, to conform with
+        the :class:`~sklearn.base.MetaEstimatorMixin` interface.
+
+        :return: the value of the native estimator's :attr:`.est` attribute
+        """
+        return self.native_estimator.est
+
+    @estimator.setter
+    def estimator(self, est: BaseEstimator) -> None:
+        """
+        Alias for the native estimator's :attr:`.est` attribute, to conform with
+        the :class:`~sklearn.base.MetaEstimatorMixin` interface.
+
+        :param est: the new value for the native estimator's :attr:`.est` attribute
+        """
+        self.native_estimator.est = est
+
+    @estimator.deleter
+    def estimator(self) -> None:
+        """
+        Alias for the native estimator's :attr:`.est` attribute, to conform with
+        the :class:`~sklearn.base.MetaEstimatorMixin` interface.
+        """
+        del self.native_estimator.est
+
+
+class GrootCVDF(_ARFSWrapperDF[GrootCV], native=GrootCV):
+    """
+    DF version of :class:`~arfs.feature_selection.allrelevant.GrootCV`.
     """
 
 

--- a/src/sklearndf/transformation/extra/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/extra/wrapper/_wrapper.py
@@ -4,8 +4,10 @@ Core implementation of :mod:`sklearndf.transformation.extra.wrapper`
 from __future__ import annotations
 
 import logging
+from typing import Generic, TypeVar
 
 import pandas as pd
+from sklearn.feature_selection import SelectorMixin
 
 from pytools.api import AllTracker
 
@@ -14,7 +16,7 @@ from ...wrapper import ColumnSubsetTransformerWrapperDF, NumpyTransformerWrapper
 
 log = logging.getLogger(__name__)
 
-__all__ = ["BorutaPyWrapperDF"]
+__all__ = ["BorutaPyWrapperDF", "ARFSWrapperDF"]
 
 try:
     # import boruta classes only if installed
@@ -22,35 +24,58 @@ try:
 except ImportError:
     BorutaPy = None
 
+
+#
+# Type variables
+#
+
+T_FeatureSelector = TypeVar("T_FeatureSelector", bound=SelectorMixin)
+
+
 #
 # Ensure all symbols introduced below are included in __all__
 #
 
 __tracker = AllTracker(globals())
 
+
 #
 # Class definitions
 #
 
-if BorutaPy:
 
-    class BorutaPyWrapperDF(
-        MetaEstimatorWrapperDF[BorutaPy],
-        NumpyTransformerWrapperDF[BorutaPy],
-        ColumnSubsetTransformerWrapperDF[BorutaPy],
-    ):
-        """
-        DF wrapper for :class:`~boruta.BorutaPy`.
-        """
+class BorutaPyWrapperDF(
+    MetaEstimatorWrapperDF[BorutaPy],
+    NumpyTransformerWrapperDF[BorutaPy],
+    ColumnSubsetTransformerWrapperDF[BorutaPy],
+):
+    """
+    DF wrapper for :class:`~boruta.BorutaPy`.
+    """
 
-        def _get_features_out(self) -> pd.Index:
-            return self.feature_names_in_[self.native_estimator.support_]
+    def _get_features_out(self) -> pd.Index:
+        return self.feature_names_in_[self.native_estimator.support_]
 
-        def _get_sparse_threshold(self) -> float:
-            # don't allow sparse input
-            return 0.0
+    def _get_sparse_threshold(self) -> float:
+        # don't allow sparse input
+        return 0.0
 
-else:
-    __all__.remove("BorutaPyWrapperDF")
+
+class ARFSWrapperDF(
+    MetaEstimatorWrapperDF[T_FeatureSelector],
+    ColumnSubsetTransformerWrapperDF[T_FeatureSelector],
+    Generic[T_FeatureSelector],
+):
+    """
+    DF wrapper for :class:`~boruta.BorutaPy`.
+    """
+
+    def _get_features_out(self) -> pd.Index:
+        return self.feature_names_in_[self.native_estimator.support_]
+
+    def _get_sparse_threshold(self) -> float:
+        # don't allow sparse input
+        return 0.0
+
 
 __tracker.validate()

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -1274,7 +1274,7 @@ def _mirror_attributes(
 
     for name, member in vars(native_estimator).items():
 
-        if member is None or name.startswith("_") or name in wrapper_attributes:
+        if member is None or name in wrapper_attributes:
             continue
 
         alias = _make_alias(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -616,7 +616,15 @@ class EstimatorWrapperDF(
         if name.startswith("_"):
             super().__setattr__(name, value)
         else:
-            setattr(self._native_estimator, name, value)
+            try:
+                self.__getattribute__(name)
+            except AttributeError:
+                # set the attribute in the native estimator if it is not defined in this
+                # wrapper object
+                setattr(self._native_estimator, name, value)
+            else:
+                # otherwise, overwrite the attribute in this wrapper object
+                super().__setattr__(name, value)
 
 
 @inheritdoc(match="[see superclass]")

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -1227,7 +1227,7 @@ class MetaEstimatorWrapperDF(
     In that case, we issue a warning that the wrapped estimator is being used instead
     of the DF version.
 
-    This class covers three variants used in sklearn:
+    This class covers three variants used in scikit-learn:
 
     - one delegate estimator in attribute `estimator`
     - one delegate estimator in attribute `base_estimator`

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -1240,14 +1240,14 @@ class MetaEstimatorWrapperDF(
         estimator = getattr(self, "estimator", None)
         if estimator is not None:
             self.estimator = self._native_learner(estimator)
-            substituted.append(estimator)
+            substituted.append("estimator")
 
         base_estimator = getattr(self, "base_estimator", None)
         # attribute base_estimator is deprecated as of scikit-learn 1.2, with the
         # default value of "deprecated"
         if base_estimator is not None and base_estimator != "deprecated":
             self.base_estimator = self._native_learner(base_estimator)
-            substituted.append(base_estimator)
+            substituted.append("base_estimator")
 
         estimators = getattr(self, "estimators", None)
         if estimators is not None:
@@ -1255,7 +1255,7 @@ class MetaEstimatorWrapperDF(
                 (name, self._native_learner(estimator))
                 for name, estimator in estimators
             ]
-            substituted.extend(estimators)
+            substituted.append("estimators")
 
         if substituted:
             warnings.warn(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -219,9 +219,9 @@ class EstimatorWrapperDF(
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """
-        :param args: positional arguments to use when initializing a new new delegate
+        :param args: positional arguments to use when initializing a new delegate
             estimator
-        :param kwargs: keyword arguments to use when initializing a new new delegate
+        :param kwargs: keyword arguments to use when initializing a new delegate
             estimator
         """
         super().__init__()
@@ -403,7 +403,8 @@ class EstimatorWrapperDF(
         return self
 
     def _validate_delegate_estimator(self) -> None:
-        # no validation required by default; to be overloaded as needed
+        # Called as the last step of the estimator wrapper's constructor.
+        # No validation required by default; to be overloaded as needed.
         pass
 
     def _get_features_in(self) -> pd.Index:

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -601,30 +601,41 @@ class EstimatorWrapperDF(
         }
 
     def __getattr__(self, name: str) -> Any:
-        # get a non-private attribute of the delegate estimator
+        # This method is only called if the attribute name is not found in the
+        # instance's dictionary, and __getattribute__() has raised an AttributeError.
+
+        # For private attributes, give up and raise attribute error.
         if name.startswith("_"):
-            # raise attribute error
+            # The following will raise an AttributeError
             self.__getattribute__(name)
         else:
+            # For public attributes, try to get the attribute from the delegate
+            # estimator. If the attribute is not found, raise an attribute error.
             try:
                 return getattr(self._native_estimator, name)
             except AttributeError:
-                # raise attribute error
+                # The following will raise an AttributeError
                 self.__getattribute__(name)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        # set a public attribute of the delegate estimator
+        # This method is called whenever an attribute assignment is attempted.
+
+        # For private attributes, set the attribute in this wrapper object.
         if name.startswith("_"):
             super().__setattr__(name, value)
         else:
+            # For public attributes, set the attribute in this wrapper object only
+            # if it is already defined. Otherwise, set the attribute in the delegate
+            # estimator.
+
             try:
                 self.__getattribute__(name)
             except AttributeError:
-                # set the attribute in the native estimator if it is not defined in this
-                # wrapper object
+                # The attribute is not defined in this wrapper object, so set it in
+                # the delegate estimator.
                 setattr(self._native_estimator, name, value)
             else:
-                # otherwise, overwrite the attribute in this wrapper object
+                # The attribute is defined in this wrapper object, so set it here.
                 super().__setattr__(name, value)
 
 

--- a/test/test/conftest.py
+++ b/test/test/conftest.py
@@ -9,6 +9,7 @@ import sklearn
 from sklearn import datasets
 from sklearn.utils import Bunch
 
+from sklearndf import __sklearn_1_1__, __sklearn_version__
 from sklearndf.transformation import OneHotEncoderDF
 
 logging.basicConfig(level=logging.DEBUG)
@@ -36,12 +37,17 @@ def n_jobs() -> int:
 @pytest.fixture  # type: ignore
 def diabetes_df(diabetes_target: str) -> pd.DataFrame:
     #  load sklearn test-data and convert to pd
-    diabetes: Bunch = datasets.load_diabetes()
+    diabetes: Bunch
+    if __sklearn_version__ >= __sklearn_1_1__:
+        diabetes = datasets.load_diabetes(scaled=False)
+    else:
+        # arg scaled does not exist in scikit-learn < 1.1
+        diabetes = datasets.load_diabetes()
 
     return pd.DataFrame(
         data=np.c_[diabetes.data, diabetes.target],
         columns=[*map(str, diabetes.feature_names), diabetes_target],
-    )
+    ).astype(dtype={"sex": "category"})
 
 
 @pytest.fixture  # type: ignore

--- a/test/test/sklearndf/test_meta_estimators.py
+++ b/test/test/sklearndf/test_meta_estimators.py
@@ -26,7 +26,14 @@ log = logging.getLogger(__name__)
 
 
 def test_meta_estimators() -> None:
-    VotingClassifierDF(estimators=[("rf", RandomForestClassifierDF())])
+    with pytest.warns(
+        expected_warning=UserWarning,
+        match=(
+            "^the following attributes of VotingClassifierDF have been replaced with "
+            "their native scikit-learn counterparts: estimators$"
+        ),
+    ):
+        VotingClassifierDF(estimators=[("rf", RandomForestClassifierDF())])
 
     with pytest.raises(
         TypeError,
@@ -41,7 +48,14 @@ def test_meta_estimators() -> None:
             ]
         )
 
-    regressor = MultiOutputRegressorDF(estimator=RandomForestRegressorDF())
+    with pytest.warns(
+        expected_warning=UserWarning,
+        match=(
+            "^the following attributes of MultiOutputRegressorDF have been replaced "
+            "with their native scikit-learn counterparts: estimator$"
+        ),
+    ):
+        regressor = MultiOutputRegressorDF(estimator=RandomForestRegressorDF())
     assert is_regressor(regressor)
 
     with pytest.raises(
@@ -55,7 +69,14 @@ def test_meta_estimators() -> None:
             estimator=RegressorPipelineDF(regressor=RandomForestRegressorDF())
         )
 
-    classifier = ClassifierChainDF(base_estimator=RandomForestClassifierDF())
+    with pytest.warns(
+        expected_warning=UserWarning,
+        match=(
+            "^the following attributes of ClassifierChainDF have been replaced "
+            "with their native scikit-learn counterparts: base_estimator$"
+        ),
+    ):
+        classifier = ClassifierChainDF(base_estimator=RandomForestClassifierDF())
     assert is_classifier(classifier)
 
     with pytest.raises(

--- a/test/test/sklearndf/transformation/test_extra.py
+++ b/test/test/sklearndf/transformation/test_extra.py
@@ -1,68 +1,119 @@
+from typing import Any, Callable, Dict, Type
+
 import numpy as np
 import pandas as pd
-from sklearn.ensemble import RandomForestRegressor
+import pytest
+from lightgbm import LGBMRegressor
 
+from sklearndf import TransformerDF
 from sklearndf.pipeline import PipelineDF
 from sklearndf.regression import RandomForestRegressorDF
-from sklearndf.transformation import (
-    ColumnTransformerDF,
-    OneHotEncoderDF,
-    SimpleImputerDF,
+from sklearndf.regression.extra import LGBMRegressorDF
+from sklearndf.transformation import SimpleImputerDF
+from sklearndf.transformation.extra import BoostAGrootaDF, BorutaDF, GrootCVDF, LeshyDF
+from sklearndf.wrapper import MissingEstimator
+
+regressor_params = dict(max_depth=5, n_jobs=-3, random_state=42, n_estimators=100)
+lgbm_regressor = LGBMRegressor(**regressor_params)
+lgbm_regressor_df = LGBMRegressorDF(**regressor_params)
+
+parametrize_feature_selector_cls: Callable[
+    [Callable[..., None]], Callable[..., None]
+] = pytest.mark.parametrize(
+    # the class/parameter combinations to test for feature selection
+    argnames=["feature_selector_cls", "feature_selector_params"],
+    argvalues=[
+        (cls, params)
+        for cls, params in [
+            # Boruta selector
+            (
+                BorutaDF,
+                dict(
+                    estimator=RandomForestRegressorDF(
+                        max_depth=5, n_jobs=-3, random_state=42, n_estimators=100
+                    )
+                ),
+            ),
+            # Various ARFS selectors
+            (LeshyDF, dict(estimator=lgbm_regressor, random_state=42, perc=90)),
+            (LeshyDF, dict(estimator=lgbm_regressor_df, random_state=42, perc=90)),
+            (BoostAGrootaDF, dict(est=lgbm_regressor, cutoff=1.1)),
+            (GrootCVDF, dict()),
+        ]
+        if not issubclass(cls.__wrapped__, MissingEstimator)
+    ],
 )
-from sklearndf.transformation.extra import BorutaDF
 
 
-def test_boruta_df() -> None:
-    """Test basic functionality of BorutaDF with both sklearn and sklearndf predictor"""
+@parametrize_feature_selector_cls
+def test_feature_selection_df(
+    feature_selector_cls: Type[TransformerDF], feature_selector_params: Dict[str, Any]
+) -> None:
+    """
+    Test feature selection using the Boruta or ARFS package using a simple synthetic
+    dataset.
+
+    :param feature_selector_cls: The feature selector class to test.
+    :param feature_selector_params: The parameters to use for the feature selector.
+    """
+
     df = pd.DataFrame(data=np.random.randn(100, 5), columns=list("abcde"))
     x = df.iloc[:, :-1]
     y = df.iloc[:, -1]
 
-    boruta = BorutaDF(estimator=RandomForestRegressor(), max_iter=10)
-    boruta.fit(x, y)
-
-    boruta_df = BorutaDF(estimator=RandomForestRegressorDF(), max_iter=10)
-    boruta_df.fit(x, y)
+    feature_selector = feature_selector_cls(**feature_selector_params)
+    feature_selector.fit(x, y)
+    assert set(feature_selector.feature_names_out_) <= {"a", "b", "c", "d", "e"}
 
 
-def test_boruta_pipeline(diabetes_df: pd.DataFrame, diabetes_target: str) -> None:
-    """Test a pipeline with on the diabetes dataset"""
+@parametrize_feature_selector_cls
+def test_feature_selection_pipeline_df(
+    feature_selector_cls: Type[TransformerDF],
+    feature_selector_params: Dict[str, Any],
+    diabetes_df: pd.DataFrame,
+    diabetes_target: str,
+) -> None:
+    """
+    Test feature selection using the Boruta or ARFS package using the diabetes
+    dataset.
 
-    boruta_selector = PipelineDF(
+    :param feature_selector_cls: The feature selector class to test.
+    :param feature_selector_params: The parameters to use for the feature selector.
+    :param diabetes_df: The diabetes dataset.
+    :param diabetes_target: The diabetes target column.
+    """
+
+    feature_selector = feature_selector_cls(**feature_selector_params)
+
+    diabetes_df = diabetes_df.sample(frac=0.5, random_state=42)
+
+    feature_selection_pipeline = PipelineDF(
         steps=[
             (
                 "preprocess",
                 PipelineDF(
                     steps=[
                         ("imputer", SimpleImputerDF()),
-                        (
-                            "onehot",
-                            ColumnTransformerDF(
-                                [
-                                    (
-                                        "onehot",
-                                        OneHotEncoderDF(
-                                            drop="first", categories="auto"
-                                        ),
-                                        ["sex"],
-                                    ),
-                                ],
-                                remainder="passthrough",
-                            ),
-                        ),
                     ]
                 ),
             ),
-            (
-                "boruta",
-                BorutaDF(
-                    estimator=RandomForestRegressor(), n_estimators=10, max_iter=10
-                ),
-            ),
+            ("selector", feature_selector),
         ]
     )
 
     x = diabetes_df.drop(columns=diabetes_target)
     y = diabetes_df.loc[:, diabetes_target]
 
-    boruta_selector.fit(x, y)
+    feature_selection_pipeline.fit(x, y)
+
+    try:
+        assert set(feature_selection_pipeline.feature_names_out_) == set(
+            feature_selector.selected_features_
+        )
+    except AttributeError:
+        pass
+    assert set(feature_selection_pipeline.feature_names_out_) in [
+        {"bmi", "bp", "s3", "s5"},
+        *({"bmi", "bp", "s3", "s5", extra} for extra in ["sex", "s1", "s6"]),
+        {"bmi", "bp", "s2", "s5", "s6"},
+    ]

--- a/test/test/sklearndf/transformation/test_extra.py
+++ b/test/test/sklearndf/transformation/test_extra.py
@@ -114,6 +114,6 @@ def test_feature_selection_pipeline_df(
         pass
     assert set(feature_selection_pipeline.feature_names_out_) in [
         {"bmi", "bp", "s3", "s5"},
-        *({"bmi", "bp", "s3", "s5", extra} for extra in ["sex", "s1", "s6"]),
+        *({"bmi", "bp", "s3", "s5", extra} for extra in ["sex", "s1", "s2", "s6"]),
         {"bmi", "bp", "s2", "s5", "s6"},
     ]

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 import sklearn
 from numpy.testing import assert_array_equal
+from pandas.arrays import SparseArray
 from pandas.testing import assert_frame_equal
 from sklearn.base import BaseEstimator, TransformerMixin, is_classifier, is_regressor
 from sklearn.compose import ColumnTransformer
@@ -427,7 +428,7 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
     def _make_frame(data: Dict[str, List[float]]) -> pd.DataFrame:
         if sparse:
             df = pd.DataFrame(
-                data={k: pd.SparseArray(v, fill_value=0) for k, v in data.items()}
+                data={k: SparseArray(v, fill_value=0) for k, v in data.items()}
             )
         else:
             df = pd.DataFrame(data=data)

--- a/test/test/test_docs.py
+++ b/test/test/test_docs.py
@@ -20,8 +20,12 @@ def test_doc() -> None:
                     r"(?:classification|regression)\.extra\.LGBM.*",
                     # XGBoost estimators in the '.extra' packages
                     r"(?:classification|regression)\.extra\.XGB.*",
-                    # BorutaDF
+                    # BorutaPy package
                     r"transformation\.extra\.BorutaDF",
+                    # ARFS package
+                    r"transformation\.extra\.BoostAGrootaDF",
+                    r"transformation\.extra\.GrootCVDF",
+                    r"transformation\.extra\.LeshyDF",
                     # scikit-learn pipeline classes
                     r"pipeline\.(PipelineDF|FeatureUnionDF).*",
                     # sparse frames version of FeatureUnion


### PR DESCRIPTION
BorutaPy is no longer maintained and is not compatible with current versions of Numpy.

Adding support for ARFS as a replacement for BorutaPy.