### PR TITLE
FIX: prevent pipeline not fitted warning

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,13 +10,20 @@ Release Notes
 *skelearndf* 2.4
 ----------------
 
-
-2.4.0
-~~~~~
-
 *sklearndf* |nbsp| 2.4 adds support for
 `scikit-learn 1.7 <https://scikit-learn.org/1.7>`_, and drops support for
 *scikit-learn* |nbsp| 1.2 and earlier, and Python |nbsp| 3.8 and earlier.
+
+
+2.4.1
+~~~~~
+
+- FIX: implement method :meth:`.EstimatorDF.__sklearn_is_fitted__`, introduced in
+  *scikit-learn* |nbsp| 1.3, to correctly report if the estimator is fitted.
+
+
+2.4.0
+~~~~~
 
 - API: add DF wrapper classes :class:`.FixedThresholdClassifierDF`
   and :class:`.TunedThresholdClassifierCVDF` for native classifiers

--- a/environment.yml
+++ b/environment.yml
@@ -12,13 +12,13 @@ dependencies:
   - pandas            ~= 2.3
   - pip               ~= 25.1
   - python            ~= 3.12.11
-  - scikit-learn      ~= 1.7.0
+  - scikit-learn      ~= 1.7.1
   - scipy             ~= 1.15
   - xgboost           ~= 3.0
   - pip:
       - arfs          ~= 3.0
       - Boruta        ~= 0.4
-# test
+  # test
   - pytest            ~= 8.1
   - pytest-cov        ~= 4.1
   # sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ numpy          = "~=2.2"
 packaging      = ">=25"
 pandas         = "~=2.3"
 python         = "~=3.12"
-scikit-learn   = "~=1.7.0"
+scikit-learn   = "~=1.7.1"
 scipy          = "~=1.16"
 xgboost        = "~=3.0"
 # additional maximum requirements of gamma-pytools

--- a/src/sklearndf/_sklearndf.py
+++ b/src/sklearndf/_sklearndf.py
@@ -296,6 +296,19 @@ class EstimatorDF(
             }
         )
 
+    def __sklearn_is_fitted__(self) -> bool:
+        """
+        Check if this estimator is fitted.
+
+        This method is used by `scikit-learn` to determine if this estimator is
+        fitted.
+
+        Delegates to the :attr:`is_fitted` property.
+
+        :return: ``True`` if the estimator is fitted, ``False`` otherwise
+        """
+        return self.is_fitted
+
 
 class LearnerDF(EstimatorDF, metaclass=ABCMeta):
     """


### PR DESCRIPTION
This PR adds a method to improve compatibility with `scikit-learn`'s fitted estimator checks.

It adds the `__sklearn_is_fitted__` method to the `EstimatorDF` class in `src/sklearndf/_sklearndf.py`, which allows `scikit-learn` to check if the estimator is fitted by delegating to the existing `is_fitted` property. This improves integration with `scikit-learn`'s internal fitted checks, and prevents false _not fitted_ warnings.