### PR TITLE
FIX: correctly handle column selector callables in data frame hstacking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         types: [ python ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-json
@@ -34,7 +34,7 @@ repos:
         exclude: condabuild/meta.yaml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.0
+    rev: v1.17.1
     hooks:
       - id: mypy
         files: src|sphinx|test

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -14,12 +14,18 @@ Release Notes
 `scikit-learn 1.7 <https://scikit-learn.org/1.7>`_, and drops support for
 *scikit-learn* |nbsp| 1.2 and earlier, and Python |nbsp| 3.8 and earlier.
 
+2.4.2
+~~~~~
+
+- FIX: update `ColumnTransformerDF` to correctly handle column selectors created
+  with scikit-learn's :class:`~sklearn.compose.make_column_selector`
+
 
 2.4.1
 ~~~~~
 
 - FIX: implement method :meth:`.EstimatorDF.__sklearn_is_fitted__`, introduced in
-  *scikit-learn* |nbsp| 1.3, to correctly report if the estimator is fitted.
+  *scikit-learn* |nbsp| 1.3, to correctly report if the estimator is fitted
 
 
 2.4.0

--- a/src/sklearndf/_util.py
+++ b/src/sklearndf/_util.py
@@ -4,15 +4,13 @@ Auxiliary functions for internal use.
 
 import math
 import numbers
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, cast
 
-import numpy.typing as npt
 import pandas as pd
-from scipy import sparse
 
 
 def hstack_frames(
-    frames: list[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]],
+    frames: list[pd.DataFrame],
     *,
     prefixes: Optional[list[str]] = None,
 ) -> Optional[pd.DataFrame]:
