### PR TITLE
FT: add support for scikit-learn 1.7

### DIFF
--- a/.idea/sklearndf.iml
+++ b/.idea/sklearndf.iml
@@ -17,7 +17,7 @@
       <excludeFolder url="file://$MODULE_DIR$/sphinx/source/tutorial/.ipynb_checkpoints" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="facet-base" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="sklearndf-develop" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="pytools" />
   </component>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: 23.10.1
     hooks:
       - id: black
-        language: python_venv
+        language: python
         language_version: python39
 
   - repo: https://github.com/pycqa/flake8
@@ -17,7 +17,7 @@ repos:
       - id: flake8
         name: flake8
         entry: flake8 --config tox.ini
-        language: python_venv
+        language: python
         language_version: python39
         additional_dependencies:
           - flake8-comprehensions ~= 3.10
@@ -30,7 +30,7 @@ repos:
       - id: check-json
       - id: check-xml
       - id: check-yaml
-        language: python_venv
+        language: python
         exclude: condabuild/meta.yaml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -38,7 +38,7 @@ repos:
     hooks:
       - id: mypy
         files: src|sphinx|test
-        language: python_venv
+        language: python
         language_version: python39
         additional_dependencies:
           - numpy~=1.24

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 25.1.0
     hooks:
       - id: black
         language: python
         language_version: python39
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 7.3.0
     hooks:
       - id: flake8
         name: flake8
@@ -20,11 +20,11 @@ repos:
         language: python
         language_version: python39
         additional_dependencies:
-          - flake8-comprehensions ~= 3.10
+          - flake8-comprehensions ~= 3.16
         types: [ python ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-json
@@ -34,12 +34,12 @@ repos:
         exclude: condabuild/meta.yaml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         files: src|sphinx|test
         language: python
-        language_version: python39
+        language_version: python310
         additional_dependencies:
-          - numpy~=1.24
-          - gamma-pytools~=2.1
+          - numpy~=2.2
+          - gamma-pytools~=3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,4 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
-    hooks:
-      - id: pyupgrade
-        args: [--py39-plus]
-
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.16.0
+    hooks:
+      - id: pyupgrade
+        args: [--py39-plus]
+
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1
     hooks:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,28 @@ Release Notes
 .. |nbsp| unicode:: 0xA0
    :trim:
 
+*skelearndf* 2.4
+----------------
+
+
+2.4.0
+~~~~~
+
+*sklearndf* |nbsp| 2.4 adds support for
+`scikit-learn 1.7 <https://scikit-learn.org/1.7>`_, and drops support for
+*scikit-learn* |nbsp| 1.2 and earlier, and Python |nbsp| 3.8 and earlier.
+
+- API: add DF wrapper classes :class:`.FixedThresholdClassifierDF`
+  and :class:`.TunedThresholdClassifierCVDF` for native classifiers
+  :class:`~sklearn.model_selection.FixedThresholdClassifier` and
+  :class:`~sklearn.model_selection.TunedThresholdClassifierCV`, respectively
+- API: add DF wrapper class :class:`.SelfTrainingClassifierDF` for native classifier
+  :class:`~sklearn.semi_supervised.SelfTrainingClassifier`
+- API: support tag propagation introduced in *scikit-learn* |nbsp| 1.6
+- API: add utility function :func:`.is_scalar_nan` that had been removed from
+  :mod:`sklearndf.utils`
+
+
 *sklearndf* 2.3
 ---------------
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -251,7 +251,7 @@ stages:
               # create and activate a build environment, then install the tools we need
               micromamba create -n build
               micromamba activate build
-              micromamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
+              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 packaging~=20.9
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 
@@ -350,7 +350,7 @@ stages:
               # create and activate a build environment, then install the tools we need
               micromamba create -n build
               micromamba activate build
-              micromamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
+              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 packaging~=20.9
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install isort~=5.12
+              python -m pip install isort~=6.0
               python -m isort --check --diff .
             displayName: 'Run isort'
       - job:
@@ -65,7 +65,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install black~=23.10.1
+              python -m pip install black~=25.1.0
               python -m black --check .
             displayName: 'Run black'
       - job:
@@ -76,7 +76,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install flake8~=5.0 flake8-comprehensions~=3.10
+              python -m pip install flake8~=7.3 flake8-comprehensions~=3.16
               python -m flake8 --config tox.ini -v .
             displayName: 'Run flake8'
       - job:
@@ -87,7 +87,7 @@ stages:
               versionSpec: '3.9'
             displayName: 'use Python 3.9'
           - script: |
-              python -m pip install mypy~=1.2.0 numpy~=1.24 gamma-pytools~=2.1
+              python -m pip install mypy~=1.16.0 numpy~=2.2 gamma-pytools~=3.0
               python -m mypy src
             displayName: 'Run mypy'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,8 +84,8 @@ stages:
         steps:
           - task: UsePythonVersion@0
             inputs:
-              versionSpec: '3.9'
-            displayName: 'use Python 3.9'
+              versionSpec: '3.10'
+            displayName: 'use Python 3.10'
           - script: |
               python -m pip install mypy~=1.16.0 numpy~=2.2 gamma-pytools~=3.0
               python -m mypy src

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,15 +219,15 @@ stages:
             # This comprises only one minimum dependencies test for tox,
             # which is usually faster than conda.
             maximum_dependencies_conda:
-              FACET_V_PYTHON_BUILD: '=3.9'
+              FACET_V_PYTHON_BUILD: '=3.12'
               BUILD_SYSTEM: 'conda'
               PKG_DEPENDENCIES: 'max'
             minimum_dependencies_tox:
-              FACET_V_PYTHON_BUILD: '=3.7'
+              FACET_V_PYTHON_BUILD: '=3.9'
               BUILD_SYSTEM: 'tox'
               PKG_DEPENDENCIES: 'min'
             maximum_dependencies_tox:
-              FACET_V_PYTHON_BUILD: '=3.9'
+              FACET_V_PYTHON_BUILD: '=3.12'
               BUILD_SYSTEM: 'tox'
               PKG_DEPENDENCIES: 'max'
 
@@ -305,27 +305,27 @@ stages:
         strategy:
           matrix:
             default_dependencies_conda:
-              FACET_V_PYTHON_BUILD: '=3.8'
+              FACET_V_PYTHON_BUILD: '=3.11'
               BUILD_SYSTEM: 'conda'
               PKG_DEPENDENCIES: 'default'
             minimum_dependencies_conda:
-              FACET_V_PYTHON_BUILD: '=3.7'
+              FACET_V_PYTHON_BUILD: '=3.9'
               BUILD_SYSTEM: 'conda'
               PKG_DEPENDENCIES: 'min'
             maximum_dependencies_conda:
-              FACET_V_PYTHON_BUILD: '=3.9'
+              FACET_V_PYTHON_BUILD: '=3.12'
               BUILD_SYSTEM: 'conda'
               PKG_DEPENDENCIES: 'max'
             default_dependencies_tox:
-              FACET_V_PYTHON_BUILD: '=3.8'
+              FACET_V_PYTHON_BUILD: '=3.11'
               BUILD_SYSTEM: 'tox'
               PKG_DEPENDENCIES: 'default'
             minimum_dependencies_tox:
-              FACET_V_PYTHON_BUILD: '=3.7'
+              FACET_V_PYTHON_BUILD: '=3.9'
               BUILD_SYSTEM: 'tox'
               PKG_DEPENDENCIES: 'min'
             maximum_dependencies_tox:
-              FACET_V_PYTHON_BUILD: '=3.9'
+              FACET_V_PYTHON_BUILD: '=3.12'
               BUILD_SYSTEM: 'tox'
               PKG_DEPENDENCIES: 'max'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,9 @@
 trigger:
-  - 2.3.x
+  - 2.4.x
   - release/*
 
 pr:
-  - 2.3.x
+  - 2.4.x
   - release/*
 
 pool:
@@ -18,7 +18,7 @@ schedules:
     displayName: Nightly full build
     branches:
       include:
-        - 2.2.x
+        - 2.3.x
 
 resources:
   repositories:

--- a/condabuild/meta.yaml
+++ b/condabuild/meta.yaml
@@ -35,7 +35,7 @@ test:
     - sklearndf.transformation
     - sklearndf.transformation.extra
   requires:
-    - pytest ~= 7.1
+    - pytest ~= 8.1
     # we need pip to install arfs
     - pip # {{ '[False]' if not environ.get('FACET_V_ARFS') }}
     # optional libraries of sklearndf, needed for testing

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pandas            ~= 2.3
   - pip               ~= 25.1
   - python            ~= 3.10
-  - scikit-learn      ~= 1.5.2
+  - scikit-learn      ~= 1.6.1
   - scipy             ~= 1.15
   - xgboost           ~= 2.1
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pandas            ~= 2.3
   - pip               ~= 25.1
   - python            ~= 3.10
-  - scikit-learn      ~= 1.6.1
+  - scikit-learn      ~= 1.7.0
   - scipy             ~= 1.15
   - xgboost           ~= 2.1
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -4,19 +4,19 @@ channels:
   - bcg_gamma
 dependencies:
   # run
-  - gamma-pytools     ~= 2.1
+  - gamma-pytools     ~= 3.0
   - joblib            ~= 1.5
-  - lightgbm          ~= 3.3
+  - lightgbm          ~= 4.6
   - matplotlib        ~= 3.7
-  - numpy             ~= 1.26
+  - numpy             ~= 2.3
   - pandas            ~= 2.3
   - pip               ~= 25.1
-  - python            ~= 3.10
+  - python            ~= 3.12.11
   - scikit-learn      ~= 1.7.0
   - scipy             ~= 1.15
   - xgboost           ~= 2.1
   - pip:
-      - arfs          ~= 1.0
+      - arfs          ~= 3.0
       - Boruta        ~= 0.4
 # test
   - pytest            ~= 8.1

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pandas            ~= 2.3
   - pip               ~= 25.1
   - python            ~= 3.10
-  - scikit-learn      ~= 1.3.2
+  - scikit-learn      ~= 1.4.2
   - scipy             ~= 1.15
   - xgboost           ~= 2.1
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - python            ~= 3.12.11
   - scikit-learn      ~= 1.7.0
   - scipy             ~= 1.15
-  - xgboost           ~= 2.1
+  - xgboost           ~= 3.0
   - pip:
       - arfs          ~= 3.0
       - Boruta        ~= 0.4

--- a/environment.yml
+++ b/environment.yml
@@ -4,31 +4,31 @@ channels:
   - bcg_gamma
 dependencies:
   # run
-  - boruta_py         ~= 0.3
   - gamma-pytools     ~= 2.1
-  - joblib            ~= 1.2
+  - joblib            ~= 1.5
   - lightgbm          ~= 3.3
   - matplotlib        ~= 3.7
-  - numpy             ~= 1.24
-  - pandas            ~= 2.0
-  - pip               ~= 23.3
-  - python            ~= 3.9
-  - scikit-learn      ~= 1.2.0
-  - scipy             ~= 1.11
-  - xgboost           ~= 1.7
+  - numpy             ~= 1.26
+  - pandas            ~= 2.3
+  - pip               ~= 25.1
+  - python            ~= 3.10
+  - scikit-learn      ~= 1.3.2
+  - scipy             ~= 1.15
+  - xgboost           ~= 2.1
   - pip:
-     - arfs           ~= 1.1
-  # test
-  - pytest     ~= 7.2.1
-  - pytest-cov ~= 2.12.1
+      - arfs          ~= 1.0
+      - Boruta        ~= 0.4
+# test
+  - pytest            ~= 8.1
+  - pytest-cov        ~= 4.1
   # sphinx
-  - nbsphinx                 ~= 0.8.9
-  - sphinx                   ~= 4.5.0
-  - sphinx-autodoc-typehints ~= 1.19.2
-  - pydata-sphinx-theme      ~= 0.8.1
+  - nbsphinx                 ~= 0.9
+  - sphinx                   ~= 7.2
+  - sphinx-autodoc-typehints ~= 1.24
+  - pydata-sphinx-theme      ~= 0.15
   # notebooks
-  - ipywidgets ~= 8.1
-  - jupyterlab ~= 3.6
-  - openpyxl   ~= 3.1
-  - seaborn    ~= 0.13
-  - tableone   ~= 0.7
+  - ipywidgets        ~= 8.1
+  - jupyterlab        ~= 4.1
+  - openpyxl          ~= 3.1
+  - seaborn           ~= 0.13
+  - tableone          ~= 0.8

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pandas            ~= 2.3
   - pip               ~= 25.1
   - python            ~= 3.10
-  - scikit-learn      ~= 1.4.2
+  - scikit-learn      ~= 1.5.2
   - scipy             ~= 1.15
   - xgboost           ~= 2.1
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ scipy          = "~=1.6.3"
 scikit-learn   = "~=1.3.2"
 xgboost        = "~=1.0.2"
 # additional minimum requirements of gamma-pytools
-joblib         = "~=0.14.1"
+joblib         = "~=1.1.1"
 matplotlib     = "~=3.3.4"
 typing_inspect = "~=0.7.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,15 @@ dist-name = "sklearndf"
 license = "Apache Software License v2.0"
 
 requires = [
-    "gamma-pytools  ~=2.1",
+    "gamma-pytools  >=2.1,<4a",   # allow pytools 2 and 3
     "numpy          >=1.21,<2a",  # cannot use ~= due to conda bug
     "packaging      >=20",
     "pandas         >=1",
-    "scikit-learn   >=1.3,<1.5a",
+    "scikit-learn   >=1.3,<1.8a",
     "scipy          ~=1.6",
 ]
 
-requires-python = ">=3.7,<4a"
+requires-python = ">=3.9,<4a"
 
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -76,9 +76,9 @@ lightgbm       = "~=3.0.0"
 numpy          = "==1.21.6"        # cannot use ~= due to conda bug
 packaging      = "~=20.9"
 pandas         = "~=1.1.5"
-python         = ">=3.7.12,<3.8a"  # cannot use ~= due to conda bug
+python         = ">=3.9.26,<3.10a"  # cannot use ~= due to conda bug
 scipy          = "~=1.6.3"
-scikit-learn   = "~=1.0.2"
+scikit-learn   = "~=1.3.2"
 xgboost        = "~=1.0.2"
 # additional minimum requirements of gamma-pytools
 joblib         = "~=0.14.1"
@@ -87,19 +87,19 @@ typing_inspect = "~=0.4.0"
 
 [build.matrix.max]
 # direct requirements of sklearndf
-arfs           = "~=1.1"
+arfs           = "~=4.0"
 gamma-pytools  = "~=2.1"
-lightgbm       = "~=3.3"
+lightgbm       = "~=4.6"
 numpy          = ">=1.24,<2a"     # cannot use ~= due to conda bug
 packaging      = ">=20"
-pandas         = "~=2.0"
-python         = ">=3.11,<3.12a"  # cannot use ~= due to conda bug
-scikit-learn   = "~=1.3.2"
-scipy          = "~=1.11"
+pandas         = "~=2.2"
+python         = ">=3.12,<3.13a"  # cannot use ~= due to conda bug
+scikit-learn   = "~=1.7.0"
+scipy          = "~=1.15"
 xgboost        = "~=1.5"
 # additional maximum requirements of gamma-pytools
-joblib         = "~=1.1"
-matplotlib     = "~=3.5"
+joblib         = "~=1.5"
+matplotlib     = "~=3.10"
 typing_inspect = "~=0.7"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,11 @@ classifiers = [
 
 [tool.flit.metadata.requires-extra]
 testing = [
-    "pytest ~= 7.1",
-    "pytest-cov ~= 2.12",
+    "pytest ~= 8.1",
+    "pytest-cov ~= 4.1",
     # optional requirements for testing sklearndf
     "lightgbm ~= 3.0",
-    "xgboost ~= 1.0",
+    "xgboost ~= 3.0",
 ]
 docs = [
     "sphinx ~= 4.5",
@@ -96,7 +96,7 @@ pandas         = "~=2.3"
 python         = ">=3.12,<3.13a"  # cannot use ~= due to conda bug
 scikit-learn   = "~=1.7.0"
 scipy          = "~=1.16"
-xgboost        = "~=2.1"
+xgboost        = "~=3.0"
 # additional maximum requirements of gamma-pytools
 joblib         = "~=1.5"
 matplotlib     = "~=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,20 +87,20 @@ typing_inspect = "~=0.4.0"
 
 [build.matrix.max]
 # direct requirements of sklearndf
-arfs           = "~=4.0"
-gamma-pytools  = "~=2.1"
+arfs           = "~=3.0"
+gamma-pytools  = "~=3.0"
 lightgbm       = "~=4.6"
-numpy          = ">=1.24,<2a"     # cannot use ~= due to conda bug
-packaging      = ">=20"
-pandas         = "~=2.2"
+numpy          = ">=2.2,<3a"     # cannot use ~= due to conda bug
+packaging      = ">=25"
+pandas         = "~=2.3"
 python         = ">=3.12,<3.13a"  # cannot use ~= due to conda bug
 scikit-learn   = "~=1.7.0"
-scipy          = "~=1.15"
-xgboost        = "~=1.5"
+scipy          = "~=1.16"
+xgboost        = "~=2.1"
 # additional maximum requirements of gamma-pytools
 joblib         = "~=1.5"
 matplotlib     = "~=3.10"
-typing_inspect = "~=0.7"
+typing_inspect = "~=0.9"
 
 [tool.black]
 # quiet = "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ xgboost        = "~=1.0.2"
 # additional minimum requirements of gamma-pytools
 joblib         = "~=0.14.1"
 matplotlib     = "~=3.3.4"
-typing_inspect = "~=0.4.0"
+typing_inspect = "~=0.7.0"
 
 [build.matrix.max]
 # direct requirements of sklearndf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires = [
     "numpy          >=1.21,<2a",  # cannot use ~= due to conda bug
     "packaging      >=20",
     "pandas         >=1",
-    "scikit-learn   >=1,<1.4a",
+    "scikit-learn   >=1.3,<1.5a",
     "scipy          ~=1.6",
 ]
 
@@ -82,7 +82,7 @@ scikit-learn   = "~=1.0.2"
 xgboost        = "~=1.0.2"
 # additional minimum requirements of gamma-pytools
 joblib         = "~=0.14.1"
-matplotlib     = "~=3.0.3"
+matplotlib     = "~=3.3.4"
 typing_inspect = "~=0.4.0"
 
 [build.matrix.max]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ testing = [
     "pytest ~= 8.1",
     "pytest-cov ~= 4.1",
     # optional requirements for testing sklearndf
-    "lightgbm ~= 3.0",
-    "xgboost ~= 3.0",
+    "lightgbm >= 3",
+    "xgboost >= 1",
 ]
 docs = [
     "sphinx ~= 4.5",

--- a/src/sklearndf/_sklearn_version.py
+++ b/src/sklearndf/_sklearn_version.py
@@ -11,6 +11,7 @@ __all__ = [
     "__sklearn_1_5__",
     "__sklearn_1_6__",
     "__sklearn_1_7__",
+    "__sklearn_1_8__",
 ]
 
 __sklearn_version__ = Version(sklearn_version)
@@ -18,3 +19,4 @@ __sklearn_1_4__ = Version("1.4")
 __sklearn_1_5__ = Version("1.5")
 __sklearn_1_6__ = Version("1.6")
 __sklearn_1_7__ = Version("1.7")
+__sklearn_1_8__ = Version("1.8")

--- a/src/sklearndf/_sklearn_version.py
+++ b/src/sklearndf/_sklearn_version.py
@@ -9,8 +9,10 @@ __all__ = [
     "__sklearn_version__",
     "__sklearn_1_4__",
     "__sklearn_1_5__",
+    "__sklearn_1_6__",
 ]
 
 __sklearn_version__ = Version(sklearn_version)
 __sklearn_1_4__ = Version("1.4")
 __sklearn_1_5__ = Version("1.5")
+__sklearn_1_6__ = Version("1.6")

--- a/src/sklearndf/_sklearn_version.py
+++ b/src/sklearndf/_sklearn_version.py
@@ -7,14 +7,10 @@ from sklearn import __version__ as sklearn_version
 
 __all__ = [
     "__sklearn_version__",
-    "__sklearn_1_1__",
-    "__sklearn_1_2__",
-    "__sklearn_1_3__",
     "__sklearn_1_4__",
+    "__sklearn_1_5__",
 ]
 
 __sklearn_version__ = Version(sklearn_version)
-__sklearn_1_1__ = Version("1.1")
-__sklearn_1_2__ = Version("1.2")
-__sklearn_1_3__ = Version("1.3")
 __sklearn_1_4__ = Version("1.4")
+__sklearn_1_5__ = Version("1.5")

--- a/src/sklearndf/_sklearn_version.py
+++ b/src/sklearndf/_sklearn_version.py
@@ -10,9 +10,11 @@ __all__ = [
     "__sklearn_1_4__",
     "__sklearn_1_5__",
     "__sklearn_1_6__",
+    "__sklearn_1_7__",
 ]
 
 __sklearn_version__ = Version(sklearn_version)
 __sklearn_1_4__ = Version("1.4")
 __sklearn_1_5__ = Version("1.5")
 __sklearn_1_6__ = Version("1.6")
+__sklearn_1_7__ = Version("1.7")

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -5,7 +5,8 @@ Core implementation of :mod:`sklearndf`
 import inspect
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Dict, List, Mapping, Optional, TypeVar, Union, cast
+from collections.abc import Mapping
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 import numpy.typing as npt
 import pandas as pd
@@ -133,7 +134,7 @@ class EstimatorDF(
 
     @property
     @fitted_only(not_fitted_error=AttributeError)
-    def output_names_(self) -> Optional[List[str]]:
+    def output_names_(self) -> Optional[list[str]]:
         """
         The name(s) of the output(s) this estimator was fitted to,
         or ``None`` if this estimator was not fitted to any outputs.
@@ -203,7 +204,7 @@ class EstimatorDF(
         return len(self._get_features_in())
 
     @abstractmethod
-    def _get_outputs(self) -> Optional[List[str]]:
+    def _get_outputs(self) -> Optional[list[str]]:
         # get the output columns as a list of strings, or None if this estimator
         # was not fitted to any outputs
         pass
@@ -282,7 +283,7 @@ class EstimatorDF(
                 # custom value: we return the expression
                 return expression
 
-        kwarg_expressions: Dict[str, Optional[Expression]] = {
+        kwarg_expressions: dict[str, Optional[Expression]] = {
             name: _kwarg_to_expression(name, value)
             for name, value in self.get_params(deep=False).items()
         }
@@ -353,7 +354,7 @@ class SupervisedLearnerDF(LearnerDF, metaclass=ABCMeta):
         pass
 
     @property
-    def output_names_(self) -> List[str]:
+    def output_names_(self) -> list[str]:
         """
         The name(s) of the output(s) this supervised learner was fitted to.
 
@@ -522,7 +523,7 @@ class ClassifierDF(
 
     @property
     @fitted_only(not_fitted_error=AttributeError)
-    def classes_(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+    def classes_(self) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         """
         Get the classes predicted by this classifier as a numpy array of class labels
         for single-output problems, or a list of such arrays for multi-output problems
@@ -535,7 +536,7 @@ class ClassifierDF(
     @abstractmethod
     def predict_proba(
         self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """
         Predict class probabilities for the given inputs.
 
@@ -557,7 +558,7 @@ class ClassifierDF(
     @abstractmethod
     def predict_log_proba(
         self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """
         Predict class log-probabilities for the given inputs.
 
@@ -612,7 +613,7 @@ class ClassifierDF(
     score.__doc__ = SupervisedLearnerDF.score.__doc__
 
     @abstractmethod
-    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+    def _get_classes(self) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         pass
 
 

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -1,11 +1,13 @@
 """
 Core implementation of :mod:`sklearndf`
 """
+
 import inspect
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Dict, List, Mapping, Optional, TypeVar, Union, cast
 
+import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from sklearn.base import (
@@ -16,7 +18,6 @@ from sklearn.base import (
     TransformerMixin,
     clone,
 )
-from sklearn.utils import is_scalar_nan
 
 from pytools.api import AllTracker, inheritdoc
 from pytools.expression import Expression, HasExpressionRepr, make_expression
@@ -259,7 +260,7 @@ class EstimatorDF(
                 )
                 and (
                     # both value and default value are np.nan ...
-                    (is_scalar_nan(value) and is_scalar_nan(default_value))
+                    (np.isnan(value) and np.isnan(default_value))
                     or (
                         # ... or both have the same expression.
                         # We cannot compare for equality since we don't know

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -7,7 +7,6 @@ import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Dict, List, Mapping, Optional, TypeVar, Union, cast
 
-import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from sklearn.base import (
@@ -23,6 +22,8 @@ from pytools.api import AllTracker, inheritdoc
 from pytools.expression import Expression, HasExpressionRepr, make_expression
 from pytools.expression.atomic import Id
 from pytools.fit import fitted_only
+
+from ._util import is_scalar_nan
 
 log = logging.getLogger(__name__)
 
@@ -260,7 +261,7 @@ class EstimatorDF(
                 )
                 and (
                     # both value and default value are np.nan ...
-                    (np.isnan(value) and np.isnan(default_value))
+                    (is_scalar_nan(value) and is_scalar_nan(default_value))
                     or (
                         # ... or both have the same expression.
                         # We cannot compare for equality since we don't know

--- a/src/sklearndf/_util.py
+++ b/src/sklearndf/_util.py
@@ -4,7 +4,7 @@ Auxiliary functions for internal use.
 
 import math
 import numbers
-from typing import Any, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 import numpy.typing as npt
 import pandas as pd
@@ -12,9 +12,9 @@ from scipy import sparse
 
 
 def hstack_frames(
-    frames: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]],
+    frames: list[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]],
     *,
-    prefixes: Optional[List[str]] = None,
+    prefixes: Optional[list[str]] = None,
 ) -> Optional[pd.DataFrame]:
     """
     If only data frames are passed, stack them horizontally.
@@ -27,7 +27,7 @@ def hstack_frames(
     """
     if all(isinstance(frame, pd.DataFrame) for frame in frames):
         # all frames are data frames
-        frames = cast(List[pd.DataFrame], frames)
+        frames = cast(list[pd.DataFrame], frames)
         if prefixes is not None:
             assert len(prefixes) == len(
                 frames

--- a/src/sklearndf/_util.py
+++ b/src/sklearndf/_util.py
@@ -109,9 +109,8 @@ def is_scalar_nan(x: Any) -> bool:
 
     :param x: the value to test
     :returns: ``True`` if the value is a scalar NaN, ``False`` otherwise
-
-
     """
+
     return (
         not isinstance(x, numbers.Integral)
         and isinstance(x, numbers.Real)

--- a/src/sklearndf/_util.py
+++ b/src/sklearndf/_util.py
@@ -2,6 +2,8 @@
 Auxiliary functions for internal use.
 """
 
+import math
+import numbers
 from typing import Any, List, Optional, Union, cast
 
 import numpy.typing as npt
@@ -85,3 +87,33 @@ def remove_invalid_lgbm_type_hint(lgbm_type: type[Any]) -> None:
     if __annotations__.get("return") == "_sklearn_Tags":
         # remove an invalid return annotation: _sklearn_Tags is not a valid type
         del __annotations__["return"]
+
+
+def is_scalar_nan(x: Any) -> bool:
+    """
+    Test if a given value is a scalar that is NaN.
+
+    Example:
+    .. code-block:: python
+
+        is_scalar_nan(np.nan)
+        # True
+        is_scalar_nan(float("nan"))
+        # True
+        is_scalar_nan(None)
+        # False
+        is_scalar_nan("")
+        # False
+        is_scalar_nan([np.nan])
+        # False
+
+    :param x: the value to test
+    :returns: ``True`` if the value is a scalar NaN, ``False`` otherwise
+
+
+    """
+    return (
+        not isinstance(x, numbers.Integral)
+        and isinstance(x, numbers.Real)
+        and math.isnan(x)
+    )

--- a/src/sklearndf/_util.py
+++ b/src/sklearndf/_util.py
@@ -70,3 +70,18 @@ def sparse_frame_density(frame: pd.DataFrame) -> float:
             return 1.0
 
     return sum(_density(sr) for _, sr in frame.items()) / len(frame.columns)
+
+
+def remove_invalid_lgbm_type_hint(lgbm_type: type[Any]) -> None:
+    """
+    Remove an invalid return annotation from the __sklearn_tags__ of a LightGBM class.
+
+    :param lgbm_type: the LightGBM type to class
+    """
+    __sklearn_tags__ = getattr(lgbm_type, "__sklearn_tags__", None)
+    if __sklearn_tags__ is None:
+        return
+    __annotations__ = getattr(__sklearn_tags__, "__annotations__", {})
+    if __annotations__.get("return") == "_sklearn_Tags":
+        # remove an invalid return annotation: _sklearn_Tags is not a valid type
+        del __annotations__["return"]

--- a/src/sklearndf/classification/__init__.py
+++ b/src/sklearndf/classification/__init__.py
@@ -2,7 +2,11 @@
 Extended versions of all `scikit-learn` classifiers with enhanced support for data
 frames.
 """
+from .. import __sklearn_1_5__, __sklearn_version__
 from ._classification import *
 from ._classification_v0_22 import *
 from ._classification_v0_23 import *
 from ._classification_v1_0 import *
+
+if __sklearn_version__ >= __sklearn_1_5__:
+    from ._classification_v1_5 import *

--- a/src/sklearndf/classification/__init__.py
+++ b/src/sklearndf/classification/__init__.py
@@ -2,7 +2,8 @@
 Extended versions of all `scikit-learn` classifiers with enhanced support for data
 frames.
 """
-from .. import __sklearn_1_5__, __sklearn_version__
+
+from .. import __sklearn_1_5__, __sklearn_1_6__, __sklearn_version__
 from ._classification import *
 from ._classification_v0_22 import *
 from ._classification_v0_23 import *
@@ -10,3 +11,6 @@ from ._classification_v1_0 import *
 
 if __sklearn_version__ >= __sklearn_1_5__:
     from ._classification_v1_5 import *
+
+if __sklearn_version__ >= __sklearn_1_6__:
+    from ._classification_v1_6 import *

--- a/src/sklearndf/classification/_classification.py
+++ b/src/sklearndf/classification/_classification.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.classification`
 """
+
 import logging
 
 from sklearn.calibration import CalibratedClassifierCV

--- a/src/sklearndf/classification/_classification_v0_22.py
+++ b/src/sklearndf/classification/_classification_v0_22.py
@@ -2,6 +2,7 @@
 Additional implementation of :mod:`sklearndf.classification` loaded
 from sklearn 0.22 onwards
 """
+
 import logging
 
 from sklearn.ensemble import StackingClassifier

--- a/src/sklearndf/classification/_classification_v0_23.py
+++ b/src/sklearndf/classification/_classification_v0_23.py
@@ -4,13 +4,12 @@ from sklearn 0.23 onwards
 """
 
 import logging
-from typing import List
 
 from pytools.api import AllTracker
 
 log = logging.getLogger(__name__)
 
-__all__: List[str] = []
+__all__: list[str] = []
 
 __imported_estimators = {name for name in globals().keys() if name.endswith("DF")}
 

--- a/src/sklearndf/classification/_classification_v1_0.py
+++ b/src/sklearndf/classification/_classification_v1_0.py
@@ -2,6 +2,7 @@
 Additional implementation of :mod:`sklearndf.classification` loaded
 from sklearn 1.0 onwards
 """
+
 import logging
 
 from sklearn.ensemble import HistGradientBoostingClassifier

--- a/src/sklearndf/classification/_classification_v1_5.py
+++ b/src/sklearndf/classification/_classification_v1_5.py
@@ -1,0 +1,74 @@
+"""
+Additional implementation of :mod:`sklearndf.classification` loaded
+from sklearn 1.0 onwards
+"""
+
+import logging
+
+from sklearn.model_selection import FixedThresholdClassifier, TunedThresholdClassifierCV
+
+from pytools.api import AllTracker
+
+from .wrapper import ThresholdClassifierWrapperDF
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "FixedThresholdClassifierDF",
+    "TunedThresholdClassifierCVDF",
+]
+
+__imported_estimators = {name for name in globals().keys() if name.endswith("DF")}
+
+#
+# Ensure all symbols introduced below are included in __all__
+#
+
+__tracker = AllTracker(globals())
+
+#
+# threshold classifiers
+#
+
+
+class FixedThresholdClassifierDF(
+    ThresholdClassifierWrapperDF[FixedThresholdClassifier],
+    native=FixedThresholdClassifier,
+):
+    """
+    Stub for DF wrapper of class ``FixedThresholdClassifier``.
+    """
+
+
+class TunedThresholdClassifierCVDF(
+    ThresholdClassifierWrapperDF[TunedThresholdClassifierCV],
+    native=TunedThresholdClassifierCV,
+):
+    """
+    Stub for DF wrapper of class ``TunedThresholdClassifierCV``.
+    """
+
+
+#
+# validate __all__
+#
+
+__tracker.validate()
+
+
+#
+# validate that __all__ comprises all symbols ending in "DF", and no others
+#
+
+__estimators = {
+    sym
+    for sym in dir()
+    if sym.endswith("DF")
+    and sym not in __imported_estimators
+    and not sym.startswith("_")
+}
+if __estimators != set(__all__):
+    raise RuntimeError(
+        "__all__ does not contain exactly all DF estimators; expected value is:\n"
+        f"{__estimators}"
+    )

--- a/src/sklearndf/classification/_classification_v1_6.py
+++ b/src/sklearndf/classification/_classification_v1_6.py
@@ -1,0 +1,64 @@
+"""
+Additional implementation of :mod:`sklearndf.classification` loaded
+from sklearn 1.0 onwards
+"""
+
+import logging
+
+from sklearn.semi_supervised import SelfTrainingClassifier
+
+from pytools.api import AllTracker
+
+from .wrapper import MetaClassifierWrapperDF
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "SelfTrainingClassifierDF",
+]
+
+__imported_estimators = {name for name in globals().keys() if name.endswith("DF")}
+
+#
+# Ensure all symbols introduced below are included in __all__
+#
+
+__tracker = AllTracker(globals())
+
+#
+# threshold classifiers
+#
+
+
+class SelfTrainingClassifierDF(
+    MetaClassifierWrapperDF[SelfTrainingClassifier],
+    native=SelfTrainingClassifier,
+):
+    """
+    Stub for DF wrapper of class ``SelfTrainingClassifier``.
+    """
+
+
+#
+# validate __all__
+#
+
+__tracker.validate()
+
+
+#
+# validate that __all__ comprises all symbols ending in "DF", and no others
+#
+
+__estimators = {
+    sym
+    for sym in dir()
+    if sym.endswith("DF")
+    and sym not in __imported_estimators
+    and not sym.startswith("_")
+}
+if __estimators != set(__all__):
+    raise RuntimeError(
+        "__all__ does not contain exactly all DF estimators; expected value is:\n"
+        f"{__estimators}"
+    )

--- a/src/sklearndf/classification/extra/__init__.py
+++ b/src/sklearndf/classification/extra/__init__.py
@@ -5,4 +5,5 @@ Note that 3rd party packages implementing the associated native estimators must 
 installed explicitly: they are not included in `sklearndf`'s package requirements to
 achieve a lean package footprint for default installs of `sklearndf`.
 """
+
 from ._extra import *

--- a/src/sklearndf/classification/extra/_extra.py
+++ b/src/sklearndf/classification/extra/_extra.py
@@ -1,12 +1,14 @@
 """
 Core implementation of :mod:`sklearndf.classification.extra`
 """
+
 import logging
 
 from sklearn.base import ClassifierMixin
 
 from pytools.api import AllTracker
 
+from ..._util import remove_invalid_lgbm_type_hint
 from ...wrapper import ClassifierWrapperDF, MissingEstimator
 
 log = logging.getLogger(__name__)
@@ -16,6 +18,8 @@ __all__ = ["LGBMClassifierDF", "XGBClassifierDF"]
 try:
     # import lightgbm classes only if installed
     from lightgbm.sklearn import LGBMClassifier
+
+    remove_invalid_lgbm_type_hint(LGBMClassifier)
 except ImportError:
 
     class LGBMClassifier(  # type: ignore

--- a/src/sklearndf/classification/wrapper/_wrapper.py
+++ b/src/sklearndf/classification/wrapper/_wrapper.py
@@ -25,6 +25,7 @@ __all__ = [
     "MetaClassifierWrapperDF",
     "MultiOutputClassifierWrapperDF",
     "PartialFitClassifierWrapperDF",
+    "ThresholdClassifierWrapperDF",
 ]
 
 #
@@ -208,6 +209,16 @@ class ClassifierChainWrapperDF(
         return super()._prediction_with_class_labels(
             X, prediction, classes=range(self.n_outputs_)
         )
+
+
+class ThresholdClassifierWrapperDF(
+    MetaClassifierWrapperDF[T_NativeClassifier],
+    Generic[T_NativeClassifier],
+    metaclass=ABCMeta,
+):
+    """
+    DF wrapper for meta-classifiers that manage decision thresholds.
+    """
 
 
 #

--- a/src/sklearndf/classification/wrapper/_wrapper.py
+++ b/src/sklearndf/classification/wrapper/_wrapper.py
@@ -4,7 +4,8 @@ Core implementation of :mod:`sklearndf.classification.wrapper`
 
 import logging
 from abc import ABCMeta
-from typing import Any, Generic, List, Optional, Sequence, TypeVar, Union, cast
+from collections.abc import Sequence
+from typing import Any, Generic, Optional, TypeVar, Union, cast
 
 import numpy.typing as npt
 import pandas as pd
@@ -150,10 +151,10 @@ class MultiOutputClassifierWrapperDF(
         self,
         X: pd.DataFrame,
         prediction: Union[
-            pd.Series, pd.DataFrame, List[npt.NDArray[Any]], npt.NDArray[Any]
+            pd.Series, pd.DataFrame, list[npt.NDArray[Any]], npt.NDArray[Any]
         ],
         classes: Optional[Sequence[Any]] = None,
-    ) -> Union[pd.Series, pd.DataFrame, List[pd.DataFrame]]:
+    ) -> Union[pd.Series, pd.DataFrame, list[pd.DataFrame]]:
         # if we have a multi-output classifier, prediction of probabilities
         # yields a list of NumPy arrays
         if not isinstance(prediction, list):
@@ -201,10 +202,10 @@ class ClassifierChainWrapperDF(
         self,
         X: pd.DataFrame,
         prediction: Union[
-            pd.Series, pd.DataFrame, List[npt.NDArray[Any]], npt.NDArray[Any]
+            pd.Series, pd.DataFrame, list[npt.NDArray[Any]], npt.NDArray[Any]
         ],
         classes: Optional[Sequence[Any]] = None,
-    ) -> Union[pd.Series, pd.DataFrame, List[pd.DataFrame]]:
+    ) -> Union[pd.Series, pd.DataFrame, list[pd.DataFrame]]:
         # todo: infer actual class names
         return super()._prediction_with_class_labels(
             X, prediction, classes=range(self.n_outputs_)

--- a/src/sklearndf/clustering/__init__.py
+++ b/src/sklearndf/clustering/__init__.py
@@ -3,11 +3,6 @@ Extended versions of `scikit-learn` clusterers with enhanced support for data
 frames.
 """
 
-from .. import __sklearn_1_1__, __sklearn_1_3__, __sklearn_version__
 from ._clustering import *
-
-if __sklearn_version__ >= __sklearn_1_1__:
-    from ._clustering_v1_1 import *
-
-if __sklearn_version__ >= __sklearn_1_3__:
-    from ._clustering_v1_3 import *
+from ._clustering_v1_1 import *
+from ._clustering_v1_3 import *

--- a/src/sklearndf/clustering/_clustering.py
+++ b/src/sklearndf/clustering/_clustering.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.clustering`
 """
+
 import logging
 
 from sklearn.cluster import (

--- a/src/sklearndf/clustering/_clustering_v1_1.py
+++ b/src/sklearndf/clustering/_clustering_v1_1.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.clustering`
 """
+
 import logging
 
 from sklearn.cluster import BisectingKMeans

--- a/src/sklearndf/clustering/_clustering_v1_3.py
+++ b/src/sklearndf/clustering/_clustering_v1_3.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.clustering`
 """
+
 import logging
 
 from sklearn.cluster import HDBSCAN

--- a/src/sklearndf/pipeline/__init__.py
+++ b/src/sklearndf/pipeline/__init__.py
@@ -2,5 +2,6 @@
 Extended versions of all `scikit-learn` pipelines with enhanced support for data
 frames.
 """
+
 from ._learner_pipeline import *
 from ._pipeline import *

--- a/src/sklearndf/pipeline/_learner_pipeline.py
+++ b/src/sklearndf/pipeline/_learner_pipeline.py
@@ -4,7 +4,7 @@ GAMMA custom two-step pipelines
 
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Any, Generic, List, Optional, TypeVar, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 import numpy.typing as npt
 import pandas as pd
@@ -173,7 +173,7 @@ class _EstimatorPipelineDF(EstimatorDF, Generic[T_FinalEstimatorDF], metaclass=A
         else:
             return self.final_estimator.n_features_in_
 
-    def _get_outputs(self) -> Optional[List[str]]:
+    def _get_outputs(self) -> Optional[list[str]]:
         if self.preprocessing is not None:
             return self.preprocessing._get_outputs()
         else:
@@ -327,20 +327,20 @@ class ClassifierPipelineDF(
         """[see superclass]"""
         return "classifier"
 
-    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+    def _get_classes(self) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         return self.final_estimator._get_classes()
 
     # noinspection PyPep8Naming
     def predict_proba(
         self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """[see superclass]"""
         return self.classifier.predict_proba(self.preprocess(X), **predict_params)
 
     # noinspection PyPep8Naming
     def predict_log_proba(
         self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """[see superclass]"""
         return self.classifier.predict_log_proba(self.preprocess(X), **predict_params)
 

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -4,7 +4,8 @@ Core implementation of :mod:`sklearndf.pipeline.wrapper`
 
 import logging
 from abc import ABCMeta
-from typing import Any, Dict, Iterator, List, Sequence, Tuple, Union, cast
+from collections.abc import Iterator, Sequence
+from typing import Any, Union, cast
 
 import numpy.typing as npt
 import pandas as pd
@@ -102,13 +103,13 @@ class PipelineWrapperDF(
             )
 
     @property
-    def steps(self) -> List[Tuple[str, EstimatorDF]]:
+    def steps(self) -> list[tuple[str, EstimatorDF]]:
         """
         The ``steps`` attribute of the underlying :class:`~sklearn.pipeline.Pipeline`.
 
         List of (name, transformer) tuples (transformers implement fit/transform).
         """
-        return cast(List[Tuple[str, EstimatorDF]], self.native_estimator.steps)
+        return cast(list[tuple[str, EstimatorDF]], self.native_estimator.steps)
 
     def __len__(self) -> int:
         """The number of steps of the pipeline."""
@@ -147,14 +148,14 @@ class PipelineWrapperDF(
         # in the pipeline
         return estimator is None or estimator == PipelineWrapperDF.PASSTHROUGH
 
-    def _transformer_steps(self) -> Iterator[Tuple[str, TransformerDF]]:
+    def _transformer_steps(self) -> Iterator[tuple[str, TransformerDF]]:
         # make an iterator of all transform steps, i.e., excluding the final step
         # in case it is not a transformer
         # excludes steps whose transformer is ``None`` or ``"passthrough"``
 
         def _iter_not_none(
-            transformer_steps: Sequence[Tuple[str, EstimatorDF]],
-        ) -> Iterator[Tuple[str, TransformerDF]]:
+            transformer_steps: Sequence[tuple[str, EstimatorDF]],
+        ) -> Iterator[tuple[str, TransformerDF]]:
             return (
                 (name, cast(TransformerDF, transformer))
                 for name, transformer in transformer_steps
@@ -226,9 +227,9 @@ class PipelineWrapperDF(
         # forward this method call to the native estimator to ensure correct tags
         return self.native_estimator.__sklearn_tags__()
 
-    def _more_tags(self) -> Dict[str, Any]:
+    def _more_tags(self) -> dict[str, Any]:
         return cast(
-            Dict[str, Any], getattr(self.native_estimator, "_more_tags", lambda: {})()
+            dict[str, Any], getattr(self.native_estimator, "_more_tags", lambda: {})()
         )
 
 
@@ -247,7 +248,7 @@ class FeatureUnionSparseFrames(
 
     # noinspection PyPep8Naming
     def _hstack(
-        self, Xs: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]]
+        self, Xs: list[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]]
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
         stacked_frames = hstack_frames(
             Xs, prefixes=[name for name, _ in self.transformer_list]

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -12,17 +12,25 @@ from pandas.core.arrays import ExtensionArray
 from scipy import sparse
 from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.preprocessing import FunctionTransformer
-from sklearn.utils import Tags
 
 from pytools.api import AllTracker
 
 from ..._util import hstack_frames
-from sklearndf import EstimatorDF, TransformerDF
+from sklearndf import EstimatorDF, TransformerDF, __sklearn_1_7__, __sklearn_version__
 from sklearndf.wrapper import (
     ClassifierWrapperDF,
     RegressorWrapperDF,
     TransformerWrapperDF,
 )
+
+if __sklearn_version__ >= __sklearn_1_7__:
+    from sklearn.utils import Tags
+
+    __TAGS = True
+else:
+    # Fallback, in case tags are not defined
+    Tags = type("Tags", (), {})
+    __TAGS = False
 
 log = logging.getLogger(__name__)
 
@@ -222,6 +230,11 @@ class PipelineWrapperDF(
         return cast(
             Dict[str, Any], getattr(self.native_estimator, "_more_tags", lambda: {})()
         )
+
+
+if not __TAGS:
+    # Installed version of scikit-learn does not support tags; remove the method
+    del PipelineWrapperDF.__sklearn_tags__
 
 
 class FeatureUnionSparseFrames(

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -12,6 +12,7 @@ from pandas.core.arrays import ExtensionArray
 from scipy import sparse
 from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.preprocessing import FunctionTransformer
+from sklearn.utils import Tags
 
 from pytools.api import AllTracker
 
@@ -144,7 +145,7 @@ class PipelineWrapperDF(
         # excludes steps whose transformer is ``None`` or ``"passthrough"``
 
         def _iter_not_none(
-            transformer_steps: Sequence[Tuple[str, EstimatorDF]]
+            transformer_steps: Sequence[Tuple[str, EstimatorDF]],
         ) -> Iterator[Tuple[str, TransformerDF]]:
             return (
                 (name, cast(TransformerDF, transformer))
@@ -212,6 +213,10 @@ class PipelineWrapperDF(
     def _estimator_type(self) -> str:
         # noinspection PyProtectedMember
         return cast(str, self.native_estimator._estimator_type)
+
+    def __sklearn_tags__(self) -> Tags:
+        # forward this method call to the native estimator to ensure correct tags
+        return self.native_estimator.__sklearn_tags__()
 
     def _more_tags(self) -> Dict[str, Any]:
         return cast(

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -17,21 +17,12 @@ from sklearn.preprocessing import FunctionTransformer
 from pytools.api import AllTracker
 
 from ..._util import hstack_frames
-from sklearndf import EstimatorDF, TransformerDF, __sklearn_1_7__, __sklearn_version__
+from sklearndf import EstimatorDF, TransformerDF, __sklearn_1_6__, __sklearn_version__
 from sklearndf.wrapper import (
     ClassifierWrapperDF,
     RegressorWrapperDF,
     TransformerWrapperDF,
 )
-
-if __sklearn_version__ >= __sklearn_1_7__:
-    from sklearn.utils import Tags
-
-    __TAGS = True
-else:
-    # Fallback, in case tags are not defined
-    Tags = type("Tags", (), {})
-    __TAGS = False
 
 log = logging.getLogger(__name__)
 
@@ -223,19 +214,17 @@ class PipelineWrapperDF(
         # noinspection PyProtectedMember
         return cast(str, self.native_estimator._estimator_type)
 
-    def __sklearn_tags__(self) -> Tags:
-        # forward this method call to the native estimator to ensure correct tags
-        return self.native_estimator.__sklearn_tags__()
+    if __sklearn_version__ >= __sklearn_1_6__:
+        from sklearn.utils import Tags
+
+        def __sklearn_tags__(self) -> Tags:
+            # forward this method call to the native estimator to ensure correct tags
+            return self.native_estimator.__sklearn_tags__()
 
     def _more_tags(self) -> dict[str, Any]:
         return cast(
             dict[str, Any], getattr(self.native_estimator, "_more_tags", lambda: {})()
         )
-
-
-if not __TAGS:
-    # Installed version of scikit-learn does not support tags; remove the method
-    del PipelineWrapperDF.__sklearn_tags__
 
 
 class FeatureUnionSparseFrames(

--- a/src/sklearndf/regression/__init__.py
+++ b/src/sklearndf/regression/__init__.py
@@ -2,6 +2,7 @@
 Extended versions of all `scikit-learn` regressors with enhanced support for data
 frames.
 """
+
 from ._regression import *
 from ._regression_v0_22 import *
 from ._regression_v0_23 import *

--- a/src/sklearndf/regression/_regression.py
+++ b/src/sklearndf/regression/_regression.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.regression`
 """
+
 import logging
 
 from sklearn.compose import TransformedTargetRegressor

--- a/src/sklearndf/regression/_regression_v0_22.py
+++ b/src/sklearndf/regression/_regression_v0_22.py
@@ -2,6 +2,7 @@
 Core implementation of :mod:`sklearndf.regression` loaded
 from sklearn 0.22 onwards
 """
+
 import logging
 
 from sklearn.ensemble import StackingRegressor

--- a/src/sklearndf/regression/_regression_v0_23.py
+++ b/src/sklearndf/regression/_regression_v0_23.py
@@ -2,6 +2,7 @@
 Core implementation of :mod:`sklearndf.regression` loaded
 from sklearn 0.23 onwards
 """
+
 import logging
 
 from sklearn.linear_model import GammaRegressor, PoissonRegressor, TweedieRegressor

--- a/src/sklearndf/regression/_regression_v1_0.py
+++ b/src/sklearndf/regression/_regression_v1_0.py
@@ -2,6 +2,7 @@
 Additional implementation of :mod:`sklearndf.regression` loaded
 from sklearn 1.0 onwards
 """
+
 import logging
 
 from sklearn.ensemble import HistGradientBoostingRegressor

--- a/src/sklearndf/regression/extra/__init__.py
+++ b/src/sklearndf/regression/extra/__init__.py
@@ -5,4 +5,5 @@ Note that 3rd party packages implementing the associated native estimators must 
 installed explicitly: they are not included in `sklearndf`'s package requirements to
 achieve a lean package footprint for default installs of `sklearndf`.
 """
+
 from ._extra import *

--- a/src/sklearndf/regression/extra/_extra.py
+++ b/src/sklearndf/regression/extra/_extra.py
@@ -1,12 +1,14 @@
 """
 Core implementation of :mod:`sklearndf.regression.extra`
 """
+
 import logging
 
 from sklearn.base import RegressorMixin
 
 from pytools.api import AllTracker
 
+from ..._util import remove_invalid_lgbm_type_hint
 from ...wrapper import MissingEstimator, RegressorWrapperDF
 
 log = logging.getLogger(__name__)
@@ -16,6 +18,10 @@ __all__ = ["LGBMRegressorDF", "XGBRegressorDF"]
 try:
     # import lightgbm classes only if installed
     from lightgbm.sklearn import LGBMRegressor
+
+    lgbm_type = LGBMRegressor
+
+    remove_invalid_lgbm_type_hint(lgbm_type)
 
 except ImportError:
 

--- a/src/sklearndf/transformation/__init__.py
+++ b/src/sklearndf/transformation/__init__.py
@@ -3,16 +3,9 @@ Extended versions of all `scikit-learn` transformers with enhanced support for d
 frames.
 """
 
-from .. import __sklearn_1_1__, __sklearn_version__
 from ._transformation import *
 from ._transformation_v0_22 import *
 from ._transformation_v0_24 import *
 from ._transformation_v1_0 import *
-
-if __sklearn_version__ >= __sklearn_1_1__:
-    from ._transformation_v1_1 import *
-
-from .. import __sklearn_1_3__
-
-if __sklearn_version__ >= __sklearn_1_3__:
-    from ._transformation_v1_3 import *
+from ._transformation_v1_1 import *
+from ._transformation_v1_3 import *

--- a/src/sklearndf/transformation/_transformation_v0_22.py
+++ b/src/sklearndf/transformation/_transformation_v0_22.py
@@ -3,7 +3,6 @@ Core implementation of :mod:`sklearndf.transformation` loaded
 from sklearn 0.22 onwards
 """
 
-
 import logging
 
 from sklearn.impute import KNNImputer

--- a/src/sklearndf/transformation/_transformation_v0_24.py
+++ b/src/sklearndf/transformation/_transformation_v0_24.py
@@ -3,7 +3,6 @@ Core implementation of :mod:`sklearndf.transformation` loaded
 from sklearn 0.24 onwards
 """
 
-
 import logging
 
 from sklearn.feature_selection import SequentialFeatureSelector

--- a/src/sklearndf/transformation/_transformation_v1_0.py
+++ b/src/sklearndf/transformation/_transformation_v1_0.py
@@ -3,7 +3,6 @@ Core implementation of :mod:`sklearndf.transformation` loaded
 from sklearn 1.0 onwards
 """
 
-
 import logging
 
 from sklearn.preprocessing import SplineTransformer

--- a/src/sklearndf/transformation/_transformation_v1_1.py
+++ b/src/sklearndf/transformation/_transformation_v1_1.py
@@ -3,7 +3,6 @@ Core implementation of :mod:`sklearndf.transformation` loaded
 from sklearn 1.1 onwards
 """
 
-
 import logging
 
 from sklearn.decomposition import MiniBatchNMF

--- a/src/sklearndf/transformation/_transformation_v1_3.py
+++ b/src/sklearndf/transformation/_transformation_v1_3.py
@@ -3,7 +3,6 @@ Core implementation of :mod:`sklearndf.transformation` loaded
 from sklearn 1.3 onwards
 """
 
-
 import logging
 
 from sklearn.preprocessing import TargetEncoder

--- a/src/sklearndf/transformation/extra/__init__.py
+++ b/src/sklearndf/transformation/extra/__init__.py
@@ -5,4 +5,5 @@ Note that 3rd party packages implementing the associated native estimators must 
 installed explicitly: they are not included in `sklearndf`'s package requirements to
 achieve a lean package footprint for default installs of `sklearndf`.
 """
+
 from ._extra import *

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 
-import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from pytools.api import AllTracker
@@ -19,17 +18,6 @@ __all__ = ["BoostAGrootaDF", "BorutaDF", "GrootCVDF", "LeshyDF"]
 try:
     # import boruta classes only if installed
     from boruta import BorutaPy
-
-    # Apply a hack to address boruta's incompatibility with numpy >= 1.24:
-    # boruta uses np.float_ which is deprecated in numpy >= 1.20 and removed in 1.24.
-    #
-    # We check these types are already defined in numpy, and if not, we define them
-    # as aliases to the corresponding new types with a trailing underscore.
-
-    for __attr in ["bool", "int", "float"]:
-        if not hasattr(np, __attr):
-            setattr(np, __attr, getattr(np, f"{__attr}_"))
-    del __attr
 
 except ImportError:
 

--- a/src/sklearndf/transformation/extra/_extra.py
+++ b/src/sklearndf/transformation/extra/_extra.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.transformation.extra`
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/sklearndf/transformation/extra/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/extra/wrapper/_wrapper.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.transformation.extra.wrapper`
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -123,9 +123,11 @@ class NumpyTransformerWrapperDF(
         if sparse_threshold > 0.0 and sparse_frame_density(df) < sparse_threshold:
             return sparse.hstack(
                 [
-                    sr.to_frame().sparse.to_coo()
-                    if isinstance(sr.dtype, pd.SparseDtype)
-                    else sr.values.reshape(-1, 1)
+                    (
+                        sr.to_frame().sparse.to_coo()
+                        if isinstance(sr.dtype, pd.SparseDtype)
+                        else sr.values.reshape(-1, 1)
+                    )
                     for _, sr in df.items()
                 ]
             ).tocsr()
@@ -666,9 +668,11 @@ class OneHotEncoderWrapperDF(TransformerWrapperDF[OneHotEncoder], metaclass=ABCM
             # count number of infrequent categories per column
             n_infrequent = np.array(
                 [
-                    1
-                    if infrequent_categories_for_column is None
-                    else len(infrequent_categories_for_column)
+                    (
+                        1
+                        if infrequent_categories_for_column is None
+                        else len(infrequent_categories_for_column)
+                    )
                     for infrequent_categories_for_column in (
                         self.native_estimator.infrequent_categories_
                     )

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -31,7 +31,7 @@ from sklearn.preprocessing import FunctionTransformer, KBinsDiscretizer, OneHotE
 
 from pytools.api import AllTracker
 
-from ... import TransformerDF, __sklearn_1_1__, __sklearn_1_2__, __sklearn_version__
+from ... import TransformerDF
 from ..._util import hstack_frames, is_sparse_frame, sparse_frame_density
 from ...wrapper import TransformerWrapperDF
 
@@ -668,9 +668,7 @@ class OneHotEncoderWrapperDF(TransformerWrapperDF[OneHotEncoder], metaclass=ABCM
             dtype=np.int_,
         )
 
-        if __sklearn_version__ >= __sklearn_1_1__ and not (
-            self.max_categories is None and self.min_frequency is None
-        ):
+        if self.max_categories is not None or self.min_frequency is not None:
             # count number of infrequent categories per column
             n_infrequent = np.array(
                 [
@@ -754,16 +752,6 @@ class EmbeddingWrapperDF(
 
     The native transformer is considered to map all input columns to each output column.
     """
-
-    if __sklearn_version__ < __sklearn_1_2__:
-        # n_features_ is deprecated as of sklearn 1.0,
-        # and will be removed in sklearn 1.2
-        @property
-        def n_features_(self) -> int:
-            """
-            The number of features when :meth:`.fit` is performed.
-            """
-            return cast(int, self.native_estimator.n_features_)
 
     def _get_n_outputs(self) -> int:
         return cast(int, self.native_estimator.n_outputs_)

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -351,7 +351,10 @@ class ColumnTransformerSparseFrames(
 
     # noinspection PyPep8Naming
     def _hstack(
-        self, Xs: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]]
+        self,
+        Xs: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]],
+        *,
+        n_samples: Optional[int] = None,
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
         if self.verbose_feature_names_out:
             prefixes = [name for name, _, _ in self.transformers]
@@ -363,7 +366,13 @@ class ColumnTransformerSparseFrames(
             stacked = hstack_frames(Xs)
 
         if stacked is None:
-            return super()._hstack(Xs)
+            if n_samples is None:
+                # Do not pass n_samples if we did not receive it, for backwards
+                # compatibility
+                return super()._hstack(Xs)
+            else:
+                # Only pass n_samples if we receive it
+                return super()._hstack(Xs, n_samples=n_samples)
         else:
             self.sparse_output_ = is_sparse_frame(stacked)
             return stacked

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -1,6 +1,7 @@
 """
 Core implementation of :mod:`sklearndf.transformation.wrapper`
 """
+
 import itertools
 import logging
 from abc import ABCMeta, abstractmethod
@@ -359,7 +360,9 @@ class ColumnTransformerSparseFrames(
         n_samples: Optional[int] = None,
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
         if self.verbose_feature_names_out:
-            prefixes = [name for name, _, _ in self.transformers]
+            # Get the prefixes for the columns of each transformer, unless the
+            # transformer does not process any columns
+            prefixes = [name for name, _, cols in self.transformers if len(cols)]
             if self._remainder[2] and self.remainder != "drop":
                 # remainder columns exist and are not being dropped
                 prefixes.append("remainder")

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -27,7 +27,7 @@ from sklearn.decomposition import PCA
 from sklearn.impute import MissingIndicator, SimpleImputer
 from sklearn.kernel_approximation import AdditiveChi2Sampler
 from sklearn.manifold import Isomap
-from sklearn.preprocessing import KBinsDiscretizer, OneHotEncoder
+from sklearn.preprocessing import FunctionTransformer, KBinsDiscretizer, OneHotEncoder
 
 from pytools.api import AllTracker
 
@@ -453,7 +453,13 @@ class ColumnTransformerWrapperDF(
             input_column_names: npt.NDArray[Any]
             output_column_names: npt.NDArray[Any]
 
-            if df_transformer == ColumnTransformerWrapperDF.PASSTHROUGH:
+            if df_transformer == ColumnTransformerWrapperDF.PASSTHROUGH or (
+                # scikit-learn 1.4+ replaces 'passthrough' with a FunctionTransformer
+                # using the identity function (represented by `None`), so we need to
+                # check for that.
+                isinstance(df_transformer, FunctionTransformer)
+                and df_transformer.func is None
+            ):
                 # we may get positional indices for columns selected by the
                 # 'passthrough' transformer, and in that case need to look up the
                 # associated column names

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -5,18 +5,8 @@ Core implementation of :mod:`sklearndf.transformation.wrapper`
 import itertools
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import (
-    Any,
-    Generic,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from collections.abc import Iterable, Sequence
+from typing import Any, Generic, Optional, TypeVar, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -158,7 +148,7 @@ class SingleColumnTransformerWrapperDF(
         y: T_Target,
         *,
         expected_columns: pd.Index = None,
-    ) -> Tuple[pd.DataFrame, T_Target]:
+    ) -> tuple[pd.DataFrame, T_Target]:
         X, y = super()._validate_parameter_types(
             X, y, expected_columns=expected_columns
         )
@@ -355,7 +345,7 @@ class ColumnTransformerSparseFrames(
     # noinspection PyPep8Naming
     def _hstack(
         self,
-        Xs: List[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]],
+        Xs: list[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]],
         *,
         n_samples: Optional[int] = None,
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
@@ -414,7 +404,7 @@ class ColumnTransformerWrapperDF(
                 f"unsupported value for arg remainder: {column_transformer.remainder!r}"
             )
 
-        non_compliant_transformers: List[str] = [
+        non_compliant_transformers: list[str] = [
             type(transformer).__name__
             for _, transformer, _ in column_transformer.transformers
             if not (
@@ -521,11 +511,11 @@ class ImputerWrapperDF(
         # get the columns that were dropped during imputation
         delegate_estimator = self.native_estimator
 
-        nan_mask: Union[List[bool], npt.NDArray[Any]] = []
+        nan_mask: Union[list[bool], npt.NDArray[Any]] = []
 
         def _nan_mask_from_statistics(
             stats: npt.NDArray[Any],
-        ) -> Union[List[bool], npt.NDArray[np.bool_]]:
+        ) -> Union[list[bool], npt.NDArray[np.bool_]]:
             if issubclass(stats.dtype.type, float):
                 return cast(npt.NDArray[np.bool_], np.isnan(stats))
             else:

--- a/src/sklearndf/wrapper/_missing.py
+++ b/src/sklearndf/wrapper/_missing.py
@@ -1,6 +1,7 @@
 """
 Handling of mocked up native estimators.
 """
+
 import logging
 from typing import Any
 

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -481,7 +481,7 @@ class EstimatorWrapperDF(
         if y is not None and not isinstance(y, (pd.Series, pd.DataFrame)):
             raise TypeError("arg y must be None, or a pandas series or data frame")
 
-        return X, cast(T_Target, y)
+        return X, y  # type: ignore[return-value]
 
     @staticmethod
     def _verify_df(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -239,8 +239,9 @@ class EstimatorWrapperDF(
         self._outputs: Optional[List[str]] = None
 
         # check if a fitted estimator was passed by class method is_fitted
-        fitted_delegate_context: Tuple[T_NativeEstimator, pd.Index, int] = kwargs.get(
-            EstimatorWrapperDF.__ARG_FITTED_DELEGATE_CONTEXT, None
+        fitted_delegate_context = cast(
+            Tuple[T_NativeEstimator, pd.Index, int],
+            kwargs.get(EstimatorWrapperDF.__ARG_FITTED_DELEGATE_CONTEXT, None),
         )
 
         _native_estimator: T_NativeEstimator
@@ -502,7 +503,7 @@ class EstimatorWrapperDF(
         if y is not None and not isinstance(y, (pd.Series, pd.DataFrame)):
             raise TypeError("arg y must be None, or a pandas series or data frame")
 
-        return X, y
+        return X, cast(T_Target, y)
 
     @staticmethod
     def _verify_df(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -948,9 +948,9 @@ class SupervisedLearnerWrapperDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: pd.Series | pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: pd.Series,
-        sample_weight: pd.Series | None = None,
+        sample_weight: Optional[pd.Series] = None,
     ) -> float:
         """[see superclass]"""
         X, y = self._validate_parameter_types(X, y)
@@ -986,9 +986,9 @@ class RegressorWrapperDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: pd.Series | pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: pd.Series,
-        sample_weight: pd.Series | None = None,
+        sample_weight: Optional[pd.Series] = None,
     ) -> float:
         """[see superclass]"""
         return cast(
@@ -1122,7 +1122,7 @@ class ClassifierWrapperDF(
         self,
         X: Union[pd.Series, pd.DataFrame],
         y: pd.Series,
-        sample_weight: pd.Series | None = None,
+        sample_weight: Optional[pd.Series] = None,
     ) -> float:
         """[see superclass]"""
         return cast(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -49,6 +49,7 @@ from sklearn.base import (
     RegressorMixin,
     TransformerMixin,
 )
+from sklearn.utils import Tags
 
 from pytools.api import AllTracker, inheritdoc, public_module_prefix
 
@@ -341,6 +342,9 @@ class EstimatorWrapperDF(
             return cast(str, self.native_estimator._estimator_type)
         except AttributeError:
             return None
+
+    def __sklearn_tags__(self) -> Tags:
+        return self.native_estimator.__sklearn_tags__()
 
     @classmethod
     def from_fitted(

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -49,7 +49,6 @@ from sklearn.base import (
     RegressorMixin,
     TransformerMixin,
 )
-from sklearn.utils import Tags
 
 from pytools.api import AllTracker, inheritdoc, public_module_prefix
 
@@ -61,7 +60,19 @@ from sklearndf import (
     RegressorDF,
     SupervisedLearnerDF,
     TransformerDF,
+    __sklearn_1_7__,
+    __sklearn_version__,
 )
+
+if __sklearn_version__ >= __sklearn_1_7__:
+    from sklearn.utils import Tags
+
+    __TAGS = True
+else:
+    # Fallback, in case tags are not defined
+    Tags = type("Tags", (), {})
+    __TAGS = False
+
 
 log = logging.getLogger(__name__)
 
@@ -639,6 +650,11 @@ class EstimatorWrapperDF(
             else:
                 # The attribute is defined in this wrapper object, so set it here.
                 super().__setattr__(name, value)
+
+
+if not __TAGS:
+    # Tags are not supported; delete the
+    del EstimatorWrapperDF.__sklearn_tags__
 
 
 @inheritdoc(match="[see superclass]")

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -19,7 +19,7 @@ import warnings
 from abc import ABCMeta
 from collections.abc import Iterable, Mapping, Sequence
 from functools import update_wrapper
-from typing import Any, Callable, Generic, TypeVar, Union, cast
+from typing import Any, Callable, Generic, Optional, TypeVar, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -80,7 +80,7 @@ __all__ = [
 
 T = TypeVar("T")
 T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
-T_Target = TypeVar("T_Target", bound=Union[pd.Series, pd.DataFrame, None])
+T_Target = TypeVar("T_Target", bound=Optional[Union[pd.Series, pd.DataFrame]])
 
 T_NativeEstimator = TypeVar("T_NativeEstimator", bound=BaseEstimator)
 T_NativeTransformer = TypeVar("T_NativeTransformer", bound=TransformerMixin)
@@ -125,7 +125,7 @@ class EstimatorWrapperDFMeta(ABCMeta, Generic[T_NativeEstimator]):
         name: str,
         bases: tuple[type, ...],
         namespace: dict[str, Any],
-        native: T_NativeEstimator | None = None,
+        native: Optional[T_NativeEstimator] = None,
         **kwargs: Any,
     ) -> EstimatorWrapperDFMeta[T_NativeEstimator]:
         if native in bases:
@@ -220,12 +220,12 @@ class EstimatorWrapperDF(
             estimator
         """
         super().__init__()
-        self._features_in: pd.Index | None = None
-        self._outputs: list[str] | None = None
+        self._features_in: Optional[pd.Index] = None
+        self._outputs: Optional[list[str]] = None
 
         # check if a fitted estimator was passed by class method is_fitted
         fitted_delegate_context = cast(
-            tuple[T_NativeEstimator, pd.Index, int],
+            Optional[tuple[T_NativeEstimator, pd.Index, int]],
             kwargs.get(EstimatorWrapperDF.__ARG_FITTED_DELEGATE_CONTEXT, None),
         )
 
@@ -333,7 +333,7 @@ class EstimatorWrapperDF(
         return wrapper_n_features
 
     @property
-    def _estimator_type(self) -> str | None:
+    def _estimator_type(self) -> Optional[str]:
         try:
             # noinspection PyProtectedMember
             return cast(str, self.native_estimator._estimator_type)
@@ -382,8 +382,8 @@ class EstimatorWrapperDF(
     # noinspection PyPep8Naming
     def fit(
         self: T_EstimatorWrapperDF,
-        X: pd.DataFrame | pd.Series,
-        y: pd.Series | pd.DataFrame | None = None,
+        X: Union[pd.DataFrame, pd.Series],
+        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params: Any,
     ) -> T_EstimatorWrapperDF:
         """[see superclass]"""
@@ -410,7 +410,7 @@ class EstimatorWrapperDF(
         assert self._features_in is not None, "estimator is fitted"
         return self._features_in
 
-    def _get_outputs(self) -> list[str] | None:
+    def _get_outputs(self) -> Optional[list[str]]:
         return self._outputs
 
     def _reset_fit(self) -> None:
@@ -421,7 +421,7 @@ class EstimatorWrapperDF(
     def _fit(
         self,
         X: pd.DataFrame,
-        y: pd.Series | pd.DataFrame | None,
+        y: Optional[Union[pd.Series, pd.DataFrame]],
         **fit_params: Any,
     ) -> T_NativeEstimator:
         # noinspection PyUnresolvedReferences
@@ -438,7 +438,7 @@ class EstimatorWrapperDF(
     def _post_fit(
         self,
         X: pd.DataFrame,
-        y: pd.Series | pd.DataFrame | None = None,
+        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params: Any,
     ) -> None:
         self._features_in = X.columns.rename(self.COL_FEATURE)
@@ -452,10 +452,10 @@ class EstimatorWrapperDF(
     # noinspection PyPep8Naming
     def _validate_parameter_types(
         self,
-        X: pd.Series | pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: T_Target,
         *,
-        expected_columns: pd.Index = None,
+        expected_columns: Optional[pd.Index] = None,
     ) -> tuple[pd.DataFrame, T_Target]:
         # Check that the X and y parameters are valid data frames and series,
         # and return X as a data frame and y as a series or data frame.
@@ -495,7 +495,7 @@ class EstimatorWrapperDF(
         df_name: str,
         df: pd.DataFrame,
         expected_columns: pd.Index,
-        expected_index: pd.Index = None,
+        expected_index: Optional[pd.Index] = None,
     ) -> None:
         def _verify_labels(axis: str, actual: pd.Index, expected: pd.Index) -> None:
             missing_columns = expected.difference(actual)
@@ -543,13 +543,13 @@ class EstimatorWrapperDF(
     # noinspection PyPep8Naming
     def _prepare_X_for_delegate(
         self, X: pd.DataFrame
-    ) -> pd.DataFrame | npt.NDArray[Any]:
+    ) -> Union[pd.DataFrame, npt.NDArray[Any], sparse.csr_matrix]:
         # convert X before passing it to the delegate estimator
         return self._adjust_X_type_for_delegate(self._adjust_X_columns_for_delegate(X))
 
     def _prepare_y_for_delegate(
-        self, y: pd.Series | pd.DataFrame | None
-    ) -> pd.Series | pd.DataFrame | npt.NDArray[Any] | sparse.csr_matrix | None:
+        self, y: Optional[Union[pd.Series, pd.DataFrame]]
+    ) -> Optional[Union[pd.Series, pd.DataFrame, npt.NDArray[Any], sparse.csr_matrix]]:
         return self._adjust_y_type_for_delegate(y)
 
     # noinspection PyPep8Naming
@@ -569,14 +569,14 @@ class EstimatorWrapperDF(
     # noinspection PyPep8Naming
     def _adjust_X_type_for_delegate(
         self, X: pd.DataFrame
-    ) -> pd.DataFrame | npt.NDArray[Any] | sparse.csr_matrix:
+    ) -> Union[pd.DataFrame, npt.NDArray[Any], sparse.csr_matrix]:
         # Convert X before passing it to the delegate estimator.
         # By default, does nothing, but can be overridden.
         return X
 
     def _adjust_y_type_for_delegate(
-        self, y: pd.Series | pd.DataFrame | None
-    ) -> pd.Series | pd.DataFrame | npt.NDArray[Any] | sparse.csr_matrix | None:
+        self, y: Optional[Union[pd.Series, pd.DataFrame]]
+    ) -> Optional[Union[pd.Series, pd.DataFrame, npt.NDArray[Any], sparse.csr_matrix]]:
         # convert y before passing it to the delegate estimator
         return y
 
@@ -674,7 +674,7 @@ class TransformerWrapperDF(
         return feature_names_original_
 
     # noinspection PyPep8Naming
-    def transform(self, X: pd.Series | pd.DataFrame) -> pd.DataFrame:
+    def transform(self, X: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
         """[see superclass]"""
         X, _ = self._validate_parameter_types(X, None)
 
@@ -687,8 +687,8 @@ class TransformerWrapperDF(
     # noinspection PyPep8Naming
     def fit_transform(
         self,
-        X: pd.Series | pd.DataFrame,
-        y: pd.Series | None = None,
+        X: Union[pd.Series, pd.DataFrame],
+        y: Optional[pd.Series] = None,
         **fit_params: Any,
     ) -> pd.DataFrame:
         """[see superclass]"""
@@ -710,7 +710,7 @@ class TransformerWrapperDF(
         )
 
     # noinspection PyPep8Naming
-    def inverse_transform(self, X: pd.Series | pd.DataFrame) -> pd.DataFrame:
+    def inverse_transform(self, X: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
         """[see superclass]"""
         X, _ = self._validate_parameter_types(
             X, None, expected_columns=self.feature_names_out_
@@ -752,7 +752,7 @@ class TransformerWrapperDF(
     # noinspection PyPep8Naming
     def _prepare_X_for_delegate(
         self, X: pd.DataFrame, *, inverse: bool = False
-    ) -> pd.DataFrame | npt.NDArray[Any]:
+    ) -> Union[pd.DataFrame, npt.NDArray[Any]]:
         x_adjusted = self._adjust_X_columns_for_delegate(X, inverse=inverse)
         if inverse:
             # when doing an inverse transform, we need X as a numpy array
@@ -762,7 +762,7 @@ class TransformerWrapperDF(
 
     # noinspection PyPep8Naming
     def _adjust_X_columns_for_delegate(
-        self, X: pd.DataFrame, *, inverse: bool | None = None
+        self, X: pd.DataFrame, *, inverse: Optional[bool] = None
     ) -> pd.DataFrame:
         if inverse:
             # when converting X for an inverse transform, ensure the data frame is
@@ -778,7 +778,7 @@ class TransformerWrapperDF(
 
     @staticmethod
     def _transformed_to_df(
-        transformed: pd.DataFrame | npt.NDArray[Any] | sparse.spmatrix,
+        transformed: Union[pd.DataFrame, npt.NDArray[Any], sparse.spmatrix],
         index: pd.Index,
         columns: pd.Index,
     ) -> pd.DataFrame:
@@ -803,7 +803,7 @@ class TransformerWrapperDF(
     # noinspection PyPep8Naming
     def _transform(
         self, X: pd.DataFrame
-    ) -> npt.NDArray[Any] | sparse.csr_matrix | pd.DataFrame:
+    ) -> Union[npt.NDArray[Any], sparse.csr_matrix, pd.DataFrame]:
         return cast(
             Union[npt.NDArray[Any], sparse.csr_matrix, pd.DataFrame],
             self.native_estimator.transform(self._prepare_X_for_delegate(X)),
@@ -811,8 +811,8 @@ class TransformerWrapperDF(
 
     # noinspection PyPep8Naming
     def _fit_transform(
-        self, X: pd.DataFrame, y: pd.Series | None, **fit_params: Any
-    ) -> npt.NDArray[Any] | sparse.csr_matrix | pd.DataFrame:
+        self, X: pd.DataFrame, y: Optional[pd.Series], **fit_params: Any
+    ) -> Union[npt.NDArray[Any], sparse.csr_matrix, pd.DataFrame]:
         return cast(
             Union[npt.NDArray[Any], sparse.csr_matrix, pd.DataFrame],
             self.native_estimator.fit_transform(
@@ -858,8 +858,8 @@ class LearnerWrapperDF(
 
     # noinspection PyPep8Naming
     def predict(
-        self, X: pd.Series | pd.DataFrame, **predict_params: Any
-    ) -> pd.Series | pd.DataFrame:
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+    ) -> Union[pd.Series, pd.DataFrame]:
         """[see superclass]"""
         X, _ = self._validate_parameter_types(X, None)
 
@@ -873,14 +873,14 @@ class LearnerWrapperDF(
 
     # noinspection PyPep8Naming
     def _prediction_to_series_or_frame(
-        self, X: pd.DataFrame, y: npt.NDArray[Any] | pd.Series | pd.DataFrame
-    ) -> pd.Series | pd.DataFrame:
+        self, X: pd.DataFrame, y: Union[npt.NDArray[Any], pd.Series, pd.DataFrame]
+    ) -> Union[pd.Series, pd.DataFrame]:
         if len(y) != len(X):
             raise ValueError(
                 f"length of prediction ({len(y)}) does not match length of X ({len(X)})"
             )
 
-        outputs: list[str] | None = self._get_outputs()
+        outputs: Optional[list[str]] = self._get_outputs()
 
         if y.ndim == 1:
             if outputs is None:
@@ -1011,7 +1011,7 @@ class ClassifierWrapperDF(
 
     __native_base_class__ = ClassifierMixin
 
-    def _get_classes(self) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
+    def _get_classes(self) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         return cast(
             Union[npt.NDArray[Any], list[npt.NDArray[Any]]],
             self._native_estimator.classes_,
@@ -1019,8 +1019,8 @@ class ClassifierWrapperDF(
 
     # noinspection PyPep8Naming
     def predict_proba(
-        self, X: pd.Series | pd.DataFrame, **predict_params: Any
-    ) -> pd.DataFrame | list[pd.DataFrame]:
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """[see superclass]"""
 
         self._ensure_delegate_method("predict_proba")
@@ -1037,8 +1037,8 @@ class ClassifierWrapperDF(
 
     # noinspection PyPep8Naming
     def predict_log_proba(
-        self, X: pd.Series | pd.DataFrame, **predict_params: Any
-    ) -> pd.DataFrame | list[pd.DataFrame]:
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """[see superclass]"""
 
         self._ensure_delegate_method("predict_log_proba")
@@ -1055,8 +1055,8 @@ class ClassifierWrapperDF(
 
     # noinspection PyPep8Naming
     def decision_function(
-        self, X: pd.Series | pd.DataFrame, **predict_params: Any
-    ) -> pd.Series | pd.DataFrame:
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+    ) -> Union[pd.Series, pd.DataFrame]:
         """[see superclass]"""
 
         self._ensure_delegate_method("decision_function")
@@ -1082,11 +1082,11 @@ class ClassifierWrapperDF(
     def _prediction_with_class_labels(
         self,
         X: pd.DataFrame,
-        prediction: (
-            pd.Series | pd.DataFrame | list[npt.NDArray[Any]] | npt.NDArray[Any]
-        ),
-        classes: Sequence[Any] | None = None,
-    ) -> pd.Series | pd.DataFrame | list[pd.DataFrame]:
+        prediction: Union[
+            pd.Series, pd.DataFrame, list[npt.NDArray[Any]], npt.NDArray[Any]
+        ],
+        classes: Optional[Sequence[Any]] = None,
+    ) -> Union[pd.Series, pd.DataFrame, list[pd.DataFrame]]:
         if classes is None:
             classes = getattr(self.native_estimator, "classes_", None)
             if classes is None:
@@ -1120,7 +1120,7 @@ class ClassifierWrapperDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: pd.Series | pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: pd.Series,
         sample_weight: pd.Series | None = None,
     ) -> float:
@@ -1151,7 +1151,7 @@ class ClusterWrapperDF(
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """[see superclass]"""
         super().__init__(*args, **kwargs)
-        self._x_index: pd.Index | None = None
+        self._x_index: Optional[pd.Index] = None
 
     def _get_labels(self) -> pd.Series:
         return pd.Series(
@@ -1162,10 +1162,10 @@ class ClusterWrapperDF(
 
     def fit_predict(
         self,
-        X: pd.Series | pd.DataFrame,
-        y: pd.Series | pd.DataFrame | None = None,
+        X: Union[pd.Series, pd.DataFrame],
+        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_predict_params: Any,
-    ) -> pd.Series | pd.DataFrame:
+    ) -> Union[pd.Series, pd.DataFrame]:
         """[see superclass]"""
 
         self._reset_fit()
@@ -1202,7 +1202,7 @@ class ClusterWrapperDF(
     def _post_fit(
         self,
         X: pd.DataFrame,
-        y: pd.Series | pd.DataFrame | None = None,
+        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params: Any,
     ) -> None:
         super()._post_fit(X, y, **fit_params)
@@ -1280,7 +1280,7 @@ class MetaEstimatorWrapperDF(
     @staticmethod
     def _native_learner(
         estimator_wrapper: BaseEstimator,
-    ) -> RegressorMixin | ClassifierMixin:
+    ) -> Union[RegressorMixin, ClassifierMixin]:
         native_estimator: BaseEstimator = (
             estimator_wrapper.native_estimator
             if isinstance(estimator_wrapper, EstimatorWrapperDF)
@@ -1328,7 +1328,8 @@ def _mirror_attributes(
 
 def _make_alias(
     wrapper_module: str, wrapper_name: str, name: str, delegate_cls: type, delegate: Any
-) -> Callable[..., Any] | property | None:
+) -> Optional[Union[Callable[..., Any], property]]:
+
     if inspect.isfunction(delegate):
         return _make_method_alias(
             wrapper_module=wrapper_module,

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -45,19 +45,9 @@ from sklearndf import (
     RegressorDF,
     SupervisedLearnerDF,
     TransformerDF,
-    __sklearn_1_7__,
+    __sklearn_1_6__,
     __sklearn_version__,
 )
-
-if __sklearn_version__ >= __sklearn_1_7__:
-    from sklearn.utils import Tags
-
-    __TAGS = True
-else:
-    # Fallback, in case tags are not defined
-    Tags = type("Tags", (), {})
-    __TAGS = False
-
 
 log = logging.getLogger(__name__)
 
@@ -340,8 +330,11 @@ class EstimatorWrapperDF(
         except AttributeError:
             return None
 
-    def __sklearn_tags__(self) -> Tags:
-        return self.native_estimator.__sklearn_tags__()
+    if __sklearn_version__ >= __sklearn_1_6__:
+        from sklearn.utils import Tags
+
+        def __sklearn_tags__(self) -> Tags:
+            return self.native_estimator.__sklearn_tags__()
 
     @classmethod
     def from_fitted(
@@ -636,11 +629,6 @@ class EstimatorWrapperDF(
             else:
                 # The attribute is defined in this wrapper object, so set it here.
                 super().__setattr__(name, value)
-
-
-if not __TAGS:
-    # Tags are not supported; delete the
-    del EstimatorWrapperDF.__sklearn_tags__
 
 
 @inheritdoc(match="[see superclass]")

--- a/src/sklearndf/wrapper/_wrapper.py
+++ b/src/sklearndf/wrapper/_wrapper.py
@@ -17,24 +17,9 @@ import inspect
 import logging
 import warnings
 from abc import ABCMeta
+from collections.abc import Iterable, Mapping, Sequence
 from functools import update_wrapper
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Generic, TypeVar, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -133,14 +118,14 @@ class EstimatorWrapperDFMeta(ABCMeta, Generic[T_NativeEstimator]):
     """
 
     #: the native class wrapped by the DF wrapper class
-    __wrapped__: Type[T_NativeEstimator]
+    __wrapped__: type[T_NativeEstimator]
 
     def __new__(
-        mcs: Type[EstimatorWrapperDFMeta[T_NativeEstimator]],
+        mcs: type[EstimatorWrapperDFMeta[T_NativeEstimator]],
         name: str,
-        bases: Tuple[type, ...],
-        namespace: Dict[str, Any],
-        native: Optional[T_NativeEstimator] = None,
+        bases: tuple[type, ...],
+        namespace: dict[str, Any],
+        native: T_NativeEstimator | None = None,
         **kwargs: Any,
     ) -> EstimatorWrapperDFMeta[T_NativeEstimator]:
         if native in bases:
@@ -157,7 +142,7 @@ class EstimatorWrapperDFMeta(ABCMeta, Generic[T_NativeEstimator]):
         if native is None:
             return cls
 
-        wrapper_cls = cast(Type[EstimatorWrapperDF[T_NativeEstimator]], cls)
+        wrapper_cls = cast(type[EstimatorWrapperDF[T_NativeEstimator]], cls)
 
         if not issubclass(native, wrapper_cls.__native_base_class__):
             raise TypeError(
@@ -195,7 +180,7 @@ class EstimatorWrapperDFMeta(ABCMeta, Generic[T_NativeEstimator]):
         return wrapper_cls
 
     @property
-    def native_estimator_type(cls) -> Type[T_NativeEstimator]:
+    def native_estimator_type(cls) -> type[T_NativeEstimator]:
         """
         The type of native estimator that instances of this wrapper class delegate to.
         """
@@ -235,12 +220,12 @@ class EstimatorWrapperDF(
             estimator
         """
         super().__init__()
-        self._features_in: Optional[pd.Index] = None
-        self._outputs: Optional[List[str]] = None
+        self._features_in: pd.Index | None = None
+        self._outputs: list[str] | None = None
 
         # check if a fitted estimator was passed by class method is_fitted
         fitted_delegate_context = cast(
-            Tuple[T_NativeEstimator, pd.Index, int],
+            tuple[T_NativeEstimator, pd.Index, int],
             kwargs.get(EstimatorWrapperDF.__ARG_FITTED_DELEGATE_CONTEXT, None),
         )
 
@@ -263,7 +248,7 @@ class EstimatorWrapperDF(
         self._validate_delegate_estimator()
 
     def __new__(
-        cls: Type[T_EstimatorWrapperDF], *args: Any, **kwargs: Any
+        cls: type[T_EstimatorWrapperDF], *args: Any, **kwargs: Any
     ) -> T_EstimatorWrapperDF:
         try:
             cls.__wrapped__
@@ -273,7 +258,7 @@ class EstimatorWrapperDF(
                 "need to specify class argument 'native' in class definition"
             )
         else:
-            return cast(Type[EstimatorDF], super()).__new__(cls)
+            return cast(type[EstimatorDF], super()).__new__(cls)
 
     @property
     def is_fitted(self) -> bool:
@@ -348,7 +333,7 @@ class EstimatorWrapperDF(
         return wrapper_n_features
 
     @property
-    def _estimator_type(self) -> Optional[str]:
+    def _estimator_type(self) -> str | None:
         try:
             # noinspection PyProtectedMember
             return cast(str, self.native_estimator._estimator_type)
@@ -360,7 +345,7 @@ class EstimatorWrapperDF(
 
     @classmethod
     def from_fitted(
-        cls: Type[T_EstimatorWrapperDF],
+        cls: type[T_EstimatorWrapperDF],
         estimator: T_NativeEstimator,
         features_in: pd.Index,
         n_outputs: int,
@@ -397,8 +382,8 @@ class EstimatorWrapperDF(
     # noinspection PyPep8Naming
     def fit(
         self: T_EstimatorWrapperDF,
-        X: Union[pd.DataFrame, pd.Series],
-        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
+        X: pd.DataFrame | pd.Series,
+        y: pd.Series | pd.DataFrame | None = None,
         **fit_params: Any,
     ) -> T_EstimatorWrapperDF:
         """[see superclass]"""
@@ -425,7 +410,7 @@ class EstimatorWrapperDF(
         assert self._features_in is not None, "estimator is fitted"
         return self._features_in
 
-    def _get_outputs(self) -> Optional[List[str]]:
+    def _get_outputs(self) -> list[str] | None:
         return self._outputs
 
     def _reset_fit(self) -> None:
@@ -436,7 +421,7 @@ class EstimatorWrapperDF(
     def _fit(
         self,
         X: pd.DataFrame,
-        y: Optional[Union[pd.Series, pd.DataFrame]],
+        y: pd.Series | pd.DataFrame | None,
         **fit_params: Any,
     ) -> T_NativeEstimator:
         # noinspection PyUnresolvedReferences
@@ -453,7 +438,7 @@ class EstimatorWrapperDF(
     def _post_fit(
         self,
         X: pd.DataFrame,
-        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
+        y: pd.Series | pd.DataFrame | None = None,
         **fit_params: Any,
     ) -> None:
         self._features_in = X.columns.rename(self.COL_FEATURE)
@@ -467,11 +452,11 @@ class EstimatorWrapperDF(
     # noinspection PyPep8Naming
     def _validate_parameter_types(
         self,
-        X: Union[pd.Series, pd.DataFrame],
+        X: pd.Series | pd.DataFrame,
         y: T_Target,
         *,
         expected_columns: pd.Index = None,
-    ) -> Tuple[pd.DataFrame, T_Target]:
+    ) -> tuple[pd.DataFrame, T_Target]:
         # Check that the X and y parameters are valid data frames and series,
         # and return X as a data frame and y as a series or data frame.
         #
@@ -515,7 +500,7 @@ class EstimatorWrapperDF(
         def _verify_labels(axis: str, actual: pd.Index, expected: pd.Index) -> None:
             missing_columns = expected.difference(actual)
             extra_columns = actual.difference(expected)
-            error_detail: List[str] = []
+            error_detail: list[str] = []
 
             # check that we have the expected number of columns
             if len(actual) != len(expected):
@@ -558,13 +543,13 @@ class EstimatorWrapperDF(
     # noinspection PyPep8Naming
     def _prepare_X_for_delegate(
         self, X: pd.DataFrame
-    ) -> Union[pd.DataFrame, npt.NDArray[Any]]:
+    ) -> pd.DataFrame | npt.NDArray[Any]:
         # convert X before passing it to the delegate estimator
         return self._adjust_X_type_for_delegate(self._adjust_X_columns_for_delegate(X))
 
     def _prepare_y_for_delegate(
-        self, y: Optional[Union[pd.Series, pd.DataFrame]]
-    ) -> Union[pd.Series, pd.DataFrame, npt.NDArray[Any], sparse.csr_matrix, None]:
+        self, y: pd.Series | pd.DataFrame | None
+    ) -> pd.Series | pd.DataFrame | npt.NDArray[Any] | sparse.csr_matrix | None:
         return self._adjust_y_type_for_delegate(y)
 
     # noinspection PyPep8Naming
@@ -584,14 +569,14 @@ class EstimatorWrapperDF(
     # noinspection PyPep8Naming
     def _adjust_X_type_for_delegate(
         self, X: pd.DataFrame
-    ) -> Union[pd.DataFrame, npt.NDArray[Any], sparse.csr_matrix]:
+    ) -> pd.DataFrame | npt.NDArray[Any] | sparse.csr_matrix:
         # Convert X before passing it to the delegate estimator.
         # By default, does nothing, but can be overridden.
         return X
 
     def _adjust_y_type_for_delegate(
-        self, y: Union[pd.Series, pd.DataFrame, None]
-    ) -> Union[pd.Series, pd.DataFrame, npt.NDArray[Any], sparse.csr_matrix, None]:
+        self, y: pd.Series | pd.DataFrame | None
+    ) -> pd.Series | pd.DataFrame | npt.NDArray[Any] | sparse.csr_matrix | None:
         # convert y before passing it to the delegate estimator
         return y
 
@@ -689,7 +674,7 @@ class TransformerWrapperDF(
         return feature_names_original_
 
     # noinspection PyPep8Naming
-    def transform(self, X: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
+    def transform(self, X: pd.Series | pd.DataFrame) -> pd.DataFrame:
         """[see superclass]"""
         X, _ = self._validate_parameter_types(X, None)
 
@@ -702,8 +687,8 @@ class TransformerWrapperDF(
     # noinspection PyPep8Naming
     def fit_transform(
         self,
-        X: Union[pd.Series, pd.DataFrame],
-        y: Optional[pd.Series] = None,
+        X: pd.Series | pd.DataFrame,
+        y: pd.Series | None = None,
         **fit_params: Any,
     ) -> pd.DataFrame:
         """[see superclass]"""
@@ -725,7 +710,7 @@ class TransformerWrapperDF(
         )
 
     # noinspection PyPep8Naming
-    def inverse_transform(self, X: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
+    def inverse_transform(self, X: pd.Series | pd.DataFrame) -> pd.DataFrame:
         """[see superclass]"""
         X, _ = self._validate_parameter_types(
             X, None, expected_columns=self.feature_names_out_
@@ -767,7 +752,7 @@ class TransformerWrapperDF(
     # noinspection PyPep8Naming
     def _prepare_X_for_delegate(
         self, X: pd.DataFrame, *, inverse: bool = False
-    ) -> Union[pd.DataFrame, npt.NDArray[Any]]:
+    ) -> pd.DataFrame | npt.NDArray[Any]:
         x_adjusted = self._adjust_X_columns_for_delegate(X, inverse=inverse)
         if inverse:
             # when doing an inverse transform, we need X as a numpy array
@@ -777,7 +762,7 @@ class TransformerWrapperDF(
 
     # noinspection PyPep8Naming
     def _adjust_X_columns_for_delegate(
-        self, X: pd.DataFrame, *, inverse: Optional[bool] = None
+        self, X: pd.DataFrame, *, inverse: bool | None = None
     ) -> pd.DataFrame:
         if inverse:
             # when converting X for an inverse transform, ensure the data frame is
@@ -793,7 +778,7 @@ class TransformerWrapperDF(
 
     @staticmethod
     def _transformed_to_df(
-        transformed: Union[pd.DataFrame, npt.NDArray[Any], sparse.spmatrix],
+        transformed: pd.DataFrame | npt.NDArray[Any] | sparse.spmatrix,
         index: pd.Index,
         columns: pd.Index,
     ) -> pd.DataFrame:
@@ -818,7 +803,7 @@ class TransformerWrapperDF(
     # noinspection PyPep8Naming
     def _transform(
         self, X: pd.DataFrame
-    ) -> Union[npt.NDArray[Any], sparse.csr_matrix, pd.DataFrame]:
+    ) -> npt.NDArray[Any] | sparse.csr_matrix | pd.DataFrame:
         return cast(
             Union[npt.NDArray[Any], sparse.csr_matrix, pd.DataFrame],
             self.native_estimator.transform(self._prepare_X_for_delegate(X)),
@@ -826,8 +811,8 @@ class TransformerWrapperDF(
 
     # noinspection PyPep8Naming
     def _fit_transform(
-        self, X: pd.DataFrame, y: Optional[pd.Series], **fit_params: Any
-    ) -> Union[npt.NDArray[Any], sparse.csr_matrix, pd.DataFrame]:
+        self, X: pd.DataFrame, y: pd.Series | None, **fit_params: Any
+    ) -> npt.NDArray[Any] | sparse.csr_matrix | pd.DataFrame:
         return cast(
             Union[npt.NDArray[Any], sparse.csr_matrix, pd.DataFrame],
             self.native_estimator.fit_transform(
@@ -873,8 +858,8 @@ class LearnerWrapperDF(
 
     # noinspection PyPep8Naming
     def predict(
-        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.Series, pd.DataFrame]:
+        self, X: pd.Series | pd.DataFrame, **predict_params: Any
+    ) -> pd.Series | pd.DataFrame:
         """[see superclass]"""
         X, _ = self._validate_parameter_types(X, None)
 
@@ -888,14 +873,14 @@ class LearnerWrapperDF(
 
     # noinspection PyPep8Naming
     def _prediction_to_series_or_frame(
-        self, X: pd.DataFrame, y: Union[npt.NDArray[Any], pd.Series, pd.DataFrame]
-    ) -> Union[pd.Series, pd.DataFrame]:
+        self, X: pd.DataFrame, y: npt.NDArray[Any] | pd.Series | pd.DataFrame
+    ) -> pd.Series | pd.DataFrame:
         if len(y) != len(X):
             raise ValueError(
                 f"length of prediction ({len(y)}) does not match length of X ({len(X)})"
             )
 
-        outputs: Optional[List[str]] = self._get_outputs()
+        outputs: list[str] | None = self._get_outputs()
 
         if y.ndim == 1:
             if outputs is None:
@@ -963,9 +948,9 @@ class SupervisedLearnerWrapperDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: Union[pd.Series, pd.DataFrame],
+        X: pd.Series | pd.DataFrame,
         y: pd.Series,
-        sample_weight: Optional[pd.Series] = None,
+        sample_weight: pd.Series | None = None,
     ) -> float:
         """[see superclass]"""
         X, y = self._validate_parameter_types(X, y)
@@ -1001,9 +986,9 @@ class RegressorWrapperDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: Union[pd.Series, pd.DataFrame],
+        X: pd.Series | pd.DataFrame,
         y: pd.Series,
-        sample_weight: Optional[pd.Series] = None,
+        sample_weight: pd.Series | None = None,
     ) -> float:
         """[see superclass]"""
         return cast(
@@ -1026,16 +1011,16 @@ class ClassifierWrapperDF(
 
     __native_base_class__ = ClassifierMixin
 
-    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+    def _get_classes(self) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
         return cast(
-            Union[npt.NDArray[Any], List[npt.NDArray[Any]]],
+            Union[npt.NDArray[Any], list[npt.NDArray[Any]]],
             self._native_estimator.classes_,
         )
 
     # noinspection PyPep8Naming
     def predict_proba(
-        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+        self, X: pd.Series | pd.DataFrame, **predict_params: Any
+    ) -> pd.DataFrame | list[pd.DataFrame]:
         """[see superclass]"""
 
         self._ensure_delegate_method("predict_proba")
@@ -1052,8 +1037,8 @@ class ClassifierWrapperDF(
 
     # noinspection PyPep8Naming
     def predict_log_proba(
-        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+        self, X: pd.Series | pd.DataFrame, **predict_params: Any
+    ) -> pd.DataFrame | list[pd.DataFrame]:
         """[see superclass]"""
 
         self._ensure_delegate_method("predict_log_proba")
@@ -1070,8 +1055,8 @@ class ClassifierWrapperDF(
 
     # noinspection PyPep8Naming
     def decision_function(
-        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.Series, pd.DataFrame]:
+        self, X: pd.Series | pd.DataFrame, **predict_params: Any
+    ) -> pd.Series | pd.DataFrame:
         """[see superclass]"""
 
         self._ensure_delegate_method("decision_function")
@@ -1097,11 +1082,11 @@ class ClassifierWrapperDF(
     def _prediction_with_class_labels(
         self,
         X: pd.DataFrame,
-        prediction: Union[
-            pd.Series, pd.DataFrame, List[npt.NDArray[Any]], npt.NDArray[Any]
-        ],
-        classes: Optional[Sequence[Any]] = None,
-    ) -> Union[pd.Series, pd.DataFrame, List[pd.DataFrame]]:
+        prediction: (
+            pd.Series | pd.DataFrame | list[npt.NDArray[Any]] | npt.NDArray[Any]
+        ),
+        classes: Sequence[Any] | None = None,
+    ) -> pd.Series | pd.DataFrame | list[pd.DataFrame]:
         if classes is None:
             classes = getattr(self.native_estimator, "classes_", None)
             if classes is None:
@@ -1135,9 +1120,9 @@ class ClassifierWrapperDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: Union[pd.Series, pd.DataFrame],
+        X: pd.Series | pd.DataFrame,
         y: pd.Series,
-        sample_weight: Optional[pd.Series] = None,
+        sample_weight: pd.Series | None = None,
     ) -> float:
         """[see superclass]"""
         return cast(
@@ -1166,7 +1151,7 @@ class ClusterWrapperDF(
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """[see superclass]"""
         super().__init__(*args, **kwargs)
-        self._x_index: Optional[pd.Index] = None
+        self._x_index: pd.Index | None = None
 
     def _get_labels(self) -> pd.Series:
         return pd.Series(
@@ -1177,10 +1162,10 @@ class ClusterWrapperDF(
 
     def fit_predict(
         self,
-        X: Union[pd.Series, pd.DataFrame],
-        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
+        X: pd.Series | pd.DataFrame,
+        y: pd.Series | pd.DataFrame | None = None,
         **fit_predict_params: Any,
-    ) -> Union[pd.Series, pd.DataFrame]:
+    ) -> pd.Series | pd.DataFrame:
         """[see superclass]"""
 
         self._reset_fit()
@@ -1217,7 +1202,7 @@ class ClusterWrapperDF(
     def _post_fit(
         self,
         X: pd.DataFrame,
-        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
+        y: pd.Series | pd.DataFrame | None = None,
         **fit_params: Any,
     ) -> None:
         super()._post_fit(X, y, **fit_params)
@@ -1262,7 +1247,7 @@ class MetaEstimatorWrapperDF(
     """
 
     def _validate_delegate_estimator(self) -> None:
-        substituted: List[str] = []
+        substituted: list[str] = []
 
         estimator = getattr(self, "estimator", None)
         if estimator is not None:
@@ -1295,7 +1280,7 @@ class MetaEstimatorWrapperDF(
     @staticmethod
     def _native_learner(
         estimator_wrapper: BaseEstimator,
-    ) -> Union[RegressorMixin, ClassifierMixin]:
+    ) -> RegressorMixin | ClassifierMixin:
         native_estimator: BaseEstimator = (
             estimator_wrapper.native_estimator
             if isinstance(estimator_wrapper, EstimatorWrapperDF)
@@ -1318,12 +1303,12 @@ class MetaEstimatorWrapperDF(
 
 
 def _mirror_attributes(
-    wrapper_class: Type[EstimatorWrapperDF[T_NativeEstimator]],
-    native_estimator: Type[T_NativeEstimator],
+    wrapper_class: type[EstimatorWrapperDF[T_NativeEstimator]],
+    native_estimator: type[T_NativeEstimator],
     wrapper_module: str,
 ) -> None:
     wrapper_name = wrapper_class.__name__
-    wrapper_attributes: Set[str] = set(dir(wrapper_class))
+    wrapper_attributes: set[str] = set(dir(wrapper_class))
 
     for name, member in vars(native_estimator).items():
         if member is None or name in wrapper_attributes:
@@ -1343,7 +1328,7 @@ def _mirror_attributes(
 
 def _make_alias(
     wrapper_module: str, wrapper_name: str, name: str, delegate_cls: type, delegate: Any
-) -> Union[Callable[..., Any], property, None]:
+) -> Callable[..., Any] | property | None:
     if inspect.isfunction(delegate):
         return _make_method_alias(
             wrapper_module=wrapper_module,
@@ -1422,8 +1407,8 @@ def _update_wrapper(
 
 
 def _update_class_docstring(
-    df_estimator_type: Type[EstimatorWrapperDF[T_NativeEstimator]],
-    sklearn_native_estimator_type: Type[T_NativeEstimator],
+    df_estimator_type: type[EstimatorWrapperDF[T_NativeEstimator]],
+    sklearn_native_estimator_type: type[T_NativeEstimator],
 ) -> None:
     base_doc = sklearn_native_estimator_type.__doc__
 
@@ -1433,7 +1418,7 @@ def _update_class_docstring(
     base_doc_lines = base_doc.split("\n")
 
     # use the first paragraph as the tag line
-    tag_lines: List[str] = []
+    tag_lines: list[str] = []
     for line in base_doc_lines:
         # end of paragraph reached?
         stripped = line.strip()

--- a/src/sklearndf/wrapper/numpy/_numpy.py
+++ b/src/sklearndf/wrapper/numpy/_numpy.py
@@ -3,7 +3,8 @@ Estimator adapter classes to handle numpy arrays in meta-estimators.
 """
 
 import logging
-from typing import Any, Callable, Generic, List, Optional, Sequence, TypeVar, Union
+from collections.abc import Sequence
+from typing import Any, Callable, Generic, Optional, TypeVar, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -118,7 +119,7 @@ class EstimatorNPDF(
     def _get_n_features_in(self) -> int:
         return self.delegate._get_n_features_in()
 
-    def _get_outputs(self) -> Optional[List[str]]:
+    def _get_outputs(self) -> Optional[list[str]]:
         return self.delegate._get_outputs()
 
     def _get_n_outputs(self) -> int:
@@ -244,18 +245,18 @@ class ClassifierNPDF(
     delegate: T_DelegateClassifierDF
     column_names: Optional[Union[Sequence[str], Callable[[], Sequence[str]]]]
 
-    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+    def _get_classes(self) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         return self.delegate._get_classes()
 
     def predict_proba(
         self, X: Union[npt.NDArray[Any], pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """[see superclass]"""
         return self.delegate.predict_proba(self._ensure_X_frame(X), **predict_params)
 
     def predict_log_proba(
         self, X: Union[npt.NDArray[Any], pd.DataFrame], **predict_params: Any
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """[see superclass]"""
         return self.delegate.predict_log_proba(
             self._ensure_X_frame(X), **predict_params

--- a/src/sklearndf/wrapper/numpy/_numpy.py
+++ b/src/sklearndf/wrapper/numpy/_numpy.py
@@ -168,7 +168,7 @@ class EstimatorNPDF(
 
     @staticmethod
     def _ensure_y_series_or_frame(
-        y: Optional[Union[npt.NDArray[Any], pd.Series, pd.DataFrame]]
+        y: Optional[Union[npt.NDArray[Any], pd.Series, pd.DataFrame]],
     ) -> Optional[Union[pd.Series, pd.DataFrame]]:
         if isinstance(y, np.ndarray):
             if y.ndim == 1:

--- a/src/sklearndf/wrapper/stacking/_stacking.py
+++ b/src/sklearndf/wrapper/stacking/_stacking.py
@@ -6,14 +6,11 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta, abstractmethod
+from collections.abc import Sequence
 from typing import (
     Any,
     Callable,
     Generic,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -100,8 +97,8 @@ class StackingEstimatorWrapperDF(
 
     def fit(
         self: T_StackingEstimatorWrapperDF,
-        X: Union[pd.DataFrame, pd.Series],
-        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
+        X: pd.DataFrame | pd.Series,
+        y: pd.Series | pd.DataFrame | None = None,
         **fit_params: Any,
     ) -> T_StackingEstimatorWrapperDF:
         """[see superclass]"""
@@ -117,7 +114,7 @@ class StackingEstimatorWrapperDF(
                 return self
 
         native: T_NativeSupervisedLearner = self.native_estimator
-        estimators: Sequence[Tuple[str, BaseEstimator]] = native.estimators
+        estimators: Sequence[tuple[str, BaseEstimator]] = native.estimators
         final_estimator: BaseEstimator = native.final_estimator
 
         try:
@@ -157,10 +154,10 @@ class StackingEstimatorWrapperDF(
     ) -> SupervisedLearnerNPDF[T_SupervisedLearnerDF]:
         pass
 
-    def _get_estimators_features_out(self) -> List[str]:
+    def _get_estimators_features_out(self) -> list[str]:
         return [name for name, estimator in self.estimators if estimator != "drop"]
 
-    def _get_final_estimator_features_in(self) -> List[str]:
+    def _get_final_estimator_features_in(self) -> list[str]:
         names = self._get_estimators_features_out()
         if self.passthrough:
             return [*names, *self.estimators_[0].feature_names_in_]
@@ -184,7 +181,7 @@ class StackingClassifierWrapperDF(
 
         return LogisticRegressionDF()
 
-    def _get_estimators_features_out(self) -> List[str]:
+    def _get_estimators_features_out(self) -> list[str]:
         classes = self.native_estimator.classes_
         names = super()._get_estimators_features_out()
         if len(classes) > 2:
@@ -260,8 +257,8 @@ class _StackableSupervisedLearnerDF(
     @subsdoc(pattern="", replacement="", using=SupervisedLearnerDF.fit)
     def fit(
         self: T_StackableSupervisedLearnerDF,
-        X: Union[pd.Series, pd.DataFrame],
-        y: Optional[npt.NDArray[Any]] = None,
+        X: pd.Series | pd.DataFrame,
+        y: npt.NDArray[Any] | None = None,
         **fit_params: Any,
     ) -> T_StackableSupervisedLearnerDF:
         """[see SupervisedLearnerDF.fit]"""
@@ -275,7 +272,7 @@ class _StackableSupervisedLearnerDF(
         using=SupervisedLearnerDF.predict,
     )
     def predict(
-        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+        self, X: pd.Series | pd.DataFrame, **predict_params: Any
     ) -> npt.NDArray[Any]:
         """[see SupervisedLearnerDF.predict]"""
         return cast(
@@ -286,9 +283,9 @@ class _StackableSupervisedLearnerDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: Union[pd.Series, pd.DataFrame],
-        y: npt.NDArray["np.floating[Any]"],
-        sample_weight: Optional[pd.Series] = None,
+        X: pd.Series | pd.DataFrame,
+        y: npt.NDArray[np.floating[Any]],
+        sample_weight: pd.Series | None = None,
     ) -> float:
         """[see SupervisedLearnerDF.score]"""
         return self.delegate.score(X, self._convert_y_to_series(X, y), sample_weight)
@@ -303,7 +300,7 @@ class _StackableSupervisedLearnerDF(
         # noinspection PyProtectedMember
         return self.delegate._get_n_features_in()
 
-    def _get_outputs(self) -> Optional[List[str]]:
+    def _get_outputs(self) -> list[str] | None:
         # noinspection PyProtectedMember
         return self.delegate._get_outputs()
 
@@ -314,8 +311,8 @@ class _StackableSupervisedLearnerDF(
     # noinspection PyPep8Naming
     @staticmethod
     def _convert_y_to_series(
-        X: pd.DataFrame, y: Optional[npt.NDArray[Any]]
-    ) -> Optional[pd.Series]:
+        X: pd.DataFrame, y: npt.NDArray[Any] | None
+    ) -> pd.Series | None:
         if y is None:
             return y
         if not isinstance(y, np.ndarray):
@@ -335,8 +332,8 @@ class _StackableSupervisedLearnerDF(
 
     @staticmethod
     def _convert_prediction_to_numpy(
-        prediction: Union[pd.DataFrame, List[pd.DataFrame]],
-    ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        prediction: pd.DataFrame | list[pd.DataFrame],
+    ) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
         if isinstance(prediction, list):
             return [proba.values for proba in prediction]
         else:
@@ -348,27 +345,27 @@ class _StackableSupervisedLearnerDF(
 class _StackableClassifierDF(_StackableSupervisedLearnerDF[ClassifierDF], ClassifierDF):
     """[see superclass]"""
 
-    def _get_classes(self) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+    def _get_classes(self) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
         return self.delegate._get_classes()
 
     def predict_proba(
-        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        self, X: pd.Series | pd.DataFrame, **predict_params: Any
+    ) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
         """[see superclass]"""
         return self._convert_prediction_to_numpy(
             self.delegate.predict_proba(X, **predict_params)
         )
 
     def predict_log_proba(
-        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
-    ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
+        self, X: pd.Series | pd.DataFrame, **predict_params: Any
+    ) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
         """[see superclass]"""
         return self._convert_prediction_to_numpy(
             self.delegate.predict_log_proba(X, **predict_params)
         )
 
     def decision_function(
-        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+        self, X: pd.Series | pd.DataFrame, **predict_params: Any
     ) -> npt.NDArray[np.floating[Any]]:
         """[see superclass]"""
         return cast(

--- a/src/sklearndf/wrapper/stacking/_stacking.py
+++ b/src/sklearndf/wrapper/stacking/_stacking.py
@@ -7,14 +7,7 @@ from __future__ import annotations
 import logging
 from abc import ABCMeta, abstractmethod
 from collections.abc import Sequence
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Generic, Optional, TypeVar, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -97,8 +90,8 @@ class StackingEstimatorWrapperDF(
 
     def fit(
         self: T_StackingEstimatorWrapperDF,
-        X: pd.DataFrame | pd.Series,
-        y: pd.Series | pd.DataFrame | None = None,
+        X: Union[pd.DataFrame, pd.Series],
+        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
         **fit_params: Any,
     ) -> T_StackingEstimatorWrapperDF:
         """[see superclass]"""
@@ -257,8 +250,8 @@ class _StackableSupervisedLearnerDF(
     @subsdoc(pattern="", replacement="", using=SupervisedLearnerDF.fit)
     def fit(
         self: T_StackableSupervisedLearnerDF,
-        X: pd.Series | pd.DataFrame,
-        y: npt.NDArray[Any] | None = None,
+        X: Union[pd.Series, pd.DataFrame],
+        y: Optional[npt.NDArray[Any]] = None,
         **fit_params: Any,
     ) -> T_StackableSupervisedLearnerDF:
         """[see SupervisedLearnerDF.fit]"""
@@ -272,7 +265,7 @@ class _StackableSupervisedLearnerDF(
         using=SupervisedLearnerDF.predict,
     )
     def predict(
-        self, X: pd.Series | pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> npt.NDArray[Any]:
         """[see SupervisedLearnerDF.predict]"""
         return cast(
@@ -283,9 +276,9 @@ class _StackableSupervisedLearnerDF(
     # noinspection PyPep8Naming
     def score(
         self,
-        X: pd.Series | pd.DataFrame,
+        X: Union[pd.Series, pd.DataFrame],
         y: npt.NDArray[np.floating[Any]],
-        sample_weight: pd.Series | None = None,
+        sample_weight: Optional[pd.Series] = None,
     ) -> float:
         """[see SupervisedLearnerDF.score]"""
         return self.delegate.score(X, self._convert_y_to_series(X, y), sample_weight)
@@ -300,7 +293,7 @@ class _StackableSupervisedLearnerDF(
         # noinspection PyProtectedMember
         return self.delegate._get_n_features_in()
 
-    def _get_outputs(self) -> list[str] | None:
+    def _get_outputs(self) -> Optional[list[str]]:
         # noinspection PyProtectedMember
         return self.delegate._get_outputs()
 
@@ -311,8 +304,8 @@ class _StackableSupervisedLearnerDF(
     # noinspection PyPep8Naming
     @staticmethod
     def _convert_y_to_series(
-        X: pd.DataFrame, y: npt.NDArray[Any] | None
-    ) -> pd.Series | None:
+        X: pd.DataFrame, y: Optional[npt.NDArray[Any]]
+    ) -> Optional[pd.Series]:
         if y is None:
             return y
         if not isinstance(y, np.ndarray):
@@ -332,8 +325,8 @@ class _StackableSupervisedLearnerDF(
 
     @staticmethod
     def _convert_prediction_to_numpy(
-        prediction: pd.DataFrame | list[pd.DataFrame],
-    ) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
+        prediction: Union[pd.DataFrame, list[pd.DataFrame]],
+    ) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         if isinstance(prediction, list):
             return [proba.values for proba in prediction]
         else:
@@ -345,27 +338,27 @@ class _StackableSupervisedLearnerDF(
 class _StackableClassifierDF(_StackableSupervisedLearnerDF[ClassifierDF], ClassifierDF):
     """[see superclass]"""
 
-    def _get_classes(self) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
+    def _get_classes(self) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         return self.delegate._get_classes()
 
     def predict_proba(
-        self, X: pd.Series | pd.DataFrame, **predict_params: Any
-    ) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+    ) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         """[see superclass]"""
         return self._convert_prediction_to_numpy(
             self.delegate.predict_proba(X, **predict_params)
         )
 
     def predict_log_proba(
-        self, X: pd.Series | pd.DataFrame, **predict_params: Any
-    ) -> npt.NDArray[Any] | list[npt.NDArray[Any]]:
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
+    ) -> Union[npt.NDArray[Any], list[npt.NDArray[Any]]]:
         """[see superclass]"""
         return self._convert_prediction_to_numpy(
             self.delegate.predict_log_proba(X, **predict_params)
         )
 
     def decision_function(
-        self, X: pd.Series | pd.DataFrame, **predict_params: Any
+        self, X: Union[pd.Series, pd.DataFrame], **predict_params: Any
     ) -> npt.NDArray[np.floating[Any]]:
         """[see superclass]"""
         return cast(

--- a/src/sklearndf/wrapper/stacking/_stacking.py
+++ b/src/sklearndf/wrapper/stacking/_stacking.py
@@ -1,6 +1,7 @@
 """
 DF wrapper classes for stacking estimators.
 """
+
 from __future__ import annotations
 
 import logging
@@ -123,9 +124,11 @@ class StackingEstimatorWrapperDF(
             native.estimators = [
                 (
                     name,
-                    self._make_stackable_learner_df(estimator)
-                    if isinstance(estimator, SupervisedLearnerDF)
-                    else estimator,
+                    (
+                        self._make_stackable_learner_df(estimator)
+                        if isinstance(estimator, SupervisedLearnerDF)
+                        else estimator
+                    ),
                 )
                 for name, estimator in native.estimators
             ]
@@ -332,7 +335,7 @@ class _StackableSupervisedLearnerDF(
 
     @staticmethod
     def _convert_prediction_to_numpy(
-        prediction: Union[pd.DataFrame, List[pd.DataFrame]]
+        prediction: Union[pd.DataFrame, List[pd.DataFrame]],
     ) -> Union[npt.NDArray[Any], List[npt.NDArray[Any]]]:
         if isinstance(prediction, list):
             return [proba.values for proba in prediction]

--- a/test/test/conftest.py
+++ b/test/test/conftest.py
@@ -9,7 +9,6 @@ import sklearn
 from sklearn import datasets
 from sklearn.utils import Bunch
 
-from sklearndf import __sklearn_1_1__, __sklearn_version__
 from sklearndf.transformation import OneHotEncoderDF
 
 logging.basicConfig(level=logging.DEBUG)
@@ -41,11 +40,7 @@ def n_jobs() -> int:
 def diabetes_df(diabetes_target: str) -> pd.DataFrame:
     #  load sklearn test-data and convert to pd
     diabetes: Bunch
-    if __sklearn_version__ >= __sklearn_1_1__:
-        diabetes = datasets.load_diabetes(scaled=False)
-    else:
-        # arg scaled does not exist in scikit-learn < 1.1
-        diabetes = datasets.load_diabetes()
+    diabetes = datasets.load_diabetes(scaled=False)
 
     return pd.DataFrame(
         data=np.c_[diabetes.data, diabetes.target],

--- a/test/test/conftest.py
+++ b/test/test/conftest.py
@@ -101,8 +101,10 @@ def iris_targets_df(iris_df: pd.DataFrame, iris_target_name: str) -> pd.DataFram
 
 @pytest.fixture  # type: ignore
 def iris_targets_binary_df(iris_target_sr: pd.Series) -> pd.DataFrame:
-    return OneHotEncoderDF(sparse_output=False).fit_transform(
-        X=iris_target_sr.to_frame()
+    return (
+        OneHotEncoderDF(sparse_output=False)
+        .fit_transform(X=iris_target_sr.to_frame())
+        .astype(int)
     )
 
 

--- a/test/test/conftest.py
+++ b/test/test/conftest.py
@@ -106,7 +106,9 @@ def iris_targets_df(iris_df: pd.DataFrame, iris_target_name: str) -> pd.DataFram
 
 @pytest.fixture  # type: ignore
 def iris_targets_binary_df(iris_target_sr: pd.Series) -> pd.DataFrame:
-    return OneHotEncoderDF(sparse=False).fit_transform(X=iris_target_sr.to_frame())
+    return OneHotEncoderDF(sparse_output=False).fit_transform(
+        X=iris_target_sr.to_frame()
+    )
 
 
 @pytest.fixture  # type:ignore

--- a/test/test/sklearndf/__init__.py
+++ b/test/test/sklearndf/__init__.py
@@ -1,7 +1,8 @@
 import re
 import sys
+from collections.abc import Iterable
 from types import ModuleType
-from typing import Dict, Iterable, List, Optional, Set, Type, Union
+from typing import Optional, Union
 
 import pandas as pd
 import sklearn
@@ -22,12 +23,12 @@ OVERRIDDEN_SKLEARN_CLASSES = {
 
 def find_all_classes(
     *modules: ModuleType,
-) -> Set[Type[EstimatorWrapperDF[BaseEstimator]]]:
+) -> set[type[EstimatorWrapperDF[BaseEstimator]]]:
     """Finds all Class members in given module/modules."""
-    types: Set[Type[EstimatorWrapperDF[BaseEstimator]]] = set()
+    types: set[type[EstimatorWrapperDF[BaseEstimator]]] = set()
 
     def _add_classes_from_module(_m: ModuleType) -> None:
-        member: Type[EstimatorWrapperDF[BaseEstimator]]
+        member: type[EstimatorWrapperDF[BaseEstimator]]
         for member in vars(_m).values():
             if isinstance(member, type):
                 types.add(member)
@@ -38,7 +39,7 @@ def find_all_classes(
     return types
 
 
-def find_all_submodules(parent_module: ModuleType) -> Set[ModuleType]:
+def find_all_submodules(parent_module: ModuleType) -> set[ModuleType]:
     """Finds all submodules for a parent module."""
     parent_name = f"{parent_module.__name__}."
     return {
@@ -50,7 +51,7 @@ def find_all_submodules(parent_module: ModuleType) -> Set[ModuleType]:
 
 def sklearn_delegate_classes(
     module: ModuleType,
-) -> Dict[Type[BaseEstimator], Type[EstimatorWrapperDF[BaseEstimator]]]:
+) -> dict[type[BaseEstimator], type[EstimatorWrapperDF[BaseEstimator]]]:
     """
     Create a dictionary mapping sklearn classes to their corresponding sklearndf
     classes.
@@ -69,7 +70,7 @@ def iterate_classes(
     from_modules: Union[ModuleType, Iterable[ModuleType]],
     matching: str,
     excluding: Optional[Union[str, Iterable[str]]] = None,
-) -> List[Type[EstimatorWrapperDF[BaseEstimator]]]:
+) -> list[type[EstimatorWrapperDF[BaseEstimator]]]:
     """Helper to return all classes with matching name from Python module(s)"""
 
     if not isinstance(from_modules, Iterable):
@@ -87,8 +88,8 @@ def iterate_classes(
 
 
 def get_sklearndf_wrapper_class(
-    to_wrap: Type[BaseEstimator], from_module: ModuleType
-) -> Type[EstimatorWrapperDF[BaseEstimator]]:
+    to_wrap: type[BaseEstimator], from_module: ModuleType
+) -> type[EstimatorWrapperDF[BaseEstimator]]:
     """Helper to return the wrapped counterpart for a sklearn class"""
     try:
         return sklearn_delegate_classes(from_module)[to_wrap]

--- a/test/test/sklearndf/pipeline/__init__.py
+++ b/test/test/sklearndf/pipeline/__init__.py
@@ -1,4 +1,5 @@
-from typing import Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 
 from sklearndf import TransformerDF
 from sklearndf.transformation import (

--- a/test/test/sklearndf/pipeline/test_classification_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_classification_pipeline_df.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -21,7 +19,7 @@ from test.sklearndf.pipeline import make_simple_transformer
 def test_classification_pipeline_df(
     iris_features: pd.DataFrame,
     iris_target_sr: pd.DataFrame,
-    classifier_df_cls: Type[ClassifierDF],
+    classifier_df_cls: type[ClassifierDF],
 ) -> None:
     cls_p_df = ClassifierPipelineDF(
         classifier=classifier_df_cls(),

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -326,7 +326,7 @@ def test_pipeline_df_raise_set_params_error() -> None:
 @pytest.mark.parametrize(argnames="sparse", argvalues=[True, False])  # type: ignore
 def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> None:
     # the expected column dtype, depending on arg sparse
-    dtype_expected = pd.SparseDtype(np.float_, fill_value=0) if sparse else np.float_
+    dtype_expected = pd.SparseDtype(np.float64, fill_value=0) if sparse else np.float64
 
     # apply the test data to a simple feature union
     feature_union = FeatureUnionDF(

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -323,10 +323,16 @@ def test_pipeline_df_raise_set_params_error() -> None:
         pipe.set_params(fake__estimator="nope")
 
 
-@pytest.mark.parametrize(argnames="sparse", argvalues=[True, False])  # type: ignore
-def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> None:
+@pytest.mark.parametrize(  # type: ignore
+    argnames="sparse_output", argvalues=[True, False]
+)
+def test_feature_union(
+    test_data_categorical: pd.DataFrame, sparse_output: bool
+) -> None:
     # the expected column dtype, depending on arg sparse
-    dtype_expected = pd.SparseDtype(np.float_, fill_value=0) if sparse else np.float_
+    dtype_expected = (
+        pd.SparseDtype(np.float_, fill_value=0) if sparse_output else np.float_
+    )
 
     # apply the test data to a simple feature union
     feature_union = FeatureUnionDF(
@@ -342,7 +348,7 @@ def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> Non
     ), f"all columns should be of type {dtype_expected}: {transformed.dtypes}"
 
     # if the output is sparse, make it dense
-    if sparse:
+    if sparse_output:
         transformed = transformed.sparse.to_dense()
 
     # assert that the one-hot encoding is as expected

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -20,7 +20,6 @@ from sklearn import clone
 from sklearn.base import BaseEstimator, TransformerMixin, is_classifier, is_regressor
 from sklearn.feature_selection import f_classif
 
-from sklearndf import __sklearn_1_1__, __sklearn_version__
 from sklearndf.classification import SVCDF, LogisticRegressionDF
 from sklearndf.pipeline import FeatureUnionDF, PipelineDF
 from sklearndf.regression import DummyRegressorDF, LassoDF, LinearRegressionDF
@@ -220,25 +219,14 @@ def test_pipeline_df__init() -> None:
 
     # Check that we can't instantiate pipelines with objects without fit
     # method
-    if __sklearn_version__ < __sklearn_1_1__:
-        with pytest.raises(
-            TypeError,
-            match=(
-                "Last step of Pipeline should implement fit "
-                "or be the string 'passthrough'"
-                ".*NoFit.*"
-            ),
-        ):
-            PipelineDF([("clf", NoFit())])
-    else:
-        with pytest.raises(
-            ValueError,
-            match=(
-                "expected final step 'clf' to be an EstimatorDF or passthrough, "
-                "but found an instance of NoFit"
-            ),
-        ):
-            PipelineDF([("clf", NoFit())])
+    with pytest.raises(
+        ValueError,
+        match=(
+            "expected final step 'clf' to be an EstimatorDF or passthrough, "
+            "but found an instance of NoFit"
+        ),
+    ):
+        PipelineDF([("clf", NoFit())])
 
     # Smoke test with only an estimator
     clf = NoTransformerDF()

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -323,15 +323,21 @@ def test_pipeline_df_raise_set_params_error() -> None:
         pipe.set_params(fake__estimator="nope")
 
 
-@pytest.mark.parametrize(argnames="sparse", argvalues=[True, False])  # type: ignore
-def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> None:
+@pytest.mark.parametrize(  # type: ignore
+    argnames="sparse_output", argvalues=[True, False]
+)
+def test_feature_union(
+    test_data_categorical: pd.DataFrame, sparse_output: bool
+) -> None:
     # the expected column dtype, depending on arg sparse
-    dtype_expected = pd.SparseDtype(np.float_, fill_value=0) if sparse else np.float_
+    dtype_expected = (
+        pd.SparseDtype(np.float_, fill_value=0) if sparse_output else np.float_
+    )
 
     # apply the test data to a simple feature union
     feature_union = FeatureUnionDF(
         [
-            ("one_hot", OneHotEncoderDF(drop="first", sparse=sparse)),
+            ("one_hot", OneHotEncoderDF(drop="first", sparse_output=sparse_output)),
         ]
     )
     transformed = feature_union.fit_transform(test_data_categorical)
@@ -342,7 +348,7 @@ def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> Non
     ), f"all columns should be of type {dtype_expected}: {transformed.dtypes}"
 
     # if the output is sparse, make it dense
-    if sparse:
+    if sparse_output:
         transformed = transformed.sparse.to_dense()
 
     # assert that the one-hot encoding is as expected
@@ -359,43 +365,42 @@ def test_feature_union(test_data_categorical: pd.DataFrame, sparse: bool) -> Non
         ).rename_axis(columns="feature"),
     )
 
-    if __sklearn_version__ >= __sklearn_1_1__:
-        # test the passthrough option introduced in sklearn 1.1
+    # test the passthrough option introduced in sklearn 1.1
 
-        # apply the test data to a simple feature union
-        feature_union = FeatureUnionDF(
+    # apply the test data to a simple feature union
+    feature_union = FeatureUnionDF(
+        [
+            ("one_hot", OneHotEncoderDF(drop="first", sparse_output=sparse_output)),
+            ("pass", "passthrough"),
+            ("pass_again", "passthrough"),
+        ],
+    )
+    transformed = feature_union.fit_transform(test_data_categorical)
+
+    # assert that all one-hot-encoded columns of the data frame are sparse
+    assert all(
+        dtype == (dtype_expected if column.startswith("one_hot__") else np.object_)
+        for column, dtype in zip(transformed.columns, transformed.dtypes)
+    )
+
+    # assert that the one-hot encoding is as expected
+    assert_frame_equal(
+        transformed,
+        pd.concat(
             [
-                ("one_hot", OneHotEncoderDF(drop="first", sparse=sparse)),
-                ("pass", "passthrough"),
-                ("pass_again", "passthrough"),
-            ],
-        )
-        transformed = feature_union.fit_transform(test_data_categorical)
-
-        # assert that all one-hot-encoded columns of the data frame are sparse
-        assert all(
-            dtype == (dtype_expected if column.startswith("one_hot__") else np.object_)
-            for column, dtype in zip(transformed.columns, transformed.dtypes)
-        )
-
-        # assert that the one-hot encoding is as expected
-        assert_frame_equal(
-            transformed,
-            pd.concat(
-                [
-                    pd.DataFrame(
-                        dict(
-                            one_hot__a_yes=[1.0, 1.0, 0.0],
-                            one_hot__b_green=[0.0, 0.0, 1.0],
-                            one_hot__b_red=[1.0, 0.0, 0.0],
-                            one_hot__c_father=[0.0, 1.0, 0.0],
-                            one_hot__c_mother=[0.0, 0.0, 1.0],
-                        ),
-                        dtype=dtype_expected,
+                pd.DataFrame(
+                    dict(
+                        one_hot__a_yes=[1.0, 1.0, 0.0],
+                        one_hot__b_green=[0.0, 0.0, 1.0],
+                        one_hot__b_red=[1.0, 0.0, 0.0],
+                        one_hot__c_father=[0.0, 1.0, 0.0],
+                        one_hot__c_mother=[0.0, 0.0, 1.0],
                     ),
-                    test_data_categorical.add_prefix("pass__"),
-                    test_data_categorical.add_prefix("pass_again__"),
-                ],
-                axis=1,
-            ).rename_axis(columns="feature"),
-        )
+                    dtype=dtype_expected,
+                ),
+                test_data_categorical.add_prefix("pass__"),
+                test_data_categorical.add_prefix("pass_again__"),
+            ],
+            axis=1,
+        ).rename_axis(columns="feature"),
+    )

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import shutil
 import time
+from collections.abc import Mapping
 from tempfile import mkdtemp
-from typing import Any, Dict, Mapping, cast
+from typing import Any, cast
 
 import joblib
 import numpy as np
@@ -62,10 +63,10 @@ class NoTransformer(
     def fit(self, X: Any, y: Any = None, **fit_params: Any) -> NoTransformer:
         return self
 
-    def get_params(self, deep: bool = False) -> Dict[str, Any]:
+    def get_params(self, deep: bool = False) -> dict[str, Any]:
         return {"a": self.a, "b": self.b}
 
-    def set_params(self, a: Any = None, **params: Dict[str, Any]) -> NoTransformer:
+    def set_params(self, a: Any = None, **params: dict[str, Any]) -> NoTransformer:
         self.a = a
         return self
 

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -2,6 +2,7 @@
 Test module for PipelineDF inspired by:
 https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/tests/test_pipeline.py
 """
+
 from __future__ import annotations
 
 import shutil

--- a/test/test/sklearndf/pipeline/test_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_pipeline_df.py
@@ -217,8 +217,7 @@ def test_pipeline_df__init() -> None:
     with pytest.raises(TypeError):
         PipelineDF()
 
-    # Check that we can't instantiate pipelines with objects without fit
-    # method
+    # Check that we can't instantiate pipelines with objects without a `fit` method
     with pytest.raises(
         ValueError,
         match=(
@@ -319,7 +318,7 @@ def test_feature_union(
 ) -> None:
     # the expected column dtype, depending on arg sparse
     dtype_expected = (
-        pd.SparseDtype(np.float_, fill_value=0) if sparse_output else np.float_
+        pd.SparseDtype(np.float64, fill_value=0) if sparse_output else np.float64
     )
 
     # apply the test data to a simple feature union

--- a/test/test/sklearndf/pipeline/test_regression_pipeline_df.py
+++ b/test/test/sklearndf/pipeline/test_regression_pipeline_df.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -20,7 +18,7 @@ from test.sklearndf.pipeline import make_simple_transformer
 def test_regression_pipeline_df(
     diabetes_features: pd.DataFrame,
     diabetes_target_sr: pd.Series,
-    regressor_df_cls: Type[RegressorDF],
+    regressor_df_cls: type[RegressorDF],
 ) -> None:
     rpdf = RegressorPipelineDF(
         regressor=regressor_df_cls(),

--- a/test/test/sklearndf/test_base.py
+++ b/test/test/sklearndf/test_base.py
@@ -18,6 +18,7 @@ from sklearn.utils import estimator_html_repr
 from pytools.expression import freeze, make_expression
 from pytools.expression.atomic import Id
 
+from sklearndf import __sklearn_1_6__, __sklearn_version__
 from sklearndf.classification import SVCDF, DecisionTreeClassifierDF
 from sklearndf.clustering.wrapper import KMeansBaseWrapperDF
 from sklearndf.pipeline import PipelineDF
@@ -313,3 +314,25 @@ def test_native_class_validation() -> None:
 
         class MismatchedNativeClass5(PipelineDF, native=RandomForestRegressor):
             pass
+
+
+@pytest.mark.skipif(  # type: ignore[misc]
+    __sklearn_version__ < __sklearn_1_6__,
+    reason="This test requires scikit-learn 1.6 or later",
+)
+def test_sklearn_tags() -> None:
+    # Check that sklearn tags are correctly set for the DummyEstimatorDF
+    estimator = DummyEstimatorDF()
+    tags = estimator.__sklearn_tags__()
+
+    from sklearn.utils import InputTags
+
+    assert tags.estimator_type is None
+    assert isinstance(tags.input_tags, InputTags)
+    assert tags.transformer_tags is None
+    assert tags.classifier_tags is None
+    assert tags.regressor_tags is None
+    assert not tags.array_api_support
+    assert not tags.no_validation
+    assert not tags.non_deterministic
+    assert tags.requires_fit

--- a/test/test/sklearndf/test_base.py
+++ b/test/test/sklearndf/test_base.py
@@ -73,12 +73,12 @@ def test_clone() -> None:
     # (which, in this case, is the current state of the estimator),
     # and check that the obtained copy is a correct deep copy.
 
-    encoder = OneHotEncoderDF(drop="first", sparse=False)
+    encoder = OneHotEncoderDF(drop="first", sparse_output=False)
     new_encoder = encoder.clone()
     assert encoder is not new_encoder
     assert encoder.get_params() == new_encoder.get_params()
 
-    encoder = OneHotEncoderDF(handle_unknown="ignore", sparse=False)
+    encoder = OneHotEncoderDF(handle_unknown="ignore", sparse_output=False)
     new_encoder = sklearn.clone(encoder)
 
     assert encoder is not new_encoder
@@ -90,7 +90,7 @@ def test_clone_2() -> None:
     # make a copy of its original state. Then we check that the copy doesn't
     # have the specific attribute we manually added to the initial estimator.
 
-    encoder = OneHotEncoderDF(drop="first", sparse=False)
+    encoder = OneHotEncoderDF(drop="first", sparse_output=False)
 
     encoder.own_attribute = "test"
     new_encoder = encoder.clone()

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -8,7 +8,13 @@ from sklearn.base import is_classifier
 from sklearn.multioutput import ClassifierChain, MultiOutputClassifier
 
 import sklearndf.classification as classification
-from sklearndf import ClassifierDF
+from sklearndf import (
+    ClassifierDF,
+    __sklearn_1_5__,
+    __sklearn_1_6__,
+    __sklearn_version__,
+)
+from sklearndf.classification.wrapper import ThresholdClassifierWrapperDF
 from test.sklearndf import check_expected_not_fitted_error, iterate_classes
 
 CLASSIFIERS_TO_TEST = iterate_classes(
@@ -22,15 +28,18 @@ def test_classifier_count() -> None:
     n = len(CLASSIFIERS_TO_TEST)
 
     print(f"Testing {n} classifiers.")
-    assert n == 41
 
-
-BASE_ESTIMATOR = "estimator"
+    if __sklearn_version__ < __sklearn_1_5__:
+        assert n == 41
+    elif __sklearn_version__ < __sklearn_1_6__:
+        assert n == 43
+    else:
+        raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
 
 CLASSIFIER_INIT_PARAMETERS: Dict[str, Dict[str, Any]] = {
     "CalibratedClassifierCVDF": {
-        BASE_ESTIMATOR: classification.RandomForestClassifierDF()
+        "estimator": classification.RandomForestClassifierDF()
     },
     "ClassifierChainDF": {"base_estimator": classification.RandomForestClassifierDF()},
     "MultiOutputClassifierDF": {"estimator": classification.RandomForestClassifierDF()},
@@ -51,6 +60,13 @@ CLASSIFIER_INIT_PARAMETERS: Dict[str, Dict[str, Any]] = {
             ("Logit", classification.LogisticRegressionCVDF()),
             ("AdaBoost", classification.AdaBoostClassifierDF()),
         )
+    },
+    "TunedThresholdClassifierCVDF": {
+        "estimator": classification.RandomForestClassifierDF()
+    },
+    "FixedThresholdClassifierDF": {
+        "estimator": classification.RandomForestClassifierDF(),
+        "threshold": 0.5,
     },
 }
 
@@ -89,6 +105,7 @@ def test_wrapped_fit_predict(
     assert is_classifier(classifier)
 
     is_chain = isinstance(classifier.native_estimator, ClassifierChain)
+    is_threshold = isinstance(classifier, ThresholdClassifierWrapperDF)
 
     is_multi_output = isinstance(classifier.native_estimator, MultiOutputClassifier)
     check_expected_not_fitted_error(estimator=classifier)
@@ -98,6 +115,10 @@ def test_wrapped_fit_predict(
         # classification can act as input to the next classification
         classes = set(range(iris_targets_binary_df.shape[1]))
         classifier.fit(X=iris_features, y=iris_targets_binary_df)
+    elif is_threshold:
+        # for threshold classifiers, the classes are binary
+        classes = {0, 1}
+        classifier.fit(X=iris_features, y=iris_targets_binary_df.iloc[:, 0])
     elif is_multi_output:
         classes = set(
             chain(
@@ -116,7 +137,8 @@ def test_wrapped_fit_predict(
 
     # test predictions data-type, length and values
     assert isinstance(
-        predictions, pd.DataFrame if is_multi_output or is_chain else pd.Series
+        predictions,
+        pd.DataFrame if is_multi_output or is_chain else pd.Series,
     )
     assert len(predictions) == len(iris_target_sr)
     assert np.all(predictions.isin(classes))
@@ -134,11 +156,19 @@ def test_wrapped_fit_predict(
                 assert classifier.n_outputs_ == len(predictions)
             else:
                 if is_chain:
+                    # for classifier chains and threshold classifiers, we have a binary
+                    # output
                     assert (
                         classifier.output_names_
                         == iris_targets_binary_df.columns.tolist()
                     )
                     assert classifier.n_outputs_ == predictions.shape[1]
+                elif is_threshold:
+                    # for threshold classifiers, we have a single binary output
+                    assert classifier.output_names_ == [
+                        iris_targets_binary_df.columns[0]
+                    ]
+                    assert classifier.n_outputs_ == 1
                 else:
                     assert classifier.output_names_ == [iris_target_sr.name]
                     assert classifier.n_outputs_ == 1

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -12,6 +12,7 @@ from sklearndf import (
     ClassifierDF,
     __sklearn_1_5__,
     __sklearn_1_6__,
+    __sklearn_1_7__,
     __sklearn_version__,
 )
 from sklearndf.classification.wrapper import ThresholdClassifierWrapperDF
@@ -33,6 +34,8 @@ def test_classifier_count() -> None:
         assert n == 41
     elif __sklearn_version__ < __sklearn_1_6__:
         assert n == 43
+    elif __sklearn_version__ < __sklearn_1_7__:
+        assert n == 44
     else:
         raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
@@ -67,6 +70,9 @@ CLASSIFIER_INIT_PARAMETERS: Dict[str, Dict[str, Any]] = {
     "FixedThresholdClassifierDF": {
         "estimator": classification.RandomForestClassifierDF(),
         "threshold": 0.5,
+    },
+    "SelfTrainingClassifierDF": {
+        "estimator": classification.RandomForestClassifierDF()
     },
 }
 

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -12,7 +12,7 @@ from sklearndf import (
     ClassifierDF,
     __sklearn_1_5__,
     __sklearn_1_6__,
-    __sklearn_1_7__,
+    __sklearn_1_8__,
     __sklearn_version__,
 )
 from sklearndf.classification.wrapper import ThresholdClassifierWrapperDF
@@ -34,7 +34,7 @@ def test_classifier_count() -> None:
         assert n == 41
     elif __sklearn_version__ < __sklearn_1_6__:
         assert n == 43
-    elif __sklearn_version__ < __sklearn_1_7__:
+    elif __sklearn_version__ < __sklearn_1_8__:
         assert n == 44
     else:
         raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -37,7 +37,7 @@ def test_classifier_count() -> None:
     elif __sklearn_version__ < __sklearn_1_8__:
         assert n == 44
     else:
-        raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")
+        pytest.fail(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
 
 CLASSIFIER_INIT_PARAMETERS: Dict[str, Dict[str, Any]] = {

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import Any, Dict, Type
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -40,7 +40,7 @@ def test_classifier_count() -> None:
         pytest.fail(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
 
-CLASSIFIER_INIT_PARAMETERS: Dict[str, Dict[str, Any]] = {
+CLASSIFIER_INIT_PARAMETERS: dict[str, dict[str, Any]] = {
     "CalibratedClassifierCVDF": {
         "estimator": classification.RandomForestClassifierDF()
     },
@@ -94,7 +94,7 @@ CLASSIFIERS_PARTIAL_FIT = [
     argnames="sklearndf_cls", argvalues=CLASSIFIERS_TO_TEST
 )
 def test_wrapped_fit_predict(
-    sklearndf_cls: Type[ClassifierDF],
+    sklearndf_cls: type[ClassifierDF],
     iris_features: pd.DataFrame,
     iris_target_sr: pd.Series,
     iris_targets_df: pd.DataFrame,
@@ -102,7 +102,7 @@ def test_wrapped_fit_predict(
 ) -> None:
     """Test fit & predict & predict[_log]_proba of wrapped sklearn classifiers"""
     # noinspection PyArgumentList
-    parameters: Dict[str, Any] = CLASSIFIER_INIT_PARAMETERS.get(
+    parameters: dict[str, Any] = CLASSIFIER_INIT_PARAMETERS.get(
         sklearndf_cls.__name__, {}
     )
     # noinspection PyArgumentList
@@ -197,7 +197,7 @@ def test_wrapped_fit_predict(
     argnames="sklearndf_cls", argvalues=CLASSIFIERS_PARTIAL_FIT
 )
 def test_wrapped_partial_fit(
-    sklearndf_cls: Type[ClassifierDF],
+    sklearndf_cls: type[ClassifierDF],
     iris_features: pd.DataFrame,
     iris_target_sr: pd.Series,
     iris_targets_df: pd.DataFrame,

--- a/test/test/sklearndf/test_classification.py
+++ b/test/test/sklearndf/test_classification.py
@@ -8,7 +8,7 @@ from sklearn.base import is_classifier
 from sklearn.multioutput import ClassifierChain, MultiOutputClassifier
 
 import sklearndf.classification as classification
-from sklearndf import ClassifierDF, __sklearn_1_2__, __sklearn_version__
+from sklearndf import ClassifierDF
 from test.sklearndf import check_expected_not_fitted_error, iterate_classes
 
 CLASSIFIERS_TO_TEST = iterate_classes(
@@ -25,10 +25,7 @@ def test_classifier_count() -> None:
     assert n == 41
 
 
-if __sklearn_version__ < __sklearn_1_2__:
-    BASE_ESTIMATOR = "base_estimator"
-else:
-    BASE_ESTIMATOR = "estimator"
+BASE_ESTIMATOR = "estimator"
 
 
 CLASSIFIER_INIT_PARAMETERS: Dict[str, Dict[str, Any]] = {

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -4,13 +4,7 @@ import pandas as pd
 import pytest
 
 import sklearndf.clustering
-from sklearndf import (
-    ClusterDF,
-    __sklearn_1_4__,
-    __sklearn_1_5__,
-    __sklearn_1_6__,
-    __sklearn_version__,
-)
+from sklearndf import ClusterDF, __sklearn_1_7__, __sklearn_version__
 from sklearndf.clustering import FeatureAgglomerationDF
 from test.sklearndf import iterate_classes
 
@@ -29,11 +23,7 @@ def test_clusterer_count() -> None:
 
     print(f"Testing {n} clusterers.")
 
-    if __sklearn_version__ < __sklearn_1_4__:
-        assert n == 11
-    elif __sklearn_version__ < __sklearn_1_5__:
-        assert n == 11
-    elif __sklearn_version__ < __sklearn_1_6__:
+    if __sklearn_version__ < __sklearn_1_7__:
         assert n == 11
     else:
         raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -41,7 +41,7 @@ def test_clusterer_fit_predict_call(
 
     assert not clusterer_instance.is_fitted
     result_prediction = clusterer_instance.fit_predict(iris_features)
-    assert type(result_prediction) == pd.Series
+    assert type(result_prediction) is pd.Series
     assert clusterer_instance.is_fitted
 
 

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 import sklearndf.clustering
-from sklearndf import ClusterDF, __sklearn_1_7__, __sklearn_version__
+from sklearndf import ClusterDF, __sklearn_1_8__, __sklearn_version__
 from sklearndf.clustering import FeatureAgglomerationDF
 from test.sklearndf import iterate_classes
 
@@ -23,7 +23,7 @@ def test_clusterer_count() -> None:
 
     print(f"Testing {n} clusterers.")
 
-    if __sklearn_version__ < __sklearn_1_7__:
+    if __sklearn_version__ < __sklearn_1_8__:
         assert n == 11
     else:
         raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -4,7 +4,13 @@ import pandas as pd
 import pytest
 
 import sklearndf.clustering
-from sklearndf import ClusterDF, __sklearn_1_4__, __sklearn_1_5__, __sklearn_version__
+from sklearndf import (
+    ClusterDF,
+    __sklearn_1_4__,
+    __sklearn_1_5__,
+    __sklearn_1_6__,
+    __sklearn_version__,
+)
 from sklearndf.clustering import FeatureAgglomerationDF
 from test.sklearndf import iterate_classes
 
@@ -26,6 +32,8 @@ def test_clusterer_count() -> None:
     if __sklearn_version__ < __sklearn_1_4__:
         assert n == 11
     elif __sklearn_version__ < __sklearn_1_5__:
+        assert n == 11
+    elif __sklearn_version__ < __sklearn_1_6__:
         assert n == 11
     else:
         raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -26,7 +26,7 @@ def test_clusterer_count() -> None:
     if __sklearn_version__ < __sklearn_1_8__:
         assert n == 11
     else:
-        raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")
+        pytest.fail(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
 
 @pytest.mark.parametrize(  # type: ignore

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 import sklearndf.clustering
-from sklearndf import ClusterDF, __sklearn_1_1__, __sklearn_1_3__, __sklearn_version__
+from sklearndf import ClusterDF, __sklearn_1_4__, __sklearn_1_5__, __sklearn_version__
 from sklearndf.clustering import FeatureAgglomerationDF
 from test.sklearndf import iterate_classes
 
@@ -23,12 +23,12 @@ def test_clusterer_count() -> None:
 
     print(f"Testing {n} clusterers.")
 
-    if __sklearn_version__ < __sklearn_1_1__:
-        assert n == 9
-    elif __sklearn_version__ < __sklearn_1_3__:
-        assert n == 10
-    else:
+    if __sklearn_version__ < __sklearn_1_4__:
         assert n == 11
+    elif __sklearn_version__ < __sklearn_1_5__:
+        assert n == 11
+    else:
+        raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
 
 @pytest.mark.parametrize(  # type: ignore

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import pandas as pd
 import pytest
 
@@ -33,7 +31,7 @@ def test_clusterer_count() -> None:
     argnames="sklearn_clusterer_cls", argvalues=CLUSTERERS_TO_TEST
 )
 def test_clusterer_fit_predict_call(
-    iris_features: pd.DataFrame, sklearn_clusterer_cls: Type[ClusterDF]
+    iris_features: pd.DataFrame, sklearn_clusterer_cls: type[ClusterDF]
 ) -> None:
     """Check if each sklearndf clusterer supports fit_predict method"""
 
@@ -49,7 +47,7 @@ def test_clusterer_fit_predict_call(
     argnames="sklearn_clusterer_cls", argvalues=CLUSTERERS_WITH_AGGLOMERATION
 )
 def test_clusterer_fit_call(
-    iris_features: pd.DataFrame, sklearn_clusterer_cls: Type[ClusterDF]
+    iris_features: pd.DataFrame, sklearn_clusterer_cls: type[ClusterDF]
 ) -> None:
     """Check if each sklearndf clusterer supports fit method"""
 

--- a/test/test/sklearndf/test_clustering.py
+++ b/test/test/sklearndf/test_clustering.py
@@ -39,7 +39,7 @@ def test_clusterer_fit_predict_call(
 
     assert not clusterer_instance.is_fitted
     result_prediction = clusterer_instance.fit_predict(iris_features)
-    assert type(result_prediction) is pd.Series
+    assert isinstance(result_prediction, pd.Series)
     assert clusterer_instance.is_fitted
 
 

--- a/test/test/sklearndf/test_regression.py
+++ b/test/test/sklearndf/test_regression.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -22,7 +22,7 @@ from test.sklearndf import check_expected_not_fitted_error, iterate_classes
 
 # noinspection PyTypeChecker
 # ignore false alert about module type
-REGRESSORS_TO_TEST: List[Type[EstimatorWrapperDF[BaseEstimator]]] = iterate_classes(
+REGRESSORS_TO_TEST: list[type[EstimatorWrapperDF[BaseEstimator]]] = iterate_classes(
     from_modules=sklearndf.regression,
     matching=r".*DF",
     excluding=[RegressorDF.__name__, TransformerDF.__name__, r".*WrapperDF"],
@@ -39,7 +39,7 @@ def test_regressor_count() -> None:
         pytest.fail(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
 
-DEFAULT_REGRESSOR_PARAMETERS: Dict[str, Dict[str, Any]] = {
+DEFAULT_REGRESSOR_PARAMETERS: dict[str, dict[str, Any]] = {
     "MultiOutputRegressorDF": dict(estimator=RandomForestRegressorDF()),
     "MultiOutputRegressorDF_partial_fit": dict(estimator=SGDRegressorDF()),
     "RegressorChainDF": dict(base_estimator=RandomForestRegressorDF()),
@@ -73,13 +73,13 @@ REGRESSORS_PARTIAL_FIT = [
     argnames="sklearndf_cls", argvalues=REGRESSORS_TO_TEST
 )
 def test_wrapped_fit_predict(
-    sklearndf_cls: Type[RegressorDF],
+    sklearndf_cls: type[RegressorDF],
     diabetes_features: pd.DataFrame,
     diabetes_target_sr: pd.Series,
     diabetes_target_df: pd.DataFrame,
 ) -> None:
     """Test fit & predict of wrapped sklearn regressors"""
-    parameters: Dict[str, Any] = DEFAULT_REGRESSOR_PARAMETERS.get(
+    parameters: dict[str, Any] = DEFAULT_REGRESSOR_PARAMETERS.get(
         sklearndf_cls.__name__, {}
     )
 
@@ -118,7 +118,7 @@ def test_wrapped_fit_predict(
     argnames="sklearndf_cls", argvalues=REGRESSORS_PARTIAL_FIT
 )
 def test_wrapped_partial_fit(
-    sklearndf_cls: Type[RegressorDF],
+    sklearndf_cls: type[RegressorDF],
     diabetes_features: pd.DataFrame,
     diabetes_target_sr: pd.Series,
     diabetes_target_df: pd.DataFrame,

--- a/test/test/sklearndf/test_regression.py
+++ b/test/test/sklearndf/test_regression.py
@@ -6,7 +6,7 @@ from sklearn.base import BaseEstimator, is_regressor
 from sklearn.multioutput import MultiOutputRegressor, RegressorChain
 
 import sklearndf.regression
-from sklearndf import RegressorDF, TransformerDF, __sklearn_1_6__, __sklearn_version__
+from sklearndf import RegressorDF, TransformerDF, __sklearn_1_7__, __sklearn_version__
 from sklearndf.regression import (
     SVRDF,
     IsotonicRegressionDF,
@@ -33,7 +33,7 @@ def test_regressor_count() -> None:
     n = len(REGRESSORS_TO_TEST)
 
     print(f"Testing {n} regressors.")
-    if __sklearn_version__ < __sklearn_1_6__:
+    if __sklearn_version__ < __sklearn_1_7__:
         assert n == 55
     else:
         raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")

--- a/test/test/sklearndf/test_regression.py
+++ b/test/test/sklearndf/test_regression.py
@@ -36,7 +36,7 @@ def test_regressor_count() -> None:
     if __sklearn_version__ < __sklearn_1_8__:
         assert n == 55
     else:
-        raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")
+        pytest.fail(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
 
 DEFAULT_REGRESSOR_PARAMETERS: Dict[str, Dict[str, Any]] = {

--- a/test/test/sklearndf/test_regression.py
+++ b/test/test/sklearndf/test_regression.py
@@ -6,7 +6,7 @@ from sklearn.base import BaseEstimator, is_regressor
 from sklearn.multioutput import MultiOutputRegressor, RegressorChain
 
 import sklearndf.regression
-from sklearndf import RegressorDF, TransformerDF
+from sklearndf import RegressorDF, TransformerDF, __sklearn_1_6__, __sklearn_version__
 from sklearndf.regression import (
     SVRDF,
     IsotonicRegressionDF,
@@ -33,7 +33,10 @@ def test_regressor_count() -> None:
     n = len(REGRESSORS_TO_TEST)
 
     print(f"Testing {n} regressors.")
-    assert n == 55
+    if __sklearn_version__ < __sklearn_1_6__:
+        assert n == 55
+    else:
+        raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")
 
 
 DEFAULT_REGRESSOR_PARAMETERS: Dict[str, Dict[str, Any]] = {

--- a/test/test/sklearndf/test_regression.py
+++ b/test/test/sklearndf/test_regression.py
@@ -6,7 +6,7 @@ from sklearn.base import BaseEstimator, is_regressor
 from sklearn.multioutput import MultiOutputRegressor, RegressorChain
 
 import sklearndf.regression
-from sklearndf import RegressorDF, TransformerDF, __sklearn_1_7__, __sklearn_version__
+from sklearndf import RegressorDF, TransformerDF, __sklearn_1_8__, __sklearn_version__
 from sklearndf.regression import (
     SVRDF,
     IsotonicRegressionDF,
@@ -33,7 +33,7 @@ def test_regressor_count() -> None:
     n = len(REGRESSORS_TO_TEST)
 
     print(f"Testing {n} regressors.")
-    if __sklearn_version__ < __sklearn_1_7__:
+    if __sklearn_version__ < __sklearn_1_8__:
         assert n == 55
     else:
         raise AssertionError(f"Unexpected scikit-learn version: {__sklearn_version__}")

--- a/test/test/sklearndf/test_sklearn_coverage.py
+++ b/test/test/sklearndf/test_sklearn_coverage.py
@@ -168,9 +168,9 @@ def _check_unexpected_sklearn_class(cls: type) -> None:
 )
 def test_classifier_coverage(sklearn_classifier_cls: Type[ClassifierMixin]) -> None:
     """Check if each sklearn classifier has a wrapped sklearndf counterpart."""
-    sklearn_classes: Dict[
-        Type[BaseEstimator], Type[EstimatorDF]
-    ] = sklearn_delegate_classes(sklearndf.classification)
+    sklearn_classes: Dict[Type[BaseEstimator], Type[EstimatorDF]] = (
+        sklearn_delegate_classes(sklearndf.classification)
+    )
 
     if sklearn_classifier_cls not in sklearn_classes:
         _check_unexpected_sklearn_class(sklearn_classifier_cls)
@@ -181,9 +181,9 @@ def test_classifier_coverage(sklearn_classifier_cls: Type[ClassifierMixin]) -> N
 )
 def test_regressor_coverage(sklearn_regressor_cls: Type[RegressorMixin]) -> None:
     """Check if each sklearn regressor has a wrapped sklearndf counterpart."""
-    sklearn_classes: Dict[
-        Type[BaseEstimator], Type[EstimatorDF]
-    ] = sklearn_delegate_classes(sklearndf.regression)
+    sklearn_classes: Dict[Type[BaseEstimator], Type[EstimatorDF]] = (
+        sklearn_delegate_classes(sklearndf.regression)
+    )
 
     if sklearn_regressor_cls not in sklearn_classes:
         _check_unexpected_sklearn_class(sklearn_regressor_cls)
@@ -195,9 +195,9 @@ def test_regressor_coverage(sklearn_regressor_cls: Type[RegressorMixin]) -> None
 def test_transformer_coverage(sklearn_transformer_cls: Type[TransformerMixin]) -> None:
     """Check if each sklearn transformer has a wrapped sklearndf counterpart."""
 
-    sklearn_classes: Dict[
-        Type[BaseEstimator], Type[EstimatorDF]
-    ] = sklearn_delegate_classes(sklearndf.transformation)
+    sklearn_classes: Dict[Type[BaseEstimator], Type[EstimatorDF]] = (
+        sklearn_delegate_classes(sklearndf.transformation)
+    )
 
     if sklearn_transformer_cls not in sklearn_classes:
         _check_unexpected_sklearn_class(sklearn_transformer_cls)
@@ -222,9 +222,9 @@ def test_pipeline_coverage(sklearn_pipeline_cls: Type[Pipeline]) -> None:
 )
 def test_clusterer_coverage(sklearn_clusterer_cls: Type[ClusterMixin]) -> None:
     """Check if each sklearn clusterer has a wrapped sklearndf counterpart."""
-    sklearn_classes: Dict[
-        Type[BaseEstimator], Type[EstimatorDF]
-    ] = sklearn_delegate_classes(sklearndf.clustering)
+    sklearn_classes: Dict[Type[BaseEstimator], Type[EstimatorDF]] = (
+        sklearn_delegate_classes(sklearndf.clustering)
+    )
 
     if sklearn_clusterer_cls not in sklearn_classes:
         _check_unexpected_sklearn_class(sklearn_clusterer_cls)

--- a/test/test/sklearndf/test_sklearn_coverage.py
+++ b/test/test/sklearndf/test_sklearn_coverage.py
@@ -1,6 +1,7 @@
 import itertools
+from collections.abc import Iterable
 from types import ModuleType
-from typing import Dict, Iterable, List, Optional, Type, TypeVar, Union
+from typing import Optional, TypeVar, Union
 
 import pytest
 import sklearn
@@ -85,9 +86,9 @@ UNSUPPORTED_SKLEARN_CLASSES = {
 
 def _find_sklearn_classes_to_cover(
     from_modules: Union[ModuleType, Iterable[ModuleType]],
-    subclass_of: Type[T],
+    subclass_of: type[T],
     excluding: Optional[Union[str, Iterable[str]]] = None,
-) -> List[Type[T]]:
+) -> list[type[T]]:
     return [
         cls
         for cls in iterate_classes(
@@ -97,7 +98,7 @@ def _find_sklearn_classes_to_cover(
     ]
 
 
-def sklearn_classifier_classes() -> List[type]:
+def sklearn_classifier_classes() -> list[type]:
     return _find_sklearn_classes_to_cover(
         from_modules=find_all_submodules(sklearn),
         subclass_of=ClassifierMixin,
@@ -105,7 +106,7 @@ def sklearn_classifier_classes() -> List[type]:
     )
 
 
-def sklearn_regressor_classes() -> List[type]:
+def sklearn_regressor_classes() -> list[type]:
     return _find_sklearn_classes_to_cover(
         from_modules=find_all_submodules(sklearn),
         subclass_of=RegressorMixin,
@@ -113,7 +114,7 @@ def sklearn_regressor_classes() -> List[type]:
     )
 
 
-def sklearn_pipeline_classes() -> List[type]:
+def sklearn_pipeline_classes() -> list[type]:
     pipeline_modules = find_all_submodules(sklearn.pipeline)
     pipeline_modules.add(sklearn.pipeline)
 
@@ -124,7 +125,7 @@ def sklearn_pipeline_classes() -> List[type]:
     )
 
 
-def sklearn_transformer_classes() -> List[type]:
+def sklearn_transformer_classes() -> list[type]:
     """Return all classes that are 'just' transformers, not learners or pipelines."""
     transformer_mixin_classes = [
         cls
@@ -147,7 +148,7 @@ def sklearn_transformer_classes() -> List[type]:
     return transformer_classes
 
 
-def sklearn_clusterer_classes() -> List[type]:
+def sklearn_clusterer_classes() -> list[type]:
     return _find_sklearn_classes_to_cover(
         from_modules=find_all_submodules(sklearn),
         subclass_of=ClusterMixin,
@@ -166,9 +167,9 @@ def _check_unexpected_sklearn_class(cls: type) -> None:
 @pytest.mark.parametrize(  # type: ignore
     argnames="sklearn_classifier_cls", argvalues=sklearn_classifier_classes()
 )
-def test_classifier_coverage(sklearn_classifier_cls: Type[ClassifierMixin]) -> None:
+def test_classifier_coverage(sklearn_classifier_cls: type[ClassifierMixin]) -> None:
     """Check if each sklearn classifier has a wrapped sklearndf counterpart."""
-    sklearn_classes: Dict[Type[BaseEstimator], Type[EstimatorDF]] = (
+    sklearn_classes: dict[type[BaseEstimator], type[EstimatorDF]] = (
         sklearn_delegate_classes(sklearndf.classification)
     )
 
@@ -179,9 +180,9 @@ def test_classifier_coverage(sklearn_classifier_cls: Type[ClassifierMixin]) -> N
 @pytest.mark.parametrize(  # type: ignore
     argnames="sklearn_regressor_cls", argvalues=sklearn_regressor_classes()
 )
-def test_regressor_coverage(sklearn_regressor_cls: Type[RegressorMixin]) -> None:
+def test_regressor_coverage(sklearn_regressor_cls: type[RegressorMixin]) -> None:
     """Check if each sklearn regressor has a wrapped sklearndf counterpart."""
-    sklearn_classes: Dict[Type[BaseEstimator], Type[EstimatorDF]] = (
+    sklearn_classes: dict[type[BaseEstimator], type[EstimatorDF]] = (
         sklearn_delegate_classes(sklearndf.regression)
     )
 
@@ -192,10 +193,10 @@ def test_regressor_coverage(sklearn_regressor_cls: Type[RegressorMixin]) -> None
 @pytest.mark.parametrize(  # type: ignore
     argnames="sklearn_transformer_cls", argvalues=sklearn_transformer_classes()
 )
-def test_transformer_coverage(sklearn_transformer_cls: Type[TransformerMixin]) -> None:
+def test_transformer_coverage(sklearn_transformer_cls: type[TransformerMixin]) -> None:
     """Check if each sklearn transformer has a wrapped sklearndf counterpart."""
 
-    sklearn_classes: Dict[Type[BaseEstimator], Type[EstimatorDF]] = (
+    sklearn_classes: dict[type[BaseEstimator], type[EstimatorDF]] = (
         sklearn_delegate_classes(sklearndf.transformation)
     )
 
@@ -206,7 +207,7 @@ def test_transformer_coverage(sklearn_transformer_cls: Type[TransformerMixin]) -
 @pytest.mark.parametrize(  # type: ignore
     argnames="sklearn_pipeline_cls", argvalues=sklearn_pipeline_classes()
 )
-def test_pipeline_coverage(sklearn_pipeline_cls: Type[Pipeline]) -> None:
+def test_pipeline_coverage(sklearn_pipeline_cls: type[Pipeline]) -> None:
     """Check if each sklearn pipeline estimator has
     a wrapped sklearndf counterpart."""
 
@@ -220,9 +221,9 @@ def test_pipeline_coverage(sklearn_pipeline_cls: Type[Pipeline]) -> None:
 @pytest.mark.parametrize(  # type: ignore
     argnames="sklearn_clusterer_cls", argvalues=sklearn_clusterer_classes()
 )
-def test_clusterer_coverage(sklearn_clusterer_cls: Type[ClusterMixin]) -> None:
+def test_clusterer_coverage(sklearn_clusterer_cls: type[ClusterMixin]) -> None:
     """Check if each sklearn clusterer has a wrapped sklearndf counterpart."""
-    sklearn_classes: Dict[Type[BaseEstimator], Type[EstimatorDF]] = (
+    sklearn_classes: dict[type[BaseEstimator], type[EstimatorDF]] = (
         sklearn_delegate_classes(sklearndf.clustering)
     )
 

--- a/test/test/sklearndf/transformation/test_extra.py
+++ b/test/test/sklearndf/transformation/test_extra.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Optional
 
 import numpy as np
 import pandas as pd
@@ -74,7 +74,7 @@ parametrize_feature_selector_cls: Callable[
 
 @parametrize_feature_selector_cls
 def test_feature_selection_df(
-    feature_selector_cls: Type[TransformerDF], feature_selector_params: Dict[str, Any]
+    feature_selector_cls: type[TransformerDF], feature_selector_params: dict[str, Any]
 ) -> None:
     """
     Test feature selection using the Boruta or ARFS package using a simple synthetic
@@ -95,8 +95,8 @@ def test_feature_selection_df(
 
 @parametrize_feature_selector_cls
 def test_feature_selection_pipeline_df(
-    feature_selector_cls: Type[TransformerDF],
-    feature_selector_params: Dict[str, Any],
+    feature_selector_cls: type[TransformerDF],
+    feature_selector_params: dict[str, Any],
     diabetes_df: pd.DataFrame,
     diabetes_target: str,
 ) -> None:

--- a/test/test/sklearndf/transformation/test_extra.py
+++ b/test/test/sklearndf/transformation/test_extra.py
@@ -54,9 +54,11 @@ parametrize_feature_selector_cls: Callable[
             (LeshyDF, dict(estimator=lgbm_regressor_df, random_state=42, perc=90)),
             (
                 BoostAGrootaDF,
-                dict(est=lgbm_regressor, cutoff=1.1)
-                if __arfs_version__ is None or __arfs_version__ < __arfs_1_1__
-                else dict(estimator=lgbm_regressor, cutoff=1.1),
+                (
+                    dict(est=lgbm_regressor, cutoff=1.1)
+                    if __arfs_version__ is None or __arfs_version__ < __arfs_1_1__
+                    else dict(estimator=lgbm_regressor, cutoff=1.1)
+                ),
             ),
             (GrootCVDF, dict()),
         ]

--- a/test/test/sklearndf/transformation/test_imputers.py
+++ b/test/test/sklearndf/transformation/test_imputers.py
@@ -1,6 +1,5 @@
 import itertools
 import logging
-from typing import Type
 
 import numpy as np
 import pandas as pd
@@ -23,7 +22,7 @@ IMPUTERS_TO_TEST = iterate_classes(
     argvalues=itertools.product(IMPUTERS_TO_TEST, [True, False]),
 )
 def test_imputer(
-    imputer_cls: Type[TransformerDF],
+    imputer_cls: type[TransformerDF],
     add_indicator: bool,
 ) -> None:
     """

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -22,8 +22,8 @@ from sklearndf import (
     ClassifierDF,
     RegressorDF,
     TransformerDF,
-    __sklearn_1_1__,
-    __sklearn_1_3__,
+    __sklearn_1_4__,
+    __sklearn_1_5__,
     __sklearn_version__,
 )
 from sklearndf.classification import RandomForestClassifierDF
@@ -70,12 +70,12 @@ def test_transformer_count() -> None:
     n = len(TRANSFORMERS_TO_TEST)
 
     print(f"Testing {n} transformers.")
-    if __sklearn_version__ < __sklearn_1_1__:
-        assert n == 58
-    elif __sklearn_version__ < __sklearn_1_3__:
-        assert n == 60
-    else:
+    if __sklearn_version__ < __sklearn_1_4__:
         assert n == 61
+    elif __sklearn_version__ < __sklearn_1_5__:
+        assert n == 61
+    else:
+        assert False, f"unexpected sklearn version: {__sklearn_version__}"
 
 
 @pytest.fixture  # type: ignore
@@ -371,11 +371,10 @@ def test_simple_imputer_df() -> None:
         imputer_df.feature_names_in_.values, imputer_native.feature_names_in_
     )
 
-    if __sklearn_version__ >= __sklearn_1_1__:
-        assert_array_equal(
-            imputer_df.feature_names_out_.values,
-            imputer_native.get_feature_names_out(),
-        )
+    assert_array_equal(
+        imputer_df.feature_names_out_.values,
+        imputer_native.get_feature_names_out(),
+    )
 
 
 @pytest.fixture  # type: ignore

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -290,6 +290,28 @@ def test_column_transformer(test_data: pd.DataFrame) -> None:
     )
 
 
+def test_column_transformer_with_unmatched_transformation(
+    test_data: pd.DataFrame,
+) -> None:
+    # Test that a ColumnTransformerDF with a transformer that does not match any
+    # columns does not raise an error.
+    numeric_data = test_data.select_dtypes(include=float)
+    numeric_columns: List[str] = numeric_data.columns.tolist()
+    assert numeric_columns == ["c0", "c2"]
+    # noinspection PyShadowingNames
+    tx = ColumnTransformerDF(
+        transformers=[
+            ("tx", StandardScalerDF(), []),
+            ("rest", "passthrough", numeric_columns),
+        ]
+    )
+    transformed_df = tx.fit_transform(X=test_data)
+    # check that the transformed DataFrame is the same as the input DataFrame
+    assert_frame_equal(
+        transformed_df, numeric_data.add_prefix("rest__").rename_axis("feature", axis=1)
+    )
+
+
 def test_normalizer_df() -> None:
     x = [[4.0, 1.0, 2.0, 2.0], [1.0, 3.0, 9.0, 3.0], [5.0, 7.0, 5.0, 1.0]]
     test_df = pd.DataFrame(x, columns=pd.Index(["a", "b", "c", "d"], name="feature_in"))

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -22,9 +22,7 @@ from sklearndf import (
     ClassifierDF,
     RegressorDF,
     TransformerDF,
-    __sklearn_1_4__,
-    __sklearn_1_5__,
-    __sklearn_1_7__,
+    __sklearn_1_8__,
     __sklearn_version__,
 )
 from sklearndf.classification import RandomForestClassifierDF
@@ -71,11 +69,7 @@ def test_transformer_count() -> None:
     n = len(TRANSFORMERS_TO_TEST)
 
     print(f"Testing {n} transformers.")
-    if __sklearn_version__ < __sklearn_1_4__:
-        assert n == 61
-    elif __sklearn_version__ < __sklearn_1_5__:
-        assert n == 61
-    elif __sklearn_version__ < __sklearn_1_7__:
+    if __sklearn_version__ < __sklearn_1_8__:
         assert n == 61
     else:
         assert False, f"unexpected sklearn version: {__sklearn_version__}"

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -72,7 +72,7 @@ def test_transformer_count() -> None:
     if __sklearn_version__ < __sklearn_1_8__:
         assert n == 61
     else:
-        assert False, f"unexpected sklearn version: {__sklearn_version__}"
+        pytest.fail(f"unexpected sklearn version: {__sklearn_version__}")
 
 
 @pytest.fixture  # type: ignore

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, cast
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -90,7 +90,7 @@ def test_data() -> pd.DataFrame:
 @pytest.mark.parametrize(  # type: ignore
     argnames="sklearndf_cls", argvalues=TRANSFORMERS_TO_TEST
 )
-def test_wrapped_constructor(sklearndf_cls: Type[TransformerDF]) -> None:
+def test_wrapped_constructor(sklearndf_cls: type[TransformerDF]) -> None:
     transformer_df: TransformerDF = sklearndf_cls()
 
     if isinstance(transformer_df, RegressorDF):
@@ -137,7 +137,7 @@ def test_special_wrapped_constructors() -> None:
     ),
 )
 def test_fit_transform(
-    sklearn_cls: Type[BaseEstimator], test_data: pd.DataFrame
+    sklearn_cls: type[BaseEstimator], test_data: pd.DataFrame
 ) -> None:
     # we only need the numerical column of the test data
     test_data = test_data.select_dtypes(include=float)
@@ -199,16 +199,16 @@ def test_fit_transform(
 
 
 def test_column_transformer(test_data: pd.DataFrame) -> None:
-    numeric_columns: List[str] = test_data.select_dtypes(include=float).columns.tolist()
+    numeric_columns: list[str] = test_data.select_dtypes(include=float).columns.tolist()
     assert numeric_columns == ["c0", "c2"]
 
     # noinspection PyShadowingNames
     def _test_transformer(
         *,
         remainder: str,
-        names_in: List[str],
-        names_original: List[str],
-        names_out: List[str],
+        names_in: list[str],
+        names_original: list[str],
+        names_out: list[str],
         **transformer_args: Any,
     ) -> None:
         feature_names_out_expected = pd.Index(names_out, name="feature")
@@ -296,7 +296,7 @@ def test_column_transformer_with_unmatched_transformation(
     # Test that a ColumnTransformerDF with a transformer that does not match any
     # columns does not raise an error.
     numeric_data = test_data.select_dtypes(include=float)
-    numeric_columns: List[str] = numeric_data.columns.tolist()
+    numeric_columns: list[str] = numeric_data.columns.tolist()
     assert numeric_columns == ["c0", "c2"]
     # noinspection PyShadowingNames
     tx = ColumnTransformerDF(
@@ -414,7 +414,7 @@ def df_outlier() -> pd.DataFrame:
 def test_one_hot_encoding(
     test_data_categorical: pd.DataFrame, sparse_output: bool
 ) -> None:
-    def _make_frame(data: Dict[str, List[float]]) -> pd.DataFrame:
+    def _make_frame(data: dict[str, list[float]]) -> pd.DataFrame:
         if sparse_output:
             df = pd.DataFrame(
                 data={k: SparseArray(v, fill_value=0) for k, v in data.items()}

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -24,6 +24,7 @@ from sklearndf import (
     TransformerDF,
     __sklearn_1_4__,
     __sklearn_1_5__,
+    __sklearn_1_6__,
     __sklearn_version__,
 )
 from sklearndf.classification import RandomForestClassifierDF
@@ -73,6 +74,8 @@ def test_transformer_count() -> None:
     if __sklearn_version__ < __sklearn_1_4__:
         assert n == 61
     elif __sklearn_version__ < __sklearn_1_5__:
+        assert n == 61
+    elif __sklearn_version__ < __sklearn_1_6__:
         assert n == 61
     else:
         assert False, f"unexpected sklearn version: {__sklearn_version__}"

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -390,10 +390,14 @@ def df_outlier() -> pd.DataFrame:
     )
 
 
-@pytest.mark.parametrize(argnames="sparse", argvalues=[True, False])  # type: ignore
-def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> None:
+@pytest.mark.parametrize(  # type: ignore
+    argnames="sparse_output", argvalues=[True, False]
+)
+def test_one_hot_encoding(
+    test_data_categorical: pd.DataFrame, sparse_output: bool
+) -> None:
     def _make_frame(data: Dict[str, List[float]]) -> pd.DataFrame:
-        if sparse:
+        if sparse_output:
             df = pd.DataFrame(
                 data={k: SparseArray(v, fill_value=0) for k, v in data.items()}
             )
@@ -402,7 +406,104 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
         return df.rename_axis(columns="feature")
 
     assert_frame_equal(
-        OneHotEncoderDF(drop=None, sparse=sparse).fit_transform(test_data_categorical),
+        OneHotEncoderDF(drop=None, sparse_output=sparse_output).fit_transform(
+            test_data_categorical
+        ),
+        _make_frame(
+            {
+                "a_no": [0.0, 0.0, 1.0],
+                "a_yes": [1.0, 1.0, 0.0],
+                "b_blue": [0.0, 1.0, 0.0],
+                "b_green": [0.0, 0.0, 1.0],
+                "b_red": [1.0, 0.0, 0.0],
+                "c_child": [1.0, 0.0, 0.0],
+                "c_father": [0.0, 1.0, 0.0],
+                "c_mother": [0.0, 0.0, 1.0],
+            }
+        ),
+    )
+
+    assert_frame_equal(
+        OneHotEncoderDF(drop="first", sparse_output=sparse_output).fit_transform(
+            test_data_categorical
+        ),
+        _make_frame(
+            {
+                "a_yes": [1.0, 1.0, 0.0],
+                "b_green": [0.0, 0.0, 1.0],
+                "b_red": [1.0, 0.0, 0.0],
+                "c_father": [0.0, 1.0, 0.0],
+                "c_mother": [0.0, 0.0, 1.0],
+            }
+        ),
+    )
+
+    assert_frame_equal(
+        OneHotEncoderDF(
+            drop=["yes", "red", "mother"], sparse_output=sparse_output
+        ).fit_transform(test_data_categorical),
+        _make_frame(
+            {
+                "a_no": [0.0, 0.0, 1.0],
+                "b_blue": [0.0, 1.0, 0.0],
+                "b_green": [0.0, 0.0, 1.0],
+                "c_child": [1.0, 0.0, 0.0],
+                "c_father": [0.0, 1.0, 0.0],
+            }
+        ),
+    )
+
+    assert_frame_equal(
+        OneHotEncoderDF(drop="if_binary", sparse_output=sparse_output).fit_transform(
+            test_data_categorical
+        ),
+        _make_frame(
+            {
+                "a_yes": [1.0, 1.0, 0.0],
+                "b_blue": [0.0, 1.0, 0.0],
+                "b_green": [0.0, 0.0, 1.0],
+                "b_red": [1.0, 0.0, 0.0],
+                "c_child": [1.0, 0.0, 0.0],
+                "c_father": [0.0, 1.0, 0.0],
+                "c_mother": [0.0, 0.0, 1.0],
+            }
+        ),
+    )
+
+    assert_frame_equal(
+        OneHotEncoderDF(min_frequency=2, sparse_output=sparse_output).fit_transform(
+            test_data_categorical
+        ),
+        _make_frame(
+            {
+                "a_yes": [1.0, 1.0, 0.0],
+                "a_infrequent_sklearn": [0.0, 0.0, 1.0],
+                "b_infrequent_sklearn": [1.0, 1.0, 1.0],
+                "c_infrequent_sklearn": [1.0, 1.0, 1.0],
+            }
+        ),
+    )
+
+    assert_frame_equal(
+        OneHotEncoderDF(max_categories=2, sparse_output=sparse_output).fit_transform(
+            test_data_categorical
+        ),
+        _make_frame(
+            {
+                "a_yes": [1.0, 1.0, 0.0],
+                "a_infrequent_sklearn": [0.0, 0.0, 1.0],
+                "b_red": [1.0, 0.0, 0.0],
+                "b_infrequent_sklearn": [0.0, 1.0, 1.0],
+                "c_mother": [0.0, 0.0, 1.0],
+                "c_infrequent_sklearn": [1.0, 1.0, 0.0],
+            }
+        ),
+    )
+
+    assert_frame_equal(
+        OneHotEncoderDF(max_categories=10, sparse_output=sparse_output).fit_transform(
+            test_data_categorical
+        ),
         _make_frame(
             {
                 "a_no": [0.0, 0.0, 1.0],
@@ -418,39 +519,9 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
     )
 
     assert_frame_equal(
-        OneHotEncoderDF(drop="first", sparse=sparse).fit_transform(
-            test_data_categorical
-        ),
-        _make_frame(
-            {
-                "a_yes": [1.0, 1.0, 0.0],
-                "b_green": [0.0, 0.0, 1.0],
-                "b_red": [1.0, 0.0, 0.0],
-                "c_father": [0.0, 1.0, 0.0],
-                "c_mother": [0.0, 0.0, 1.0],
-            }
-        ),
-    )
-
-    assert_frame_equal(
-        OneHotEncoderDF(drop=["yes", "red", "mother"], sparse=sparse).fit_transform(
-            test_data_categorical
-        ),
-        _make_frame(
-            {
-                "a_no": [0.0, 0.0, 1.0],
-                "b_blue": [0.0, 1.0, 0.0],
-                "b_green": [0.0, 0.0, 1.0],
-                "c_child": [1.0, 0.0, 0.0],
-                "c_father": [0.0, 1.0, 0.0],
-            }
-        ),
-    )
-
-    assert_frame_equal(
-        OneHotEncoderDF(drop="if_binary", sparse=sparse).fit_transform(
-            test_data_categorical
-        ),
+        OneHotEncoderDF(
+            drop="if_binary", max_categories=10, sparse_output=sparse_output
+        ).fit_transform(test_data_categorical),
         _make_frame(
             {
                 "a_yes": [1.0, 1.0, 0.0],
@@ -464,94 +535,28 @@ def test_one_hot_encoding(test_data_categorical: pd.DataFrame, sparse: bool) -> 
         ),
     )
 
-    if __sklearn_version__ >= __sklearn_1_1__:
-        assert_frame_equal(
-            OneHotEncoderDF(min_frequency=2, sparse=sparse).fit_transform(
-                test_data_categorical
-            ),
-            _make_frame(
-                {
-                    "a_yes": [1.0, 1.0, 0.0],
-                    "a_infrequent_sklearn": [0.0, 0.0, 1.0],
-                    "b_infrequent_sklearn": [1.0, 1.0, 1.0],
-                    "c_infrequent_sklearn": [1.0, 1.0, 1.0],
-                }
-            ),
-        )
+    assert_frame_equal(
+        OneHotEncoderDF(
+            drop="first", max_categories=2, sparse_output=sparse_output
+        ).fit_transform(test_data_categorical),
+        _make_frame(
+            {
+                "a_infrequent_sklearn": [0.0, 0.0, 1.0],
+                "b_infrequent_sklearn": [0.0, 1.0, 1.0],
+                "c_infrequent_sklearn": [1.0, 1.0, 0.0],
+            }
+        ),
+    )
 
-        assert_frame_equal(
-            OneHotEncoderDF(max_categories=2, sparse=sparse).fit_transform(
-                test_data_categorical
-            ),
-            _make_frame(
-                {
-                    "a_yes": [1.0, 1.0, 0.0],
-                    "a_infrequent_sklearn": [0.0, 0.0, 1.0],
-                    "b_red": [1.0, 0.0, 0.0],
-                    "b_infrequent_sklearn": [0.0, 1.0, 1.0],
-                    "c_mother": [0.0, 0.0, 1.0],
-                    "c_infrequent_sklearn": [1.0, 1.0, 0.0],
-                }
-            ),
-        )
-
-        assert_frame_equal(
-            OneHotEncoderDF(max_categories=10, sparse=sparse).fit_transform(
-                test_data_categorical
-            ),
-            _make_frame(
-                {
-                    "a_no": [0.0, 0.0, 1.0],
-                    "a_yes": [1.0, 1.0, 0.0],
-                    "b_blue": [0.0, 1.0, 0.0],
-                    "b_green": [0.0, 0.0, 1.0],
-                    "b_red": [1.0, 0.0, 0.0],
-                    "c_child": [1.0, 0.0, 0.0],
-                    "c_father": [0.0, 1.0, 0.0],
-                    "c_mother": [0.0, 0.0, 1.0],
-                }
-            ),
-        )
-
-        assert_frame_equal(
-            OneHotEncoderDF(
-                drop="if_binary", max_categories=10, sparse=sparse
-            ).fit_transform(test_data_categorical),
-            _make_frame(
-                {
-                    "a_yes": [1.0, 1.0, 0.0],
-                    "b_blue": [0.0, 1.0, 0.0],
-                    "b_green": [0.0, 0.0, 1.0],
-                    "b_red": [1.0, 0.0, 0.0],
-                    "c_child": [1.0, 0.0, 0.0],
-                    "c_father": [0.0, 1.0, 0.0],
-                    "c_mother": [0.0, 0.0, 1.0],
-                }
-            ),
-        )
-
-        assert_frame_equal(
-            OneHotEncoderDF(
-                drop="first", max_categories=2, sparse=sparse
-            ).fit_transform(test_data_categorical),
-            _make_frame(
-                {
-                    "a_infrequent_sklearn": [0.0, 0.0, 1.0],
-                    "b_infrequent_sklearn": [0.0, 1.0, 1.0],
-                    "c_infrequent_sklearn": [1.0, 1.0, 0.0],
-                }
-            ),
-        )
-
-        assert_frame_equal(
-            OneHotEncoderDF(
-                drop="if_binary", max_categories=2, sparse=sparse
-            ).fit_transform(test_data_categorical),
-            _make_frame(
-                {
-                    "a_infrequent_sklearn": [0.0, 0.0, 1.0],
-                    "b_infrequent_sklearn": [0.0, 1.0, 1.0],
-                    "c_infrequent_sklearn": [1.0, 1.0, 0.0],
-                }
-            ),
-        )
+    assert_frame_equal(
+        OneHotEncoderDF(
+            drop="if_binary", max_categories=2, sparse_output=sparse_output
+        ).fit_transform(test_data_categorical),
+        _make_frame(
+            {
+                "a_infrequent_sklearn": [0.0, 0.0, 1.0],
+                "b_infrequent_sklearn": [0.0, 1.0, 1.0],
+                "c_infrequent_sklearn": [1.0, 1.0, 0.0],
+            }
+        ),
+    )

--- a/test/test/sklearndf/transformation/test_transformation.py
+++ b/test/test/sklearndf/transformation/test_transformation.py
@@ -24,7 +24,7 @@ from sklearndf import (
     TransformerDF,
     __sklearn_1_4__,
     __sklearn_1_5__,
-    __sklearn_1_6__,
+    __sklearn_1_7__,
     __sklearn_version__,
 )
 from sklearndf.classification import RandomForestClassifierDF
@@ -75,7 +75,7 @@ def test_transformer_count() -> None:
         assert n == 61
     elif __sklearn_version__ < __sklearn_1_5__:
         assert n == 61
-    elif __sklearn_version__ < __sklearn_1_6__:
+    elif __sklearn_version__ < __sklearn_1_7__:
         assert n == 61
     else:
         assert False, f"unexpected sklearn version: {__sklearn_version__}"

--- a/tox.ini
+++ b/tox.ini
@@ -55,18 +55,26 @@ max-line-length = 88
 
 show-source = true
 
+# W504: line break before binary operator
+# E402: module level import not at top of file
+# E731: do not assign a lambda expression, use a def
+# E741: ignore not easy to read variables like i l I etc
+# F842: local variable is annotated but never used
+# C408: Unnecessary (dict/list/tuple) call - rewrite as a literal
+# Ignores below are added to prevent conflicts with Black formatter
+# E231: Missing whitespace after ',', ';', or ':'
+# E203: space before :
+# W503: line break before binary operator
 ignore =
-    W504,  # line break after binary operator
-    E402,  # module level import not at top of file
-    E731,  # do not assign a lambda expression, use a def
-    E741,  # ignore not easy to read variables like i l I etc
-    C408,  # Unnecessary (dict/list/tuple) call - rewrite as a literal
-    S001,  # found modulo formatter (incorrect picks up mod operations)
-
-    # Ignores below are added to prevent conflicts with Black formatter
-    E231,  # Missing whitespace after ',', ';', or ':'
-    E203,  # space before :
-    W503,  # line break before binary operator
+    W504,
+    E402,
+    E731,
+    E741,
+    F842,
+    C408,
+    E231,
+    E203,
+    W503,
 
 per-file-ignores =
     __init__.py: F401, F403, F405


### PR DESCRIPTION
This pull request introduces a series of updates to enhance compatibility with scikit-learn up to v1.7. The changes include updates to dependencies, addition of new classification and regression wrappers, utility functions, and adjustments to pipeline handling.

### Dependency Updates:
* Updated `environment.yml` to increase versions of dependencies like `numpy`, `pandas`, `scikit-learn`, and `python`. Removed `boruta_py` and added `Boruta`.
* Adjusted version constraints in `pyproject.toml` for dependencies such as `gamma-pytools`, `scikit-learn`, and `python`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-R25) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L79-R102)

### Classification Enhancements:
* Added new classifiers `FixedThresholdClassifierDF` and `TunedThresholdClassifierCVDF` in `_classification_v1_5.py`.
* Introduced `SelfTrainingClassifierDF` in `_classification_v1_6.py`.
* Updated `classification/__init__.py` to dynamically load new classifiers based on scikit-learn version.

### Utility Functions:
* Added `is_scalar_nan` and `remove_invalid_lgbm_type_hint` functions in `_util.py` for improved handling of NaN values and LightGBM type hints.

### Pipeline Adjustments:
* Enhanced `PipelineWrapperDF` to handle scikit-learn tags dynamically, ensuring compatibility with newer versions.

### Configuration Updates:
* Updated `.pre-commit-config.yaml` to switch language from `python_venv` to `python` for hooks like `black`, `flake8`, and `mypy`. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L11-R11) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L20-R20) [[3]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L33-R41)
* Replaced `boa` with `rattler-build` in `azure-pipelines.yml` for conda build environments. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L254-R254) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L353-R353)