@@ -25,20 +23,14 @@ def hstack_frames(
     :return: the stacked data frame if all elements of ``frames`` are data frames;
         ``None`` otherwise
     """
-    if all(isinstance(frame, pd.DataFrame) for frame in frames):
-        # all frames are data frames
-        frames = cast(list[pd.DataFrame], frames)
-        if prefixes is not None:
-            assert len(prefixes) == len(
-                frames
-            ), "number of prefixes must match number of frames"
-            frames = [
-                frame.add_prefix(f"{prefix}__")
-                for frame, prefix in zip(frames, prefixes)
-            ]
-        return pd.concat(frames, axis=1)
-    else:
-        return None
+    if prefixes is not None:
+        assert len(prefixes) == len(
+            frames
+        ), "number of prefixes must match number of frames"
+        frames = [
+            frame.add_prefix(f"{prefix}__") for frame, prefix in zip(frames, prefixes)
+        ]
+    return pd.concat(frames, axis=1)
 
 
 def is_sparse_frame(frame: pd.DataFrame) -> bool:

--- a/src/sklearndf/_util.py
+++ b/src/sklearndf/_util.py
@@ -13,7 +13,7 @@ def hstack_frames(
     frames: list[pd.DataFrame],
     *,
     prefixes: Optional[list[str]] = None,
-) -> Optional[pd.DataFrame]:
+) -> pd.DataFrame:
     """
     If only data frames are passed, stack them horizontally.
 

--- a/src/sklearndf/pipeline/wrapper/_wrapper.py
+++ b/src/sklearndf/pipeline/wrapper/_wrapper.py
@@ -241,13 +241,12 @@ class FeatureUnionSparseFrames(
     def _hstack(
         self, Xs: list[Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]]
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
-        stacked_frames = hstack_frames(
-            Xs, prefixes=[name for name, _ in self.transformer_list]
-        )
-        if stacked_frames is None:
-            return super()._hstack(Xs)
+        if all(isinstance(X, pd.DataFrame) for X in Xs):
+            return hstack_frames(
+                Xs, prefixes=[name for name, _ in self.transformer_list]
+            )
         else:
-            return stacked_frames
+            return super()._hstack(Xs)
 
 
 class FeatureUnionWrapperDF(

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -349,28 +349,41 @@ class ColumnTransformerSparseFrames(
         *,
         n_samples: Optional[int] = None,
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
-        if self.verbose_feature_names_out:
-            # Get the prefixes for the columns of each transformer, unless the
-            # transformer does not process any columns
-            prefixes = [name for name, _, cols in self.transformers if len(cols)]
-            if self._remainder[2] and self.remainder != "drop":
-                # remainder columns exist and are not being dropped
-                prefixes.append("remainder")
-            stacked = hstack_frames(Xs, prefixes=prefixes)
-        else:
-            stacked = hstack_frames(Xs)
 
-        if stacked is None:
+        if all(isinstance(X, pd.DataFrame) for X in Xs):
+            stacked: pd.DataFrame
+
+            if self.verbose_feature_names_out:
+                # Get the prefixes for the columns of each transformer, unless the
+                # transformer does not process any columns
+                prefixes = [
+                    name
+                    for name, cols in (
+                        # resolve callable column selectors to get the actual columns …
+                        (name, cols(x) if callable(cols) else cols)
+                        for (name, _, cols), x in zip(self.transformers, Xs)
+                    )
+                    # … and only keep the prefixes for transformers that actually
+                    # processed one or more columns
+                    if len(cols)
+                ]
+                if self._remainder[2] and self.remainder != "drop":
+                    # remainder columns exist and are not being dropped
+                    prefixes.append("remainder")
+                stacked = hstack_frames(Xs, prefixes=prefixes)
+            else:
+                stacked = hstack_frames(Xs)
+            self.sparse_output_ = is_sparse_frame(stacked)
+            return stacked
+        else:
             if n_samples is None:
                 # Do not pass n_samples if we did not receive it, for backwards
                 # compatibility
+                # noinspection PyArgumentList
                 return super()._hstack(Xs)
             else:
                 # Only pass n_samples if we receive it
                 return super()._hstack(Xs, n_samples=n_samples)
-        else:
-            self.sparse_output_ = is_sparse_frame(stacked)
-            return stacked
 
 
 class ColumnTransformerWrapperDF(
@@ -420,7 +433,7 @@ class ColumnTransformerWrapperDF(
                 f"{TransformerDF.__name__} or special values "
                 f'"{" and ".join(ColumnTransformerWrapperDF.__SPECIAL_TRANSFORMERS)}" '
                 "as valid transformers, but "
-                f'also got: {", ".join(non_compliant_transformers)}'
+                f"also got: {', '.join(non_compliant_transformers)}"
             )
 
     def _get_features_original(self) -> pd.Series:
@@ -800,3 +813,8 @@ class VectorizerWrapperDF(
 #
 
 __tracker.validate()
+
+
+#
+# Auxiliary functions
+#

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -815,7 +815,6 @@ __tracker.validate()
 def _slice_not_empty(s: slice) -> bool:
     if s.start is None:
         return s.stop is not None and s.stop > 0
-    elif s.stop is None:
-        return s.start is not None
-    else:
-        return s.stop > s.start  # type: ignore[no-any-return]
+    if s.stop is None:
+        return True
+    return s.stop > s.start  # type: ignore[no-any-return]

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -814,7 +814,7 @@ __tracker.validate()
 
 def _slice_not_empty(s: slice) -> bool:
     if s.start is None:
-        return s.stop is not None and s.stop > 0
+        return s.stop is None or s.stop > 0
     if s.stop is None:
         return True
     return s.stop > s.start  # type: ignore[no-any-return]

--- a/src/sklearndf/transformation/wrapper/_wrapper.py
+++ b/src/sklearndf/transformation/wrapper/_wrapper.py
@@ -349,26 +349,18 @@ class ColumnTransformerSparseFrames(
         *,
         n_samples: Optional[int] = None,
     ) -> Union[npt.NDArray[Any], sparse.spmatrix, pd.DataFrame]:
-
         if all(isinstance(X, pd.DataFrame) for X in Xs):
             stacked: pd.DataFrame
 
             if self.verbose_feature_names_out:
-                # Get the prefixes for the columns of each transformer, unless the
-                # transformer does not process any columns
+                # Process all transformers in the ColumnTransformer
                 prefixes = [
                     name
-                    for name, cols in (
-                        # resolve callable column selectors to get the actual columns …
-                        (name, cols(x) if callable(cols) else cols)
-                        for (name, _, cols), x in zip(self.transformers, Xs)
-                    )
-                    # … and only keep the prefixes for transformers that actually
-                    # processed one or more columns
-                    if len(cols)
+                    for name, _, _ in self.transformers
+                    if _slice_not_empty(self.output_indices_[name])
                 ]
                 if self._remainder[2] and self.remainder != "drop":
-                    # remainder columns exist and are not being dropped
+                    # Remainder columns exist and are not being dropped
                     prefixes.append("remainder")
                 stacked = hstack_frames(Xs, prefixes=prefixes)
             else:
@@ -818,3 +810,12 @@ __tracker.validate()
 #
 # Auxiliary functions
 #
+
+
+def _slice_not_empty(s: slice) -> bool:
+    if s.start is None:
+        return s.stop is not None and s.stop > 0
+    elif s.stop is None:
+        return s.start is not None
+    else:
+        return s.stop > s.start  # type: ignore[no-any-return]


### PR DESCRIPTION
This pull request refactors how data frames are horizontally stacked in pipeline and transformation wrappers, improving compatibility with column selectors and ensuring correct prefix handling. The main changes focus on updating the `hstack_frames` utility function, modifying its usage in wrapper classes.

**Refactoring of DataFrame stacking and prefix handling:**

* Updated `hstack_frames` in `src/sklearndf/_util.py` to accept only lists of `pd.DataFrame` and simplified its logic, removing support for numpy arrays and sparse matrices. [[1]](diffhunk://#diff-be2aedd804fa6837892c4fa751e9d0ec27d82248e73c2b55690ed5dce07c5664L7-R13) [[2]](diffhunk://#diff-be2aedd804fa6837892c4fa751e9d0ec27d82248e73c2b55690ed5dce07c5664L28-L41)
* Modified `_hstack` methods in `FeatureUnionSparseFrames` (`src/sklearndf/pipeline/wrapper/_wrapper.py`) and `ColumnTransformerWrapperDF` (`src/sklearndf/transformation/wrapper/_wrapper.py`) to use the new `hstack_frames` only when all inputs are data frames, otherwise fallback to the superclass implementation. [[1]](diffhunk://#diff-7d6dd7eb59531e946df563994189170df89117710203279c94d11d0040cf3631L244-R249) [[2]](diffhunk://#diff-e227d9f4a73c2fac803f9fe46c9b95dcd7d08df641dbef81757e037fed9c958aR352-L373)

**Auxiliary function and logic improvements:**

* Added `_slice_not_empty` in `src/sklearndf/transformation/wrapper/_wrapper.py` to check if a slice is non-empty, used for more robust prefix assignment in column transformers.
* Improved prefix assignment logic for verbose feature names in column transformers to ensure correct handling of remainder columns and selectors.

**Release notes update:**

* Documented the fix for `ColumnTransformerDF` to correctly handle column selectors created with scikit-learn's `make_column_selector`.